### PR TITLE
Update for existing localized XLFs.

### DIFF
--- a/resources/xlf/de/admin-tool-ext-win.de.xlf
+++ b/resources/xlf/de/admin-tool-ext-win.de.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/de/agent.de.xlf
+++ b/resources/xlf/de/agent.de.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">Neuer Zeitplan</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Abbrechen</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Zeitplanname</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Zeitpläne</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">Proxy erstellen</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">Proxy bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Allgemein</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">Proxyname</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">Name der Anmeldeinformationen</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Beschreibung</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">Subsystem</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">Betriebssystem (CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">Replikationsmomentaufnahme</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">Replikationstransaktionsprotokoll-Leser</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">Replikationsverteiler</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">Replikationsmerge</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">Replikations-Warteschlangenleser</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">SQL Server Analysis Services-Abfrage</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">SQL Server Analysis Services-Befehl</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">SQL Server Integration Services-Paket</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">Folgenden Subsystemen gegenüber aktiv</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">Auftragszeitpläne</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">Verfügbare Zeitpläne:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Beschreibung</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">Operator erstellen</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">Operator bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Allgemein</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Benachrichtigungen</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Aktiviert</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">E-Mail-Name</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">E-Mail-Name für Pager</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">Montag</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">Dienstag</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">Mittwoch</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">Donnerstag</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">Freitag  </target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">Samstag</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">Sonntag</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">Beginn des Arbeitstags</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">Ende des Arbeitstags</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">Pager empfangsbereit am</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">Liste der Warnungen</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">Warnungsname</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">E-Mail</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">Pager</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">Allgemein</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">Auftragszeitpläne</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Schritte</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Zeitpläne</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Warnungen</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">Verfügbare Zeitpläne:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Benachrichtigungen</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">Der Auftragsname darf nicht leer sein.</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">Name</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Besitzer</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">ID</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Kategorie</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">Beschreibung</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Aktiviert</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">Liste der Auftragsschritte</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">Schritt</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Typ</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">Bei Erfolg</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">Bei Fehler</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">Neuer Schritt</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">Schritt bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">Schritt löschen</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">Schritt nach oben verschieben</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">Schritt nach unten verschieben</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">Schritt starten</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">Aktionen, die nach Abschluss des Auftrags ausgeführt werden sollen</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">E-Mail</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">Seite</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">In Ereignisprotokoll für Windows-Anwendungen schreiben</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">Auftrag automatisch löschen</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">Zeitplanliste</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">Zeitplan auswählen</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Zeitplanname</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">Liste der Warnungen</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">Neue Warnung</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">Warnungsname</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Aktiviert</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Typ</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">Neuer Auftrag</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">Auftrag bearbeiten</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">Zusätzlich zu sendende Benachrichtigung</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">Verzögerung zwischen Antworten</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">Verzögerung (Minuten)</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">Operator erstellen</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">Operator bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Allgemein</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Benachrichtigungen</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">E-Mail-Name</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">E-Mail-Name für Pager</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">Montag</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">Dienstag</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">Mittwoch</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">Donnerstag</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">Freitag  </target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">Samstag</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">Sonntag</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">Beginn des Arbeitstags</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">Ende des Arbeitstags</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">Pager empfangsbereit am</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">Liste der Warnungen</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">Warnungsname</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">E-Mail</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">Pager</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">Fehler bei Proxyaktualisierung: "{0}"</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Allgemein</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">Der Proxy "{0}" wurde erfolgreich aktualisiert.</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Schritte</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">Der Proxy "{0}" wurde erfolgreich erstellt.</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">Zeitpläne</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Warnungen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Benachrichtigungen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">Der Auftragsname darf nicht leer sein.</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Besitzer</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Kategorie</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">Liste der Auftragsschritte</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">Schritt</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Typ</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">Bei Erfolg</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">Bei Fehler</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">Neuer Schritt</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">Schritt bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">Schritt löschen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">Schritt nach oben verschieben</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">Schritt nach unten verschieben</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">Schritt starten</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">Aktionen, die nach Abschluss des Auftrags ausgeführt werden sollen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">E-Mail</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">Seite</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">In Ereignisprotokoll für Windows-Anwendungen schreiben</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">Auftrag automatisch löschen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Zeitplanliste</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Zeitplan auswählen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Zeitplan entfernen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">Liste der Warnungen</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">Neue Warnung</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">Warnungsname</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Typ</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">Neuer Auftrag</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">Auftrag bearbeiten</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">Fehler beim Aktualisieren des Schritts: "{0}"</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">Es muss ein Auftragsname angegeben werden.</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">Es muss ein Schrittname angegeben werden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">Fehler beim Aktualisieren des Schritts: "{0}"</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">Es muss ein Auftragsname angegeben werden.</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">Es muss ein Schrittname angegeben werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">Dieses Feature befindet sich noch in der Entwicklungsphase. Verwenden Sie den neuesten Insider-Build, wenn Sie die Neuerungen testen möchten.</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">Vorlage erfolgreich aktualisiert</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">Fehler beim Aktualisieren der Vorlage</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">Das Notizbuch muss gespeichert werden, bevor es in den Terminkalender aufgenommen wird. Bitte speichern Sie und versuchen Sie dann erneut, die Zeitplanung durchzuführen.</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">Neue Verbindung hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">Verbindung auswählen</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">Wählen Sie eine gültige Verbindung aus</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">Dieses Feature befindet sich noch in der Entwicklungsphase. Verwenden Sie den neuesten Insider-Build, wenn Sie die Neuerungen testen möchten.</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">Proxy erstellen</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">Proxy bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Allgemein</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">Proxyname</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">Name der Anmeldeinformationen</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">Subsystem</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">Betriebssystem (CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">Replikationsmomentaufnahme</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">Replikationstransaktionsprotokoll-Leser</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">Replikationsverteiler</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">Replikationsmerge</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">Replikations-Warteschlangenleser</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">SQL Server Analysis Services-Abfrage</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">SQL Server Analysis Services-Befehl</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">SQL Server Integration Services-Paket</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">Fehler bei Proxyaktualisierung: "{0}"</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">Der Proxy "{0}" wurde erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">Der Proxy "{0}" wurde erfolgreich erstellt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">Neuer Notebook-Auftrag</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">Notebook-Auftrag bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Allgemein</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">Details zum Notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">Notebook-Pfad</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">Speicherdatenbank</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">Ausführungsdatenbank</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Datenbank auswählen</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">Auftragsdetails</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Besitzer</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Zeitplanliste</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Zeitplan auswählen</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Zeitplan entfernen</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">Wählen Sie ein Notizbuch aus, das vom PC in den Terminkalender aufgenommen werden soll.</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">Wählen Sie eine Datenbank aus, in der alle Notebook-Auftragsmetadaten und -ergebnisse gespeichert werden sollen.</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">Wählen Sie eine Datenbank aus, für die Notebook-Abfragen ausgeführt werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">Wenn das Notizbuch abgeschlossen ist</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">Wenn das Notizbuch fehlschlägt</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">Wenn das Notizbuch erfolgreich ist</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">Es muss ein Name für das Notizbuch angegeben werden</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">Der Vorlagenpfad muss angegeben werden</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">Ungültiger Notizbuchpfad</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">Speicherdatenbank auswählen</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">Ausführungsdatenbank auswählen</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">Ein Auftrag mit einem ähnlichen Namen ist bereits vorhanden</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">Fehler beim Aktualisieren des Notizbuchs "{0}"</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">Fehler beim Erstellen des Notebooks „{0}“</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">Notizbuch „{0}“ wurde erfolgreich aktualisiert</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">Notizbuch „{0}“ erfolgreich erstellt</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/de/azurecore.de.xlf
+++ b/resources/xlf/de/azurecore.de.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">Fehler beim Abrufen von Ressourcengruppen für das Konto "{0}" ({1}), Abonnement "{2}" ({3}), Mandant "{4}": {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">Fehler beim Abrufen von Standorten für das Konto "{0}" ({1}), Abonnement "{2}" ({3}), Mandant "{4}": {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">Ungültige Abfrage</target>
@@ -379,8 +383,8 @@
         <target state="translated">SQL Server – Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
-        <target state="translated">PostgreSQL Hyperscale mit Azure Arc-Aktivierung</target>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
+        <target state="translated">PostgreSQL Hyperscale mit Azure Arc-Unterstützung</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
         <source xml:lang="en">Unable to open link, missing required values</source>
@@ -411,7 +415,7 @@
         <target state="translated">Unbekannter Fehler bei der Azure-Authentifizierung.</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">Der angegebene Mandant mit der ID "{0}" wurde nicht gefunden.</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,7 +423,7 @@
         <target state="translated">Bei der Authentifizierung ist ein Fehler aufgetreten, oder Ihre Token wurden aus dem System gelöscht. Versuchen Sie erneut, Ihr Konto in Azure Data Studio hinzuzufügen.</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">Fehler beim Tokenabruf. Öffnen Sie die Entwicklertools, um den Fehler anzuzeigen.</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">Fehler beim Abrufen der Anmeldeinformationen für das Konto "{0}". Wechseln Sie zum Dialogfeld "Konten", und aktualisieren Sie das Konto.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">Anforderungen von diesem Konto wurden gedrosselt. Wählen Sie eine geringere Anzahl von Abonnements aus, um den Vorgang zu wiederholen.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">Fehler beim Laden von Azure-Ressourcen: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Azure Data Explorer-Cluster</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/de/big-data-cluster.de.xlf
+++ b/resources/xlf/de/big-data-cluster.de.xlf
@@ -60,6 +60,126 @@
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">Bei Festlegung auf TRUE werden SSL-Überprüfungsfehler für SQL Server-Big Data Cluster-Endpunkte wie HDFS, Spark und Controller ignoriert.</target>
       </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">SQL Server-Big Data-Cluster</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">Mit dem Big Data-Cluster von SQL Server können Sie skalierbare Cluster aus SQL Server-, Spark- und HDFS-Containern bereitstellen, die in Kubernetes ausgeführt werden.</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Version</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">Bereitstellungsziel</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">Neuer Azure Kubernetes Service-Cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">Vorhandener Azure Kubernetes Service-Cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">Vorhandener Kubernetes-Cluster (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">Vorhandener Azure Red Hat OpenShift-Cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">Vorhandener OpenShift-Cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">Einstellungen für SQL Server-Big-Data-Cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">Clustername</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">Benutzername für Controller</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">Kennwort</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">Kennwort bestätigen</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Azure-Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">Abonnement-ID</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">Mein Azure-Standardabonnement verwenden</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">Ressourcengruppenname</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">Region</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">Name des AKS-Clusters</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">VM-Größe</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">VM-Anzahl</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">Name der Speicherklasse</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">Kapazität für Daten (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">Kapazität für Protokolle (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">Ich akzeptiere {0}, {1} und {2}.</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Microsoft-Datenschutzbestimmungen</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">azdata-Lizenzbedingungen</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">SQL Server-Lizenzbedingungen</target>
+      </trans-unit>
     </body>
   </file>
   <file original="extensions/big-data-cluster/dist/bigDataCluster/utils" source-language="en" datatype="plaintext" target-language="de">

--- a/resources/xlf/de/cms.de.xlf
+++ b/resources/xlf/de/cms.de.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">Wird geladen...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">Unerwarteter Fehler beim Laden gespeicherter Server: {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">Wird geladen...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">Die Gruppe zentraler Verwaltungsserver enthält bereits einen registrierten Server namens "{0}".</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Azure SQL-Datenbank-Server können nicht als zentraler Verwaltungsserver verwendet werden.</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Azure SQL Server-Instanzen können nicht als zentrale Verwaltungsserver verwendet werden.</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/de/dacpac.de.xlf
+++ b/resources/xlf/de/dacpac.de.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="de">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Dacpac</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">Vollständiger Pfad zu dem Ordner, in dem DACPAC- und BACPAC-Dateien standardmäßig gespeichert werden</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Zielserver</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Quellserver</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Quelldatenbank</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Zieldatenbank</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">Dateispeicherort</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">Datei auswählen</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">Zusammenfassung der Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Version</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">Einstellung</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Wert</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">Datenbankname</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Öffnen</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">Vorhandene Datenbank aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">Neue Datenbank</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">{0} der aufgeführten Bereitstellungsaktionen können zu einem Datenverlust führen. Stellen Sie sicher, dass eine Sicherung oder eine Momentaufnahme vorhanden ist, falls Probleme mit der Bereitstellung auftreten.</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">Vorgang trotz möglicher Datenverluste fortsetzen</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">Die aufgeführten Bereitstellungsaktionen führen zu keinem Datenverlust.</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">Speichern</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">Dateispeicherort</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">Version (Verwenden Sie x.x.x.x, wobei x für eine Zahl steht)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Öffnen</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">DACPAC-Datei einer Datenschichtanwendung für eine SQL Server-Instanz bereitstellen [DACPAC bereitstellen]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">Schema und Daten aus einer Datenbank in das logische BACPAC-Dateiformat exportieren [BACPAC exportieren]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">Datenbankname</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">Vorhandene Datenbank aktualisieren</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">Neue Datenbank</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Zieldatenbank</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">Zielserver</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">Quellserver</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">Quelldatenbank</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Version</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">Einstellung</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Wert</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">Standardeinstellung</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">Assistent für Datenebenenanwendung</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">Skript generieren</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">Sie können den Status der Skriptgenerierung in der Aufgabenansicht anzeigen, sobald der Assistent geschlossen ist. Das generierte Skript wird nach Abschluss des Vorgangs geöffnet.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">Standardeinstellung</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">Planvorgänge bereitstellen</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">Eine Datenbank desselben Namens ist bereits in der SQL Server-Instanz vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">Undefinierter Name.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">Der Dateiname darf nicht mit einem Punkt enden.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">Der Dateiname darf nicht aus Leerzeichen bestehen.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">Ungültige Dateizeichen</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">Dieser Dateiname ist für Windows reserviert. Wählen Sie einen anderen Namen, und versuchen Sie es noch mal.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">Reservierter Dateiname. Wählen Sie einen anderen Namen aus, und versuchen Sie es noch mal.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">Der Dateiname darf nicht mit einem Leerzeichen enden.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">Der Dateiname umfasst mehr als 255 Zeichen.</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">Fehler beim Generieren des Bereitstellungsplans "{0}".</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">Fehler beim Generieren des Bereitstellungsskripts: {0}</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">Fehler bei {0}-Vorgang: {1}.</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">Sie können den Status der Skriptgenerierung in der Aufgabenansicht anzeigen, sobald der Assistent geschlossen ist. Das generierte Skript wird nach Abschluss des Vorgangs geöffnet.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/de/import.de.xlf
+++ b/resources/xlf/de/import.de.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="de">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">Flatfile-Importkonfiguration</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[Optional] Protokollieren Sie die Debugausgabe in der Konsole (Ansicht &gt; Ausgabe), und wählen Sie dann in der Dropdownliste den geeigneten Ausgabekanal aus.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">"{0}" wurde gestartet.</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">"{0}" wird gestartet.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">Fehler beim Starten von {0}: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">"{0}" wird in "{1}" installiert.</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">Der Dienst {0} wird installiert</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">"{0}" wurde installiert.</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">"{0}" wird heruntergeladen.</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">"{0}" wird heruntergeladen.</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">Das Herunterladen von {0} wurde abgeschlossen</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">{0} extrahiert ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">Feedback senden</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">Die Dienstkomponente konnte nicht gestartet werden.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">Server, auf dem sich die Datenbank befindet</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">Datenbank, in der die Tabelle erstellt wird</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">Ungültiger Dateispeicherort. Versuchen Sie es mit einer anderen Eingabedatei.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Durchsuchen</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Öffnen</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">Speicherort der zu importierenden Datei</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">Name der neuen Tabelle</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">Tabellenschema</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">Daten importieren</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Weiter</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">Spaltenname</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">Datentyp</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">Primärschlüssel</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">NULL-Werte zulassen</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">Mit diesem Vorgang wurde die Struktur der Eingabedatei analysiert, um die nachstehende Vorschau für die ersten 50 Zeilen zu generieren.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">Der Vorgang war nicht erfolgreich. Versuchen Sie es mit einer anderen Eingabedatei.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">Informationen importieren</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ Sie haben die Daten erfolgreich in eine Tabelle eingefügt.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">Mit diesem Vorgang wurde die Struktur der Eingabedatei analysiert, um die nachstehende Vorschau für die ersten 50 Zeilen zu generieren.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">Der Vorgang war nicht erfolgreich. Versuchen Sie es mit einer anderen Eingabedatei.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aktualisieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">Daten importieren</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Weiter</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">Spaltenname</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">Datentyp</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">Primärschlüssel</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">NULL-Werte zulassen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">Server, auf dem sich die Datenbank befindet</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">Datenbank, in der die Tabelle erstellt wird</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">Durchsuchen</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Öffnen</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">Speicherort der zu importierenden Datei</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">Name der neuen Tabelle</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">Tabellenschema</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="de">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">Stellen Sie eine Verbindung mit einem Server her, bevor Sie diesen Assistenten verwenden.</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">Die SQL-Server-Importerweiterung unterstützt diesen Verbindungstyp nicht.</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">Neue Datei importieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">Feedback senden</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">Die Dienstkomponente konnte nicht gestartet werden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">Dienst gestartet</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">Dienst wird gestartet</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">Fehler beim Starten des Importdiensts: {0}</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">Der Dienst {0} wird in "{1}" installiert.</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">Dienst wird installiert</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Installiert</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">"{0}" wird heruntergeladen.</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">Dienst wird heruntergeladen</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">Fertig!</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/de/notebook.de.xlf
+++ b/resources/xlf/de/notebook.de.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Lokaler Pfad zu einer bereits vorhandenen Python-Installation, die von Notebooks verwendet wird.</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">Zeigen Sie keine Aufforderungen zum Aktualisieren von Python an.</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">Die Zeit ( in Minuten), die abgewartet werden soll, bevor ein Server heruntergefahren wird, nachdem alle Notizbücher geschlossen wurden. (Geben Sie 0 ein, um nicht herunterzufahren)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Hiermit setzen Sie die Editor-Standardeinstellungen im Notebook-Editor außer Kraft. Zu den Einstellungen gehören Hintergrundfarbe, Farbe der aktuellen Zeile und Rahmen.</target>
@@ -49,6 +57,10 @@
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
         <target state="translated">Notebooks, die vom Benutzer für den aktuellen Arbeitsbereich angeheftet wurden</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,24 +151,24 @@
         <target state="translated">Jupyter-Books</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">Book speichern</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Jupyter Book speichern</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="translated">Buch als vertrauenswürdig einstufen</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Jupyter Book als vertrauenswürdig einstufen</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">Book durchsuchen</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Jupyter Book durchsuchen</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
         <target state="translated">Notebooks</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="translated">Bereitgestellte Bücher</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">Bereitgestellte Jupyter Books</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
@@ -174,17 +186,29 @@
         <source xml:lang="en">Close Jupyter Book</source>
         <target state="translated">Jupyter-Buch schließen</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="translated">Jupyter Notebook schließen</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">Notebook schließen</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">Notebook entfernen</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">Notebook hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">Markdowndatei hinzufügen</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
         <target state="translated">In Büchern offenlegen</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="translated">Buch erstellen (Vorschau)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Jupyter Book erstellen</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
@@ -263,8 +287,8 @@
         <target state="translated">Ordner auswählen</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="translated">Buch auswählen</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Jupyter Book auswählen</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
@@ -283,40 +307,40 @@
         <target state="translated">Externen Link öffnen</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="translated">Das Buch gilt im Arbeitsbereich jetzt als vertrauenswürdig.</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">Das Jupyter Book gilt jetzt im Arbeitsbereich als vertrauenswürdig.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="translated">Das Buch gilt in diesem Arbeitsbereich bereits als vertrauenswürdig.</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">Dieses Jupyter Book gilt in diesem Arbeitsbereich bereits als vertrauenswürdig.</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="translated">Das Buch gilt in diesem Arbeitsbereich nicht mehr als vertrauenswürdig.</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">Das Jupyter Book gilt in diesem Arbeitsbereich nicht mehr als vertrauenswürdig.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="translated">Das Buch gilt in diesem Arbeitsbereich bereits als nicht vertrauenswürdig.</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">Das Jupyter Book gilt in diesem Arbeitsbereich bereits als nicht vertrauenswürdig.</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="translated">Das Buch "{0}" ist jetzt im Arbeitsbereich angeheftet.</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">Das Jupyter Book "{0}" ist jetzt im Arbeitsbereich angeheftet.</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="translated">Das Buch "{0}" ist in diesem Arbeitsbereich nicht mehr angeheftet.</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Das Jupyter Book "{0}" ist in diesem Arbeitsbereich nicht mehr angeheftet.</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="translated">Bei der Suche im angegebenen Buch wurde keine Inhaltsverzeichnisdatei gefunden.</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">Bei der Suche im angegebenen Jupyter Book wurde keine Inhaltsverzeichnisdatei gefunden.</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="translated">Im Viewlet sind zurzeit keine Bücher ausgewählt.</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">Im Viewlet sind zurzeit keine Jupyter Books ausgewählt.</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="translated">Buchabschnitt auswählen</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Jupyter Book-Abschnitt auswählen</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
@@ -339,12 +363,12 @@
         <target state="translated">Konfigurationsdatei fehlt.</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="translated">Fehler beim Öffnen von Book "{0}": {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Fehler beim Öffnen von Jupyter Book "{0}": {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="translated">Fehler beim Lesen von Book "{0}": {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">Fehler beim Lesen von Jupyter Book "{0}": {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
@@ -363,8 +387,8 @@
         <target state="translated">Fehler beim Öffnen von Link {0}: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="translated">Fehler beim Schließen des Buchs "{0}": {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Fehler beim Schließen von Jupyter Book "{0}": {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
@@ -373,12 +397,16 @@
  Die Datei wurde in "{2}" umbenannt, um Datenverlust zu verhindern.</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="translated">Fehler beim Bearbeiten des Buchs "{0}": {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Fehler beim Bearbeiten von Jupyter Book "{0}": {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="translated">Fehler beim Auswählen eines Buchs oder eines Abschnitts zur Bearbeitung: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">Fehler beim Auswählen eines Jupyter Books oder eines Abschnitts zur Bearbeitung: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">Der Abschnitt "{0}" wurde in "{1}" nicht gefunden.</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
@@ -393,8 +421,8 @@
         <target state="translated">Speicherort</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="translated">Remotebuch hinzufügen</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">Jupyter-Remotebuch hinzufügen</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
@@ -409,8 +437,8 @@
         <target state="translated">Releases</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="translated">Buch</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter Book</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
@@ -421,8 +449,8 @@
         <target state="translated">Sprache</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="translated">Unter dem angegebenen Link sind zurzeit keine Bücher verfügbar.</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">Unter dem angegebenen Link sind zurzeit keine Jupyter Books verfügbar.</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
@@ -445,44 +473,44 @@
         <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="translated">Das Remotebuch wird heruntergeladen.</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">Remoteinstanz von Jupyter Book wird heruntergeladen.</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="translated">Der Download des Remotebuchs ist abgeschlossen.</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">Remoteinstanz von Jupyter Book wurde vollständig heruntergeladen.</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="translated">Fehler beim Herunterladen des Remotebuchs.</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">Fehler beim Herunterladen der Remoteinstanz von Jupyter Book.</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="translated">Fehler beim Dekomprimieren des Remotebuchs.</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">Fehler beim Dekomprimieren der Jupyter Book-Remoteinstanz.</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="translated">Fehler beim Erstellen des Remotebuchverzeichnisses.</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">Fehler beim Erstellen des Jupyter Book-Remoteverzeichnisses.</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="translated">Remotebuch wird heruntergeladen.</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">Remoteinstanz von Jupyter Book wird heruntergeladen.</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
         <target state="translated">Die Ressource wurde nicht gefunden.</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="translated">Bücher nicht gefunden.</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">Jupyter Books nicht gefunden.</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
         <target state="translated">Releases nicht gefunden.</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="translated">Das ausgewählte Book ist ungültig.</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">Das ausgewählte Jupyter Book ist ungültig.</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
@@ -492,21 +520,21 @@
         <source xml:lang="en">Downloading to {0}</source>
         <target state="translated">Download in "{0}"</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="translated">Neue Gruppe</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">Neue Jupyter Book-Instanz (Vorschau)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="translated">Gruppen werden zum Organisieren von Notebooks verwendet.</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Jupyter Book-Instanzen werden zum Organisieren von Notebooks verwendet.</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="translated">Speicherorte durchsuchen...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">Weitere Informationen.</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="translated">Inhaltsordner auswählen</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">Inhaltsordner</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
@@ -524,7 +552,7 @@
         <source xml:lang="en">Save location</source>
         <target state="translated">Speicherort</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
         <target state="translated">Inhaltsordner (optional)</target>
       </trans-unit>
@@ -533,8 +561,44 @@
         <target state="translated">Der Pfad für den Inhaltsordner ist nicht vorhanden.</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
+        <source xml:lang="en">Save location path does not exist.</source>
         <target state="translated">Der Speicherortpfad ist nicht vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">Fehler beim Zugriff auf: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">Neues Notebook (Vorschau)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">Neuer Markdown (Vorschau)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">Dateierweiterung</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">Die Datei ist bereits vorhanden. Möchten Sie diese Datei überschreiben?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Titel</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">Dateiname</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">Der Pfad zum Speicherort ist ungültig.</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">Die Datei "{0}" ist im Zielordner bereits vorhanden.</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">Aktuell wird eine weitere Python-Installation ausgeführt. Es wird auf den Abschluss des Vorgangs gewartet.</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">Aktive Python-Notebooksitzungen werden heruntergefahren, um sie zu aktualisieren. Möchten Sie jetzt fortfahren?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">Python {0} ist jetzt in Azure Data Studio verfügbar. Die aktuelle Python-Version (3.6.6) wird ab Dezember 2021 nicht mehr unterstützt. Möchten Sie jetzt auf Python {0} aktualisieren?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">Python {0} wird installiert und ersetzt Python 3.6.6. Einige Pakete sind möglicherweise nicht mehr mit der neuen Version kompatibel oder müssen neu installiert werden. Ein Notizbuch wird erstellt, damit Sie alle PIP-Pakete neu installieren können. Möchten Sie das Update jetzt fortsetzen?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">Fehler beim Installieren von Notebook-Abhängigkeiten: {0}</target>
@@ -603,6 +679,18 @@
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
         <target state="translated">Fehler beim Abrufen des Python-Benutzerpfads: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">Nicht mehr fragen</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">Die Aktion "{0}" wird für diesen Handler nicht unterstützt.</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">Der Link "{0}" kann nicht geöffnet werden, weil nur HTTP- und HTTPS-Links unterstützt werden.</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">Der Link "{0}" kann nicht geöffnet werden, weil nur HTTP-, HTTPS und Dateilinks unterstützt werden.</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/de/profiler.de.xlf
+++ b/resources/xlf/de/profiler.de.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/de/resource-deployment.de.xlf
+++ b/resources/xlf/de/resource-deployment.de.xlf
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">SQL Server-Containerimage mit Docker ausführen</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">SQL Server-Big Data-Cluster</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">Mit dem Big Data-Cluster von SQL Server können Sie skalierbare Cluster aus SQL Server-, Spark- und HDFS-Containern bereitstellen, die in Kubernetes ausgeführt werden.</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">Version</target>
@@ -45,34 +37,6 @@
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
         <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">Bereitstellungsziel</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">Neuer Azure Kubernetes Service-Cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">Vorhandener Azure Kubernetes Service-Cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">Vorhandener Kubernetes-Cluster (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="translated">Vorhandener Azure Red Hat OpenShift-Cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="translated">Vorhandener OpenShift-Cluster</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">Port</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">Einstellungen für SQL Server-Big-Data-Cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">Clustername</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">Benutzername für Controller</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">Kennwort</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">Kennwort bestätigen</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Azure-Einstellungen</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">Abonnement-ID</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">Mein Azure-Standardabonnement verwenden</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">Ressourcengruppenname</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">Region</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">Name des AKS-Clusters</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">VM-Größe</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">VM-Anzahl</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">Name der Speicherklasse</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">Kapazität für Daten (GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">Kapazität für Protokolle (GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">SQL Server unter Windows</target>
@@ -170,21 +70,9 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">Führen Sie SQL Server unter Windows aus, und wählen Sie eine Version aus, um loszulegen.</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">Ich akzeptiere {0}, {1} und {2}.</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
         <target state="translated">Microsoft-Datenschutzerklärung</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">azdata-Lizenzbedingungen</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">SQL Server-Lizenzbedingungen</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
@@ -485,6 +373,22 @@
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
         <target state="translated">Lizenzbedingungen akzeptieren und auswählen</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">Die Erweiterung "{0}" ist für die Bereitstellung dieser Ressource erforderlich. Möchten Sie sie jetzt installieren?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Installieren</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">Die Erweiterung "{0}" wird installiert...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">Unbekannte Erweiterung "{0}".</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
@@ -1096,10 +1000,6 @@
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">Fehler beim Laden der Erweiterung: {0}. In der Ressourcentypdefinition in "package.json" wurde ein Fehler festgestellt. Details finden Sie in der Debugkonsole.</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">Der Ressourcentyp "{0}" ist nicht definiert.</target>
@@ -2222,13 +2122,13 @@ Wählen Sie ein anderes Abonnement mit mindestens einem Server aus.</target>
         <source xml:lang="en">Deployment pre-requisites</source>
         <target state="translated">Voraussetzungen für die Bereitstellung</target>
       </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="translated">Um fortzufahren, müssen Sie die Lizenzbedingungen akzeptieren.</target>
-      </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
         <target state="translated">Einige Tools wurden noch nicht ermittelt. Stellen Sie sicher, dass sie installiert wurden, ausgeführt werden und ermittelbar sind.</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">Um fortzufahren, müssen Sie die Lizenzbedingungen akzeptieren.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
@@ -2378,6 +2278,10 @@ Wählen Sie ein anderes Abonnement mit mindestens einem Server aus.</target>
         <source xml:lang="en">Azure Data CLI</source>
         <target state="translated">Azure Data CLI</target>
       </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">Die Azure Data CLI-Erweiterung muss installiert sein, damit diese Ressource bereitgestellt werden kann. Installieren Sie sie über den Erweiterungskatalog, und versuchen Sie es noch mal.</target>
+      </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
         <target state="translated">Fehler beim Abrufen der Versionsinformationen. Weitere Informationen finden Sie im Ausgabekanal "{0}".</target>
@@ -2385,46 +2289,6 @@ Wählen Sie ein anderes Abonnement mit mindestens einem Server aus.</target>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
         <target state="translated">Fehler beim Abrufen der Versionsinformationen.{0}Ungültige Ausgabe empfangen, Versionsbefehlsausgabe abrufen: {1} </target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="translated">Zuvor heruntergeladene Datei "Azdata.msi" wird ggf. gelöscht…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="translated">"Azdata.msi" wird heruntergeladen, und die azdata-CLI wird installiert…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="translated">Installationsprotokoll wird angezeigt…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="translated">Für die azdata-CLI werden Ressourcen aus dem Brew-Repository abgerufen…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="translated">Das Brew-Repository für die azdata-CLI-Installation wird aktualisiert…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="translated">azdata wird installiert…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="translated">Repositoryinformationen werden aktualisiert…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="translated">Die für die azdata-Installation erforderlichen Pakete werden abgerufen…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="translated">Der Signaturschlüssel für azdata wird heruntergeladen und installiert…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="translated">Die azdata-Repositoryinformationen werden hinzugefügt…</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/de/schema-compare.de.xlf
+++ b/resources/xlf/de/schema-compare.de.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Quelle</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">Ziel</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">Datei</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">Datei der Datenschichtanwendung (DACPAC)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Datenbank</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Typ</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Datenbank</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">Schemavergleich</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Es wurde ein anderes Quellschema ausgewählt. Möchten Sie einen Vergleich durchführen?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Es wurde ein anderes Zielschema ausgewählt. Möchten Sie einen Vergleich durchführen?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">Es wurden verschiedene Quell- und Zielschemas ausgewählt. Möchten Sie einen Vergleich durchführen?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">Quelldatei</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">Zieldatei</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Quelldatenbank</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Zieldatenbank</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Quellserver</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Zielserver</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">Standardeinstellung</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Öffnen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">Quelldatei auswählen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">Zieldatei auswählen</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">Zurücksetzen</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">Objekttypen einschließen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">Details vergleichen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">Möchten Sie das Ziel aktualisieren?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">Klicken Sie auf "Vergleichen", um den Vergleich zu aktualisieren.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">Skript zum Bereitstellen von Änderungen am Ziel generieren</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">Keine Änderungen am Skript</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">Änderungen auf das Ziel anwenden</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">Keine Änderungen zur Anwendung vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">Beachten Sie, dass Vorgänge zum Einschließen/Ausschließen einen Moment dauern können, während betroffene Abhängigkeiten berechnet werden.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Löschen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">Ändern</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">Hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">Vergleich zwischen Quelle und Ziel</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">Der Vergleich wird gestartet. Dies kann einen Moment dauern.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">Um zwei Schemas zu vergleichen, wählen Sie zunächst ein Quellschema und ein Zielschema aus. Klicken Sie anschließend auf "Vergleichen".</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">Es wurden keine Schemaunterschiede gefunden.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Typ</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">Quellname</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">Einschließen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Aktion</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">Zielname</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">"Skript generieren" ist aktiviert, wenn das Ziel eine Datenbank ist.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">"Anwenden" ist aktiviert, wenn das Ziel eine Datenbank ist.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">"{0}" kann nicht ausgeschlossen werden. Eingeschlossene abhängige Elemente vorhanden: {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">"{0}" kann nicht eingeschlossen werden. Ausgeschlossene abhängige Elemente vorhanden: {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">"{0}" kann nicht ausgeschlossen werden. Eingeschlossene abhängige Elemente vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">"{0}" kann nicht eingeschlossen werden. Ausgeschlossene abhängige Elemente vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">Vergleichen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Beenden</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Skript generieren</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Optionen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Anwenden</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">Richtung wechseln</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">Quelle und Ziel wechseln</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">Quelle auswählen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">Ziel auswählen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">SCMP-Datei öffnen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">Quelle und Ziel sowie die in einer SCMP-Datei gespeicherten Optionen laden</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">SCMP-Datei speichern</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">Quelle und Ziel, Optionen und ausgeschlossene Elemente speichern</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">Speichern</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">Möchten Sie eine Verbindung mit "{0}" herstellen?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">Verbindung auswählen</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,7 +663,7 @@
         <target state="translated">Datenbankrollen</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
+        <source xml:lang="en">Database Triggers</source>
         <target state="translated">Datenbanktrigger</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">Externe Dateiformate</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">Externe Streams</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">Externe Streamingaufträge</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">Externe Tabellen</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">Dateigruppen</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Dateien</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">Signaturen</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">Gespeicherte Prozeduren</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">Symmetrische Schlüssel</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">Gibt an, ob Unterschiede in der Tabellenspaltenreihenfolge beim Veröffentlichen in einer Datenbank ignoriert oder aktualisiert werden sollen.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Quelle</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Ziel</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">Datei</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">Datei der Datenschichtanwendung (DACPAC)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Datenbank</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Typ</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Datenbank</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">Keine aktiven Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Schemavergleich</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Es wurde ein anderes Quellschema ausgewählt. Möchten Sie einen Vergleich durchführen?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Es wurde ein anderes Zielschema ausgewählt. Möchten Sie einen Vergleich durchführen?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">Es wurden verschiedene Quell- und Zielschemas ausgewählt. Möchten Sie einen Vergleich durchführen?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Öffnen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">Standardeinstellung</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">Details vergleichen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">Möchten Sie das Ziel aktualisieren?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">Klicken Sie auf "Vergleichen", um den Vergleich zu aktualisieren.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">Skript zum Bereitstellen von Änderungen am Ziel generieren</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">Keine Änderungen am Skript</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">Änderungen auf das Ziel anwenden</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">Keine Änderungen zur Anwendung vorhanden.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Löschen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">Ändern</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">Hinzufügen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Schemavergleich</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Quelle</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Ziel</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">Der Vergleich wird gestartet. Dies kann einen Moment dauern.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">Um zwei Schemas zu vergleichen, wählen Sie zunächst ein Quellschema und ein Zielschema aus. Klicken Sie anschließend auf "Vergleichen".</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">Es wurden keine Schemaunterschiede gefunden.</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">Fehler beim Schemavergleich: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Typ</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">Quellname</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">Einschließen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Aktion</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">Zielname</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">"Skript generieren" ist aktiviert, wenn das Ziel eine Datenbank ist.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">"Anwenden" ist aktiviert, wenn das Ziel eine Datenbank ist.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Vergleichen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Vergleichen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Beenden</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Beenden</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">Fehler beim Speichern der SCMP-Datei: {0}</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">Fehler beim Abbrechen des Schemavergleichs: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Skript generieren</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">Fehler beim Generieren des Skripts: {0}</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Optionen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Optionen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Anwenden</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">Fehler beim Anwenden des Schemavergleichs: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">Richtung wechseln</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">Quelle und Ziel wechseln</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">Quelle auswählen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">Ziel auswählen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">SCMP-Datei öffnen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">Quelle und Ziel sowie die in einer SCMP-Datei gespeicherten Optionen laden</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Öffnen</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">Fehler beim Öffnen der SCMP-Datei: {0}</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">SCMP-Datei speichern</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">Quelle und Ziel, Optionen und ausgeschlossene Elemente speichern</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">Speichern</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">Fehler beim Speichern der SCMP-Datei: {0}</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/de/sql.de.xlf
+++ b/resources/xlf/de/sql.de.xlf
@@ -1,2251 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">Das Kopieren von Images wird nicht unterstützt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">Erste Schritte</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">"Erste Schritte" anzeigen</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">Erste &amp;&amp;Schritte</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">Abfrageverlauf</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">Gibt an, ob die Erfassung des Abfrageverlaufs aktiviert ist. Bei Festlegung auf FALSE werden ausgeführte Abfragen nicht erfasst.</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Sicht</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Abfrageverlauf</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">Abfrageverlauf</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">Verbindung wird hergestellt: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">Befehl wird ausgeführt: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">Neue Abfrage wird geöffnet: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">Keine Verbindung möglich, weil keine Serverinformationen bereitgestellt wurden.</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">Die URL konnte aufgrund eines Fehlers nicht geöffnet werden: {0}</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">Hiermit wird eine Verbindung mit dem Server "{0}" hergestellt.</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">Möchten Sie die Verbindung herstellen?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">&amp;&amp;Öffnen</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">Abfragedatei wird verbunden</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">Mindestens eine Aufgabe wird zurzeit ausgeführt. Möchten Sie den Vorgang abbrechen?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">Vorschaufeatures verbessern die Benutzerfreundlichkeit von Azure Data Studio, indem sie Ihnen Vollzugriff auf neue Features und Verbesserungen ermöglichen. Weitere Informationen zu Vorschaufeatures finden Sie [hier]({0}). Möchten Sie Vorschaufeatures aktivieren?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">Ja (empfohlen)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">Nein, nicht mehr anzeigen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">Abfrageverlauf umschalten</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Löschen</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">Gesamten Verlauf löschen</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">Abfrage öffnen</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Abfrage ausführen</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">Erfassung des Abfrageverlaufs umschalten</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">Erfassung des Abfrageverlaufs anhalten</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">Erfassung des Abfrageverlaufs starten</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">Keine Abfragen zur Anzeige vorhanden.</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">Abfrageverlauf</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Fehler</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Warnung</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">Info</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">Ignorieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">Das Speichern von Ergebnissen in einem anderen Format ist für diesen Datenanbieter deaktiviert.</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">Daten können nicht serialisiert werden, weil kein Anbieter registriert wurde.</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">Unbekannter Fehler bei der Serialisierung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">Für eine Interaktion mit dem Verwaltungsdienst ist eine Verbindung erforderlich.</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Kein Handler registriert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">Datei auswählen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">Für die Interaktion mit dem Bewertungsdienst ist eine Verbindung erforderlich.</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Kein Handler registriert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">Ergebnisraster und Meldungen</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">Steuert die Schriftfamilie.</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">Steuert die Schriftbreite.</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">Legt die Schriftgröße in Pixeln fest.</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">Legt den Abstand der Buchstaben in Pixeln fest.</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">Legt die Zeilenhöhe in Pixeln fest.</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">Legt den Zellenabstand in Pixeln fest.</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">Hiermit wird die Spaltenbreite der ersten Ergebnisse automatisch angepasst. Diese Einstellung kann bei einer großen Anzahl von Spalten oder großen Zellen zu Leistungsproblemen führen.</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">Die maximale Breite in Pixeln für Spalten mit automatischer Größe</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Sicht</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">Datenbankverbindungen</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">Datenquellenverbindungen</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">Datenquellengruppen</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">Startkonfiguration</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">Bei Festlegung auf TRUE wird beim Start von Azure Data Studio standardmäßig die Serveransicht angezeigt. Bei Festlegung auf FALSE wird die zuletzt geöffnete Ansicht angezeigt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Trennen</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aktualisieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">Vorschaufeatures</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">Nicht veröffentlichte Vorschaufeatures aktivieren</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">Beim Start Verbindungsdialogfeld anzeigen</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">Benachrichtigung zu veralteter API</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">Benachrichtigung bei Verwendung veralteter APIs aktivieren/deaktivieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">Probleme</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} Aufgaben werden ausgeführt</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Sicht</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">Aufgaben</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Aufgaben</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">Die maximale Anzahl der zuletzt verwendeten Verbindungen in der Verbindungsliste.</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">Die zu verwendende Standard-SQL-Engine. Diese Einstellung legt den Standardsprachanbieter in SQL-Dateien und die Standardeinstellungen für neue Verbindungen fest.</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">Hiermit wird versucht, die Inhalte der Zwischenablage zu analysieren, wenn das Verbindungsdialogfeld geöffnet ist oder ein Element eingefügt wird.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">Farbpalette für die Servergruppe, die im Objekt-Explorer-Viewlet verwendet wird.</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">Servergruppen im Objekt-Explorer-Viewlet automatisch erweitern</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(Vorschau) Verwenden Sie die neue asynchrone Serverstruktur für die Serveransicht und das Verbindungsdialogfeld. Sie bietet Unterstützung für neue Features wie die dynamische Knotenfilterung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">Bezeichner des Kontotyps</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(Optional) Symbol zur Darstellung des Kontos in der Benutzeroberfläche. Es handelt sich entweder um einen Dateipfad oder um eine designfähige Konfiguration.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Symbolpfad, wenn ein helles Design verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Symbolpfad, wenn ein dunkles Design verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">Stellt Symbole für den Kontoanbieter zur Verfügung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">SQL-Bereich zum Bearbeiten von Daten beim Start anzeigen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Minimalwert der Y-Achse</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Maximalwert der Y-Achse</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Bezeichnung für die Y-Achse</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">Minimalwert der X-Achse</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">Maximalwert der X-Achse</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">Bezeichnung für die X-Achse</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Ressourcen-Viewer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">Zeigt die Dateneigenschaft eines Datensatzes für ein Diagramm an.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">Zeigt für jede Spalte in einem Resultset den Wert in Zeile 0 als Zählwert gefolgt vom Spaltennamen an. Unterstützt beispielsweise "1 Healthy" oder "3 Unhealthy", wobei "Healthy" dem Spaltennamen und 1 dem Wert in Zeile 1/Zelle 1 entspricht.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">Stellt die Ergebnisse in einer einfachen Tabelle dar.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">Zeigt ein Bild an, beispielsweise ein Bild, das durch eine R-Abfrage unter Verwendung von ggplot2 zurückgegeben wurde.</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">Welches Format wird erwartet – JPEG, PNG oder ein anderes Format?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">Erfolgt eine Codierung im Hexadezimal-, Base64- oder einem anderen Format?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Verwalten</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Dashboard</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">Die Webansicht, die auf dieser Registerkarte angezeigt wird.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">Der Steuerelementhost, der auf dieser Registerkarte angezeigt wird.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">Die Liste der Widgets, die auf dieser Registerkarte angezeigt werden.</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">Die Liste der Widgets, die im Widgetcontainer für die Erweiterung erwartet werden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">Die Liste der Widgets oder Webansichten, die auf dieser Registerkarte angezeigt werden.</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">Widgets oder Webansichten werden im Widgetcontainer für die Erweiterung erwartet.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">Eindeutiger Bezeichner für diesen Container.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">Der Container, der auf der Registerkarte angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">Stellt einen einzelnen oder mehrere Dashboardcontainer zur Verfügung, die Benutzer zu ihrem Dashboard hinzufügen können.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">Im Dashboardcontainer für die Erweiterung wurde keine ID angegeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">Für die Erweiterung wurde kein Container im Dashboardcontainer angegeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Es muss genau 1 Dashboardcontainer pro Bereich definiert sein.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">Im Dashboardcontainer für die Erweiterung wurde ein unbekannter Containertyp definiert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">Eindeutiger Bezeichner für diesen Navigationsbereich. Wird bei allen Anforderungen an die Erweiterung übergeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Optional) Symbol zur Darstellung dieses Navigationsbereichs in der Benutzeroberfläche. Erfordert einen Dateipfad oder eine Konfiguration, der ein Design zugeordnet werden kann.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Symbolpfad, wenn ein helles Design verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Symbolpfad, wenn ein dunkles Design verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">Der Titel des Navigationsbereichs, der dem Benutzer angezeigt werden soll.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">Der Container, der in diesem Navigationsbereich angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">Die Liste der Dashboardcontainer, die in diesem Navigationsabschnitt angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">Für die Erweiterung wurde kein Titel im Navigationsbereich angegeben.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">Für die Anwendung wurde kein Container im Navigationsbereich angegeben.</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Es muss genau 1 Dashboardcontainer pro Bereich definiert sein.</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION in NAV_SECTION ist ein ungültiger Container für die Erweiterung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">Die modellgestützte Ansicht, die auf dieser Registerkarte angezeigt wird.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Sicherung</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Wiederherstellen</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Wiederherstellen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">In Azure-Portal öffnen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">Getrennt</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">Erweiterung nicht möglich, weil der erforderliche Verbindungsanbieter "{0}" nicht gefunden wurde.</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">Vom Benutzer abgebrochen</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">Firewalldialogfeld abgebrochen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">Für die Interaktion mit "JobManagementService" ist eine Verbindung erforderlich.</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Kein Handler registriert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">Fehler beim Laden des Dateibrowsers.</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">Fehler beim Dateibrowser</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">Allgemeine ID für den Anbieter</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">Anzeigename für den Anbieter</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">Notebook-Kernelalias für den Anbieter</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">Symbolpfad für den Servertyp</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">Verbindungsoptionen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Eindeutiger Bezeichner für diese Registerkarte. Wird bei allen Anforderungen an die Erweiterung übergeben.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">Titel der Registerkarte, die dem Benutzer angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">Beschreibung dieser Registerkarte, die dem Benutzer angezeigt werden.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Eine Bedingung, die TRUE lauten muss, damit dieses Element angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">Definiert die Verbindungstypen, mit denen diese Registerkarte kompatibel ist. Der Standardwert lautet "MSSQL", wenn kein anderer Wert festgelegt wird.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">Der Container, der auf dieser Registerkarte angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">Legt fest, ob diese Registerkarte immer angezeigt werden soll oder nur dann, wenn der Benutzer sie hinzufügt.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">Legt fest, ob diese Registerkarte als Startseite für einen Verbindungstyp verwendet werden soll.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">Der eindeutige Bezeichner der Gruppe, zu der diese Registerkarte gehört. Wert für Startgruppe: Start.</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Optional) Symbol zur Darstellung dieser Registerkarte in der Benutzeroberfläche. Erfordert einen Dateipfad oder eine Konfiguration, der ein Design zugeordnet werden kann.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Symbolpfad, wenn ein helles Design verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Symbolpfad, wenn ein dunkles Design verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">Stellt eine einzelne oder mehrere Registerkarten zur Verfügung, die Benutzer zu ihrem Dashboard hinzufügen können.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">Für die Erweiterung wurde kein Titel angegeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">Es wurde keine Beschreibung zur Anzeige angegeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">Für die Erweiterung wurde kein Container angegeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">Pro Bereich muss genau 1 Dashboardcontainer definiert werden.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">Eindeutiger Bezeichner für diese Registerkartengruppe.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">Titel der Registerkartengruppe.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">Stellt eine einzelne oder mehrere Registerkartengruppen zur Verfügung, die Benutzer ihrem Dashboard hinzufügen können.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">Für die Registerkartengruppe wurde keine ID angegeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">Für die Registerkartengruppe wurde kein Titel angegeben.</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">Verwaltung</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">Überwachung</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">Leistung</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">Sicherheit</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">Problembehandlung</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Einstellungen</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">Registerkarte "Datenbanken"</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">Datenbanken</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">Erfolgreich</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">Fehlerhaft</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">Verbindungsfehler</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">Fehler bei Verbindung aufgrund eines Kerberos-Fehlers.</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">Hilfe zum Konfigurieren von Kerberos finden Sie hier: {0}</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">Wenn Sie zuvor eine Verbindung hergestellt haben, müssen Sie "kinit" möglicherweise erneut ausführen.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Schließen</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">Konto wird hinzugefügt...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">Die Kontoaktualisierung wurde durch den Benutzer abgebrochen.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">Abfrageergebnisse</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Abfrage-Editor</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Neue Abfrage</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Abfrage-Editor</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">Bei Festlegung auf TRUE werden beim Speichern der Ergebnisse als CSV auch die Spaltenüberschriften einbezogen.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">Benutzerdefiniertes Trennzeichen zwischen Werten, das beim Speichern der Ergebnisse als CSV verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">Zeichen für die Trennung von Zeilen, das beim Speichern der Ergebnisse als CSV verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">Zeichen für das Umschließen von Textfeldern, das beim Speichern der Ergebnisse als CSV verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">Dateicodierung, die beim Speichern der Ergebnisse als CSV verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">Bei Festlegung auf TRUE wird die XML-Ausgabe formatiert, wenn die Ergebnisse im XML-Format gespeichert werden.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">Beim Speichern der Ergebnisse im XML-Format verwendete Dateicodierung</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">Hiermit wird das Streamen der Ergebnisse aktiviert. Diese Option weist einige geringfügige Darstellungsprobleme auf.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">Konfigurationsoptionen für das Kopieren von Ergebnissen aus der Ergebnisansicht</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">Konfigurationsoptionen für das Kopieren mehrzeiliger Ergebnisse aus der Ergebnisansicht</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(Experimentell) Verwenden Sie eine optimierte Tabelle in der Ergebnisausgabe. Möglicherweise fehlen einige Funktionen oder befinden sich in Bearbeitung.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">Gibt an, ob die Ausführungszeit für einzelne Batches angezeigt werden soll.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">Meldungen zu Zeilenumbrüchen</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">Dieser Diagrammtyp wird standardmäßig verwendet, wenn der Diagramm-Viewer von Abfrageergebnissen aus geöffnet wird.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">Das Einfärben von Registerkarten wird deaktiviert.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">Der obere Rand der einzelnen Editor-Registerkarten wird entsprechend der jeweiligen Servergruppe eingefärbt.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">Die Hintergrundfarbe der Editor-Registerkarten entspricht der jeweiligen Servergruppe.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">Steuert die Farbe von Registerkarten basierend auf der Servergruppe der aktiven Verbindung.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">Legt fest, ob die Verbindungsinformationen für eine Registerkarte im Titel angezeigt werden.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">Aufforderung zum Speichern generierter SQL-Dateien</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">Legen Sie die Tastenzuordnung "workbench.action.query.shortcut{0}" fest, um den Verknüpfungstext als Prozeduraufruf auszuführen. Im Abfrage-Editor ausgewählter Text wird als Parameter übergeben.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">Gibt Ansichtsvorlagen an.</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">Gibt Sitzungsvorlagen an.</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Profilerfilter</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Skripterstellung als CREATE</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Skripterstellung als DROP</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Oberste 1000 auswählen</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Skripterstellung als EXECUTE</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Skripterstellung als ALTER</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Daten bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Oberste 1000 auswählen</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">10 zurückgeben</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Skripterstellung als CREATE</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Skripterstellung als EXECUTE</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Skripterstellung als ALTER</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Skripterstellung als DROP</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aktualisieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">Fehler bei Zeilencommit: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">Ausführung der Abfrage gestartet um </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">Die Ausführung der Abfrage "{0}" wurde gestartet.</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">Zeile {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">Fehler beim Abbrechen der Abfrage: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">Fehler beim Aktualisieren der Zelle: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">Bei der Erstellung eines Notebook-Managers wurde kein URI übergeben.</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">Der Notebook-Anbieter ist nicht vorhanden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Notebook-Editor</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Neues Notebook</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Neues Notebook</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">Arbeitsbereich festlegen und öffnen</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">SQL-Kernel: Notebook-Ausführung bei Fehler in Zelle beenden</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(Vorschau) Zeigen Sie alle Kernel für den aktuellen Notebook-Anbieter an.</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">Hiermit wird Notebooks das Ausführen von Azure Data Studio-Befehlen ermöglicht.</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">Hiermit wird ein Doppelklick zum Bearbeiten von Textzellen in Notebooks aktiviert.</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">Rich-Text-Ansichtsmodus für Textzellen standardmäßig festlegen</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(Vorschau) Speichern Sie den Verbindungsnamen in den Notebook-Metadaten.</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">Hiermit wird die in der Notebook-Markdownvorschau verwendete Zeilenhöhe gesteuert. Diese Zahl ist relativ zum Schriftgrad.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Ansicht</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">Notebooks suchen</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">Konfigurieren Sie Globmuster für das Ausschließen von Dateien und Ordnern aus Volltextsuchen und Quick Open. Alle Globmuster werden von der Einstellung #files.exclude# geerbt. Weitere Informationen zu Globmustern finden Sie [hier](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">Das Globmuster, mit dem Dateipfade verglichen werden sollen. Legen Sie diesen Wert auf "true" oder "false" fest, um das Muster zu aktivieren bzw. zu deaktivieren.</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">Zusätzliche Überprüfung der gleichgeordneten Elemente einer entsprechenden Datei. Verwenden Sie "$(basename)" als Variable für den entsprechenden Dateinamen.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">Diese Einstellung ist veraltet und greift jetzt auf "search.usePCRE2" zurück.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">Veraltet. Verwenden Sie "search.usePCRE2" für die erweiterte Unterstützung von RegEx-Features.</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">Wenn diese Option aktiviert ist, bleibt der SearchService-Prozess aktiv, anstatt nach einer Stunde Inaktivität beendet zu werden. Dadurch wird der Cache für Dateisuchen im Arbeitsspeicher beibehalten.</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Steuert, ob bei der Dateisuche GITIGNORE- und IGNORE-Dateien verwendet werden.</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Steuert, ob bei der Dateisuche globale GITIGNORE- und IGNORE-Dateien verwendet werden.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">Konfiguriert, ob Ergebnisse aus einer globalen Symbolsuche in die Dateiergebnisse für Quick Open eingeschlossen werden sollen.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">Gibt an, ob Ergebnisse aus zuletzt geöffneten Dateien in den Dateiergebnissen für Quick Open aufgeführt werden.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">Verlaufseinträge werden anhand des verwendeten Filterwerts nach Relevanz sortiert. Relevantere Einträge werden zuerst angezeigt.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">Verlaufseinträge werden absteigend nach Datum sortiert. Zuletzt geöffnete Einträge werden zuerst angezeigt.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">Legt die Sortierreihenfolge des Editor-Verlaufs beim Filtern in Quick Open fest.</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">Steuert, ob Symlinks während der Suche gefolgt werden.</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">Sucht ohne Berücksichtigung von Groß-/Kleinschreibung, wenn das Muster kleingeschrieben ist, andernfalls wird mit Berücksichtigung von Groß-/Kleinschreibung gesucht.</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">Steuert, ob die Suchansicht die freigegebene Suchzwischenablage unter macOS lesen oder verändern soll.</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">Steuert, ob die Suche als Ansicht in der Seitenleiste oder als Panel angezeigt wird, damit horizontal mehr Platz verfügbar ist.</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">Diese Einstellung ist veraltet. Verwenden Sie stattdessen das Kontextmenü der Suchansicht.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">Dateien mit weniger als 10 Ergebnissen werden erweitert. Andere bleiben reduziert.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">Steuert, ob die Suchergebnisse zu- oder aufgeklappt werden.</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">Steuert, ob die Vorschau für das Ersetzen geöffnet werden soll, wenn eine Übereinstimmung ausgewählt oder ersetzt wird.</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">Steuert, ob Zeilennummern für Suchergebnisse angezeigt werden.</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">Gibt an, ob die PCRE2-RegEx-Engine bei der Textsuche verwendet werden soll. Dadurch wird die Verwendung einiger erweiterter RegEx-Features wie Lookahead und Rückverweise ermöglicht. Allerdings werden nicht alle PCRE2-Features unterstützt, sondern nur solche, die auch von JavaScript unterstützt werden.</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">Veraltet. PCRE2 wird beim Einsatz von Features für reguläre Ausdrücke, die nur von PCRE2 unterstützt werden, automatisch verwendet.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">Hiermit wird die Aktionsleiste auf der rechten Seite positioniert, wenn die Suchansicht schmal ist, und gleich hinter dem Inhalt, wenn die Suchansicht breit ist.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">Hiermit wird die Aktionsleiste immer auf der rechten Seite positioniert.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">Steuert die Positionierung der Aktionsleiste auf Zeilen in der Suchansicht.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">Alle Dateien während der Eingabe durchsuchen</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">Aktivieren Sie das Starten der Suche mit dem Wort, das dem Cursor am nächsten liegt, wenn der aktive Editor keine Auswahl aufweist.</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">Hiermit wird die Suchabfrage für den Arbeitsbereich auf den ausgewählten Editor-Text aktualisiert, wenn die Suchansicht den Fokus hat. Dies geschieht entweder per Klick oder durch Auslösen des Befehls "workbench.views.search.focus".</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">Wenn #search.searchOnType aktiviert ist, wird dadurch das Timeout in Millisekunden zwischen einem eingegebenen Zeichen und dem Start der Suche festgelegt. Diese Einstellung keine Auswirkung, wenn search.searchOnType deaktiviert ist.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">Durch Doppelklicken wird das Wort unter dem Cursor ausgewählt.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">Durch Doppelklicken wird das Ergebnis in der aktiven Editor-Gruppe geöffnet.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">Durch Doppelklicken wird das Ergebnis in der Editorgruppe an der Seite geöffnet, wodurch ein Ergebnis erstellt wird, wenn noch keines vorhanden ist.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">Konfiguriert den Effekt des Doppelklickens auf ein Ergebnis in einem Such-Editor.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">Ergebnisse werden nach Ordner- und Dateinamen in alphabetischer Reihenfolge sortiert.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">Die Ergebnisse werden nach Dateinamen in alphabetischer Reihenfolge sortiert. Die Ordnerreihenfolge wird ignoriert.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">Die Ergebnisse werden nach Dateiendungen in alphabetischer Reihenfolge sortiert.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">Die Ergebnisse werden nach dem Datum der letzten Dateiänderung in absteigender Reihenfolge sortiert.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">Ergebnisse werden nach Anzahl pro Datei und in absteigender Reihenfolge sortiert.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">Die Ergebnisse werden nach Anzahl pro Datei in aufsteigender Reihenfolge sortiert.</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">Steuert die Sortierreihenfolge der Suchergebnisse.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Neue Abfrage</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Ausführen</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">Erklärung</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">Tatsächlich</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Trennen</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Verbindung ändern</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Verbinden</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">SQLCMD aktivieren</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">SQLCMD deaktivieren</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">Datenbank auswählen</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Fehler beim Ändern der Datenbank.</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">Fehler beim Ändern der Datenbank: {0}</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">Als Notebook exportieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Schließen</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Aktion</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">Details kopieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">Servergruppe hinzufügen</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">Servergruppe bearbeiten</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">Erweiterung</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">Fehler beim Erstellen der Objekt-Explorer-Sitzung.</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">Mehrere Fehler:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Fehler beim Hinzufügen des Kontos</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">Fehler bei Firewallregel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">Einige der geladenen Erweiterungen verwenden veraltete APIs. Ausführliche Informationen finden Sie auf der Registerkarte "Konsole" des Fensters "Entwicklertools".</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Nicht mehr anzeigen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">Bezeichner der Sicht. Hiermit können Sie einen Datenanbieter über die API "vscode.window.registerTreeDataProviderForView" registrieren. Dient auch zum Aktivieren Ihrer Erweiterung, indem Sie das Ereignis "onView:${id}" für "activationEvents" registrieren.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Der lesbare Name der Sicht. Dieser wird angezeigt.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">Eine Bedingung, die TRUE lauten muss, damit diese Sicht angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">Stellt Sichten für den Editor zur Verfügung.</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">Stellt Sichten für den Data Explorer-Container in der Aktivitätsleiste zur Verfügung.</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">Stellt Sichten für den Container mit bereitgestellten Sichten zur Verfügung.</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">Es können nicht mehrere Sichten mit derselben ID ({0}) im Container "{1}" mit Sichten registriert werden.</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">Im Container "{1}" mit Sichten ist bereits eine Sicht mit der ID {0} registriert.</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">Sichten müssen als Array vorliegen.</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">Die Eigenschaft "{0}" ist erforderlich und muss vom Typ "string" sein.</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">Die Eigenschaft "{0}" kann ausgelassen werden oder muss vom Typ "string" sein.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">"{0}" wurde in Ihren Benutzereinstellungen durch "{1}" ersetzt.</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">"{0}" wurde in Ihren Arbeitsbereichseinstellungen durch "{1}" ersetzt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Verwalten</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Details anzeigen</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">Weitere Informationen</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">Alle gespeicherten Konten löschen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">Aufgaben umschalten</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">Verbindungsstatus</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">Sichtbarer Benutzername für den Strukturanbieter</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">Die ID für den Anbieter muss mit der ID übereinstimmen, die zur Registrierung des Strukturdatenanbieters verwendet wurde, und mit "connectionDialog/" beginnen.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">Zeigt die Ergebnisse einer Abfrage als Diagramm im Dashboard an.</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">Ordnet den Spaltennamen einer Farbe zu. Fügen Sie z. B. "'column1': red" hinzu, damit in dieser Spalte die Farbe Rot verwendet wird.</target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">Hiermit wird die bevorzugte Position und Sichtbarkeit der Diagrammlegende angegeben. Darin werden die Spaltennamen aus der Abfrage der Bezeichnung der einzelnen Diagrammeinträge zugeordnet.</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">Wenn "dataDirection" auf "horizontal" festgelegt ist, werden die Werte aus der ersten Spalten als Legende verwendet.</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">Wenn "dataDirection" auf "vertical" festgelegt ist, werden für die Legende die Spaltennamen verwendet.</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">Legt fest, ob die Daten aus einer Spalte (vertikal) oder eine Zeile (horizontal) gelesen werden. Für Zeitreihen wird diese Einstellung ignoriert, da die Richtung vertikal sein muss.</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">Wenn "showTopNData" festgelegt ist, werden nur die ersten n Daten im Diagramm angezeigt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">In den Dashboards verwendetes Widget</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Aktionen anzeigen</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Ressourcen-Viewer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">Bezeichner der Ressource.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Der lesbare Name der Sicht. Dieser wird angezeigt.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">Pfad zum Ressourcensymbol.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">Trägt die Ressource zur Ressourcenansicht bei.</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">Die Eigenschaft "{0}" ist erforderlich und muss vom Typ "string" sein.</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">Die Eigenschaft "{0}" kann ausgelassen werden oder muss vom Typ "string" sein.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">Ressourcen-Viewer-Struktur</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">In den Dashboards verwendetes Widget</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">In den Dashboards verwendetes Widget</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">In den Dashboards verwendetes Widget</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Eine Bedingung, die TRUE lauten muss, damit dieses Element angezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">Gibt an, ob die Kopfzeile des Widgets ausgeblendet werden soll. Standardwert: FALSE.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">Der Titel des Containers</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">Die Zeile der Komponente im Raster</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">Die RowSpan-Eigenschaft der Komponente im Raster. Der Standardwert ist 1. Verwenden Sie "*", um die Anzahl von Zeilen im Raster festzulegen.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">Die Spalte der Komponente im Raster</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">Der ColSpan-Wert der Komponente im Raster. Der Standardwert ist 1. Verwenden Sie "*", um die Anzahl von Spalten im Raster festzulegen.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Eindeutiger Bezeichner für diese Registerkarte. Wird bei allen Anforderungen an die Erweiterung übergeben.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">Die Registerkarte "Erweiterung" ist unbekannt oder nicht installiert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Eigenschaftswidget aktivieren oder deaktivieren</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Anzuzeigende Eigenschaftswerte</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Anzeigename der Eigenschaft</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">Wert im Objekt mit Datenbankinformationen</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">Spezifische zu ignorierende Werte angeben</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">Wiederherstellungsmodell</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">Letzte Datenbanksicherung</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">Letzte Protokollsicherung</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">Kompatibilitätsgrad</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Besitzer</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">Hiermit wird die Dashboardseite für die Datenbank angepasst.</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Suchen</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">Hiermit werden die Dashboardregisterkarten für die Datenbank angepasst.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Eigenschaftswidget aktivieren oder deaktivieren</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Anzuzeigende Eigenschaftswerte</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Anzeigename der Eigenschaft</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">Wert im Objekt mit Serverinformationen</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Version</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">Edition</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">Computername</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">Betriebssystemversion</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Suchen</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">Hiermit wird die Dashboardseite des Servers angepasst.</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">Hiermit werden die Dashboardregisterkarten des Servers angepasst.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Verwalten</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">Die Eigenschaft "icon" kann ausgelassen werden oder muss eine Zeichenfolge oder ein Literal wie "{dark, light}" sein.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">Fügt ein Widget hinzu, das einen Server oder eine Datenbank abfragen und die Ergebnisse in unterschiedlicher Form anzeigen kann – als Diagramm, summierte Anzahl und mehr.</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">Eindeutiger Bezeichner, der zum Zwischenspeichern der Erkenntnisergebnisse verwendet wird</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">Auszuführende SQL-Abfrage. Es sollte genau 1 Resultset zurückgegeben werden.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[Optional] Pfad zu einer Datei, die eine Abfrage enthält. Verwenden Sie diese Einstellung, wenn "query" nicht festgelegt ist.</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[Optional] Intervall für die automatische Aktualisierung in Minuten. Ist kein Wert festgelegt, wird keine automatische Aktualisierung durchgeführt.</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">Zu verwendende Aktionen</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Zieldatenbank für die Aktion. Kann das Format "${ columnName }" verwenden, um einen datengesteuerten Spaltennamen zu nutzen.</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Zielserver für die Aktion. Kann das Format "${ columnName }" verwenden, um einen datengesteuerten Spaltennamen zu nutzen.</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Zielbenutzer für die Aktion. Kann das Format "${ columnName }" verwenden, um einen datengesteuerten Spaltennamen zu nutzen.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">Bezeichner für Erkenntnisse</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">Stellt Erkenntnisse in der Dashboardpalette zur Verfügung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Sicherung</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">Sie müssen die Vorschaufeatures aktivieren, um die Sicherung verwenden zu können.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">Der Sicherungsbefehl wird für Azure SQL-Datenbank-Instanzen nicht unterstützt.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">Der Sicherungsbefehl wird im Serverkontext nicht unterstützt. Wählen Sie eine Datenbank aus, und versuchen Sie es noch mal.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Wiederherstellen</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">Sie müssen die Vorschaufeatures aktivieren, um die Wiederherstellung zu verwenden.</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">Der Wiederherstellungsbefehl wird für Azure SQL-Datenbank-Instanzen nicht unterstützt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Empfehlungen anzeigen</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">Erweiterungen installieren</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">Erweiterung erstellen...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">Fehler beim Verbinden der Datenbearbeitungssitzung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">Dashboarderweiterungen öffnen</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">Aktuell sind keine Dashboarderweiterungen installiert. Wechseln Sie zum Erweiterungs-Manager, um die empfohlenen Erweiterungen zu erkunden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">Ausgewählter Pfad</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">Dateien vom Typ</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Verwerfen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">Es wurde kein Verbindungsprofil an das Flyout mit Erkenntnissen übergeben.</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">Erkenntnisfehler</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">Fehler beim Lesen der Abfragedatei: </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">Fehler beim Analysieren der Konfiguration für Erkenntnisse. Das Abfragearray/die Abfragezeichenfolge oder die Abfragedatei wurde nicht gefunden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Azure-Konto</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Azure-Mandant</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">Verbindungen anzeigen</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Verbindungen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">Kein Aufgabenverlauf zur Anzeige vorhanden.</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">Aufgabenverlauf</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">Aufgabenfehler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">Liste löschen</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">Die Liste der zuletzt verwendeten Verbindungen wurde gelöscht.</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">Möchten Sie alle Verbindungen aus der Liste löschen?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Löschen</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">Aktuelle Verbindungszeichenfolge abrufen</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">Die Verbindungszeichenfolge ist nicht verfügbar.</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">Keine aktive Verbindung verfügbar.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aktualisieren</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">Verbindung bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Trennen</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">Neue Verbindung</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">Neue Servergruppe</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">Servergruppe bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">Aktive Verbindungen anzeigen</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">Alle Verbindungen anzeigen</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Letzte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">Verbindung löschen</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">Gruppe löschen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Ausführen</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">Fehler beim Verwerfen der Bearbeitung: </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Beenden</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">SQL-Bereich anzeigen</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">SQL-Bereich schließen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">Nicht verbunden</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">Die XEvent Profiler-Sitzung wurde auf dem Server "{0}" unerwartet beendet.</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">Fehler beim Starten der neuen Sitzung.</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">Die XEvent Profiler-Sitzung für "{0}" hat Ereignisse verloren.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2257,743 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">Servergruppen</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">Beschriftungen ausblenden</target>
       </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">Name der Servergruppe</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">Der Gruppenname ist erforderlich.</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">Gruppenbeschreibung</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">Gruppenfarbe</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">Beschriftungen anzeigen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Fehler beim Hinzufügen des Kontos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">Element</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Wert</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">Details zu Erkenntnissen</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">Eigenschaft</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Wert</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">Erkenntnisse</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">Elemente</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">Details zum Element</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">Starten einer automatischen OAuth-Authentifizierung nicht möglich. Es wird bereits eine automatische OAuth-Authentifizierung ausgeführt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">Nach Ereignis sortieren</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">Nach Spalte sortieren</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">Alle löschen</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Anwenden</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">Filter</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">Diese Klausel entfernen</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">Filter speichern</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">Filter laden</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">Klausel hinzufügen</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">Feld</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">Operator</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Wert</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">Ist NULL</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">Ist nicht NULL</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">Enthält</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">Enthält nicht</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">Beginnt mit</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">Beginnt nicht mit</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Als CSV speichern</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Als JSON speichern</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Als Excel speichern</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Als XML speichern</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Kopieren</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Mit Headern kopieren</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Alle auswählen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">Definiert eine Eigenschaft, die im Dashboard angezeigt werden soll</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">Gibt an, welcher Wert soll als Beschriftung für die Eigenschaft verwendet werden soll.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">Gibt an, auf welchen Wert im Objekt zugegriffen werden soll, um den Wert zu ermitteln.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">Geben Sie Werte an, die ignoriert werden sollen.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">Standardwert, der angezeigt werden soll, wenn der Wert ignoriert wird oder kein Wert angegeben ist</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">Eine Variante für das Definieren von Dashboardeigenschaften</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">ID der Variante</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">Bedingung für die Verwendung dieser Variante</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">Feld für Vergleich</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">Hiermit wird angegeben, welcher Operator für den Vergleich verwendet werden soll.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">Wert, mit dem das Feld verglichen werden soll</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">Eigenschaften, die für die Datenbankseite angezeigt werden sollen</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">Eigenschaften, die für die Serverseite angezeigt werden sollen</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">Hiermit wird definiert, dass dieser Anbieter das Dashboard unterstützt.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">Anbieter-ID (z. B. MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">Eigenschaftswerte, die im Dashboard angezeigt werden sollen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">Ungültiger Wert.</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Wird geladen</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Ladevorgang abgeschlossen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">Leer</target>
-      </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">Alle Kontrollkästchen in folgender Spalte aktivieren: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">Es wurde keine Strukturansicht mit der ID "{0}" registriert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">Fehler beim Initialisieren der Datenbearbeitungssitzung: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">Bezeichner des Notebook-Anbieters.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">Gibt an, welche Dateierweiterungen für diesen Notebook-Anbieter registriert werden sollen.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">Gibt an, welche Kernel für diesen Notebook-Anbieter als Standard festgelegt werden sollen.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">Stellt Notebook-Anbieter zur Verfügung.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">Name des Magic-Befehls für die Zelle, z. B. "%%sql".</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">Die zu verwendende Zellensprache, wenn dieser Zellen-Magic-Befehl in der Zelle enthalten ist.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">Optionales Ausführungsziel, das von diesem Magic-Befehl angegeben wird, z. B. Spark oder SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">Optionaler Kernelsatz, auf den dies zutrifft, z. B. python3, pyspark, sql</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">Stellt die Notebook-Sprache zur Verfügung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">Zur Verwendung der F5-Tastenkombination muss eine Codezelle ausgewählt sein. Wählen Sie eine Codezelle für die Ausführung aus.</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">Zum Löschen des Ergebnisses muss eine Zelle ausgewählt sein. Wählen Sie eine Codezelle für die Ausführung aus.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">Max. Zeilen:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">Ansicht auswählen</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">Sitzung auswählen</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">Sitzung auswählen:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">Ansicht auswählen:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Text</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">Beschriftung</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Wert</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Details</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">Verstrichene Zeit</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">Zeilenanzahl</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} Zeilen</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">Abfrage wird ausgeführt...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">Ausführungsstatus</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">Zusammenfassung der Auswahl</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">Durchschnitt: {0}, Anzahl: {1}, Summe: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">SQL-Sprache auswählen</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">SQL-Sprachanbieter ändern</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">SQL-Sprachvariante</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">SQL-Engine-Anbieter ändern</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">Es besteht eine Verbindung über die Engine "{0}". Um die Verbindung zu ändern, trennen oder wechseln Sie die Verbindung.</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">Momentan ist kein Text-Editor aktiv.</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">Sprachanbieter auswählen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">Fehler beim Anzeigen des Plotly-Graphen: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Für die Ausgabe wurde kein {0}-Renderer gefunden. Folgende MIME-Typen sind enthalten: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(sicher) </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Oberste 1000 auswählen</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">10 zurückgeben</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Skripterstellung als EXECUTE</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Skripterstellung als ALTER</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Daten bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Skripterstellung als CREATE</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Skripterstellung als DROP</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">An diese Klasse muss ein NotebookProvider mit gültiger providerId übergeben werden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">An diese Klasse muss ein NotebookProvider mit gültiger providerId übergeben werden.</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">Kein Notebook-Anbieter gefunden.</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">Kein Manager gefunden.</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">Der Notebook-Manager für das Notebook "{0}" umfasst keinen Server-Manager. Es können keine Aktionen ausgeführt werden.</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">Der Notebook-Manager für das Notebook "{0}" umfasst keinen Inhalts-Manager. Es können keine Aktionen ausgeführt werden.</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">Der Notebook-Manager für das Notebook "{0}" umfasst keinen Sitzungs-Manager. Es können keine Aktionen ausgeführt werden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">Fehler beim Abrufen des Azure-Kontotokens für die Verbindung.</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">Verbindung nicht akzeptiert.</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">Möchten Sie diese Verbindung abbrechen?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">Schließen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">Kernel werden geladen...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">Kernel wird geändert...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">Anfügen an </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">Kernel </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">Kontexte werden geladen...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Verbindung ändern</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">Verbindung auswählen</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">Kein Kernel</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">Ergebnisse löschen</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">Vertrauenswürdig</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">Nicht vertrauenswürdig</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">Zellen reduzieren</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">Zellen erweitern</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">Keine</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Neues Notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Nächste Zeichenfolge suchen</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Vorhergehende Zeichenfolge suchen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">Abfrageplan</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aktualisieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">Schritt {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">Muss eine Option aus der Liste sein</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">Auswahlfeld</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Verbindung</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">Verbindung wird hergestellt</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">Verbindungstyp</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Letzte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Gespeicherte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">Verbindungsdetails</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Verbinden</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Letzte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">Keine aktuelle Verbindung</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Gespeicherte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">Keine gespeicherte Verbindung</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">Keine Daten verfügbar.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">Dateibrowserstruktur</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">Alles auswählen/Gesamte Auswahl aufheben</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">Von</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">Filter anzeigen</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">An</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Alle auswählen</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">Neue Firewallregel erstellen</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Suchen</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} Ergebnisse</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">{0} ausgewählt</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">Aufsteigend sortieren</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">Absteigend sortieren</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">Löschen</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Abbrechen</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">Ihre Client-IP-Adresse hat keinen Zugriff auf den Server. Melden Sie sich bei einem Azure-Konto an, und erstellen Sie eine neue Firewallregel für die Aktivierung des Zugriffs.</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">Weitere Informationen zu Firewalleinstellungen</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">Firewallregel</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">Meine Client-IP-Adresse hinzufügen </target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">Meinen Subnetz-IP-Adressbereich hinzufügen</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">Filteroptionen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">Alle Dateien</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Wird geladen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">Die Abfragedatei wurde in keinem der folgenden Pfade gefunden:
-{0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">Fehler wird geladen...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">Die Anmeldeinformationen für dieses Konto müssen aktualisiert werden.</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">Weitere ein-/ausblenden</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">Automatische Prüfung auf Aktualisierungen aktivieren. Azure Data Studio prüft automatisch und regelmäßig auf Aktualisierungen.</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">Aktivieren Sie diese Option, um neue Azure Data Studio-Versionen im Hintergrund unter Windows herunterzuladen und zu installieren.</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">Versionshinweise nach einem Update anzeigen. Die Versionshinweise werden in einem neuen Webbrowserfenster geöffnet.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">Das Aktionsmenü für die Dashboard-Symbolleiste</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">Titelmenü der Notizbuchzelle</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">Titelmenü des Notizbuchs</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">Symbolleistenmenü des Notizbuchs</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">Das Aktionsmenü für den Container-Titel der Dataexplorer-Ansicht</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">Kontextmenü des Dataexplorer-Elements</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">Kontextmenü des Objekt-Explorer-Elements</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">Kontextmenü zum Durchsuchen der Struktur des Verbindungsdialogfelds</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">Kontextmenü des Datenrasterelements</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">Legt die Sicherheitsrichtlinie für das Herunterladen von Erweiterungen fest.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">Die Erweiterungsrichtlinie lässt die Installation von Erweiterungen nicht zu. Ändern Sie Ihre Erweiterungsrichtlinie und versuchen Sie es noch mal.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">Die Installation der Erweiterung "{0}" aus VSIX wurde abgeschlossen. Laden Sie Azure Data Studio neu, um sie zu aktivieren.</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">Laden Sie Azure Data Studio erneut, um die Deinstallation dieser Erweiterung abzuschließen.</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">Laden Sie Azure Data Studio erneut, um die Aktualisierung dieser Erweiterung abzuschließen.</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">Laden Sie Azure Data Studio erneut, um diese Erweiterung lokal zu aktivieren.</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">Laden Sie Azure Data Studio erneut, um diese Erweiterung zu aktivieren.</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">Laden Sie Azure Data Studio erneut, um diese Erweiterung zu deaktivieren.</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">Laden Sie Azure Data Studio erneut, um die Deinstallation der Erweiterung {0} abzuschließen.</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">Laden Sie Azure Data Studio erneut, um diese Erweiterung in {0} zu aktivieren.</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">Die Installation der Erweiterung "{0}" wurde abgeschlossen. Laden Sie Azure Data Studio neu, um sie zu aktivieren.</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">Laden Sie Azure Data Studio neu, um die Neuinstallation der Erweiterung {0} abzuschließen.</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Marketplace</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Der Szenariotyp für Erweiterungsempfehlungen muss angegeben werden.</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">Die Erweiterung '{0}' mit Version '{1}' konnte nicht installiert werden, da sie nicht mit Azure Data Studio kompatibel ist.</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Neue Abfrage</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Neue &amp;&amp;Abfrage</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Neues Notizbuch</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">Steuert den für Azure Data Studio verfügbaren Arbeitsspeicher nach einem Neustart bei dem Versuch, große Dateien zu öffnen. Dies hat die gleiche Auswirkung wie das Festlegen von `--max-memory=NEWSIZE` über die Befehlszeile.</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">Möchten Sie die Sprache der Benutzeroberfläche von Azure Data Studio in {0} ändern und einen Neustart durchführen?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">Um Azure Data Studio in {0} zu verwenden, muss Azure Data Studio neu gestartet werden.</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">Neue SQL-Datei</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Neues Notizbuch</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Erweiterung aus VSIX-Paket installieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">Muss eine Option aus der Liste sein</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">Auswahlfeld</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">Notebooks anzeigen</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">Suchergebnisse</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">Der Suchpfad wurde nicht gefunden: {0}.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">Das Kopieren von Images wird nicht unterstützt.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">Fokus auf aktuelle Abfrage</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Abfrage ausführen</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">Aktuelle Abfrage ausführen</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">Abfrage mit Ergebnissen kopieren</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">Die Abfrage und die Ergebnisse wurden erfolgreich kopiert.</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">Aktuelle Abfrage mit Istplan ausführen</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">Abfrage abbrechen</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">IntelliSense-Cache aktualisieren</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">Abfrageergebnisse umschalten</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">Fokus zwischen Abfrage und Ergebnissen umschalten</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">Editor-Parameter zum Ausführen einer Tastenkombination erforderlich.</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">Abfrage analysieren</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">Die Befehle wurden erfolgreich ausgeführt.</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">Fehler bei Befehl:</target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">Stellen Sie eine Verbindung mit einem Server her.</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">Es ist bereits eine Servergruppe mit diesem Namen vorhanden.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">Erfolgreich</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">Fehlerhaft</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">In Bearbeitung</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">Nicht gestartet</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">Abgebrochen</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">Wird abgebrochen</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">In den Dashboards verwendetes Widget</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">Das Diagramm kann mit den angegebenen Daten nicht angezeigt werden.</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">In den Dashboards verwendetes Widget</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">In den Dashboards verwendetes Widget</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">In den Dashboards verwendetes Widget</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">Fehler beim Öffnen des Links: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">Fehler beim Ausführen des Befehls "{0}": {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Fehler beim Kopieren: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">Diagramm anzeigen</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">Tabelle anzeigen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Zum Bearbeiten doppelklicken&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Hier Inhalte hinzufügen... &lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">Fehler beim Aktualisieren des Knotens "{0}": {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Fertig</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Skript generieren</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Weiter</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">Zurück</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">Registerkarten sind nicht initialisiert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated"> ist erforderlich.</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">Ungültige Eingabe. Es wird ein numerischer Wert erwartet.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">Pfad zur Sicherungsdatei</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">Zieldatenbank</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Wiederherstellen</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Datenbank wiederherstellen</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Datenbank</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">Sicherungsdatei</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Datenbank wiederherstellen</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Skript</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Quelle</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">Wiederherstellen aus</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">Sie müssen einen Pfad für die Sicherungsdatei angeben.</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">Geben Sie einen oder mehrere Dateipfade (durch Kommas getrennt) ein.</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Datenbank</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">Ziel</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">Wiederherstellen in</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">Wiederherstellungsplan</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">Wiederherzustellende Sicherungssätze</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">Datenbankdateien wiederherstellen als</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">Details zu Datenbankdateien wiederherstellen</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">Logischer Dateiname</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">Dateityp</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">Ursprünglicher Dateiname</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">Wiederherstellen als</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">Wiederherstellungsoptionen</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">Sicherung des Protokollfragments</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">Serververbindungen</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">Allgemein</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">Dateien</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Optionen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">Zelle kopieren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Fertig</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">Kopieren und öffnen</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">Benutzercode</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">Website</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">Der Index "{0}" ist ungültig.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">Serverbeschreibung (optional)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">Erweiterte Eigenschaften</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Verwerfen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">nbformat v{0}.{1} nicht erkannt.</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">Diese Datei weist kein gültiges Notebook-Format auf.</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">Unbekannter Zellentyp "{0}".</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Der Ausgabetyp "{0}" wurde nicht erkannt.</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">Als Daten für "{0}" wird eine Zeichenfolge oder ein Array aus Zeichenfolgen erwartet.</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Der Ausgabetyp "{0}" wurde nicht erkannt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Willkommen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL-Administratorpaket</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL-Administratorpaket</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">Das Administratorpaket für SQL Server ist eine Sammlung gängiger Erweiterungen für die Datenbankverwaltung, die Sie beim Verwalten von SQL Server unterstützen.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Hiermit werden PowerShell-Skripts mithilfe des umfangreichen Abfrage-Editors von Azure Data Studio geschrieben und ausgeführt.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">Datenvirtualisierung</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">Hiermit werden Daten mit SQL Server 2019 virtualisiert und externe Tabellen mithilfe interaktiver Assistenten erstellt.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">Mit Azure Data Studio können Sie PostgreSQL-Datenbanken verbinden, abfragen und verwalten.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">Unterstützung für {0} ist bereits installiert.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">Nach dem Installieren zusätzlicher Unterstützung für {0} wird das Fenster neu geladen.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">Zusätzliche Unterstützung für {0} wird installiert...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">Unterstützung für {0} mit der ID {1} wurde nicht gefunden.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Neue Verbindung</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Neue Abfrage</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Neues Notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Server bereitstellen</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Willkommen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">Neu</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">Öffnen…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">Datei öffnen…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">Ordner öffnen…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">Tour starten</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">Leiste für Schnelleinführung schließen</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">Möchten Sie eine kurze Einführung in Azure Data Studio erhalten?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">Willkommen!</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">Ordner {0} mit Pfad {1} öffnen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">Installieren</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">Tastenzuordnung {0} öffnen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">Zusätzliche Unterstützung für {0} installieren</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Installiert</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">Die Tastaturzuordnung {0} ist bereits installiert.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">Unterstützung für {0} ist bereits installiert.</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Details</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">Hintergrundfarbe für die Startseite.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">Profiler-Editor für Ereignistext (schreibgeschützt)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">Fehler beim Speichern der Ergebnisse. </target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">Ergebnisdatei auswählen</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (durch Trennzeichen getrennte Datei)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Excel-Arbeitsmappe</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">Nur-Text</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">Datei wird gespeichert...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">Ergebnisse wurden erfolgreich in "{0}" gespeichert.</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Datei öffnen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">Beschriftungen ausblenden</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">Beschriftungen anzeigen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">Modellansichts-Code-Editor für Ansichtsmodell.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">Information</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Warnung</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Fehler</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Details anzeigen</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Kopieren</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Schließen</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">Zurück</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">Details ausblenden</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">Konten</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">Verknüpfte Konten</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Schließen</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">Es ist kein verknüpftes Konto vorhanden. Fügen Sie ein Konto hinzu.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">Konto hinzufügen</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">Es sind keine Clouds aktiviert. Wechseln Sie zu "Einstellungen", durchsuchen Sie die Azure-Kontokonfiguration, und aktivieren Sie mindestens eine Cloud.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">Sie haben keinen Authentifizierungsanbieter ausgewählt. Versuchen Sie es noch mal.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">Die Ausführung war aufgrund eines unerwarteten Fehlers nicht möglich: {0}	{1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">Ausführungszeit gesamt: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">Die Abfrageausführung wurde in Zeile {0} gestartet.</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">Die Ausführung von Batch "{0}" wurde gestartet.</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">Batchausführungszeit: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Fehler beim Kopieren: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Starten</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Neue Verbindung</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Neue Abfrage</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Neues Notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Datei öffnen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Datei öffnen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">Bereitstellen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">Neue Bereitstellung…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">Zuletzt verwendet</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">Mehr...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">Keine kürzlich verwendeten Ordner</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Hilfe</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">Erste Schritte</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Dokumentation</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">Problem melden oder Feature anfragen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">GitHub-Repository</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">Versionshinweise</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Beim Start Willkommensseite anzeigen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">Anpassen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Erweiterungen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">Laden Sie die von Ihnen benötigten Erweiterungen herunter, z. B. die SQL Server-Verwaltungsprogramme und mehr.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">Tastenkombinationen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">Bevorzugte Befehle finden und anpassen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">Farbdesign</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">Passen Sie das Aussehen von Editor und Code an Ihre Wünsche an.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">Informationen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">Alle Befehle suchen und ausführen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">Über die Befehlspalette ({0}) können Sie schnell auf Befehle zugreifen und nach Befehlen suchen.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">Neuerungen in der aktuellen Version erkunden</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">Monatliche Vorstellung neuer Features in Blogbeiträgen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Folgen Sie uns auf Twitter</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">Informieren Sie sich darüber, wie die Community Azure Data Studio verwendet, und kommunizieren Sie direkt mit den Technikern.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Verbinden</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Trennen</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Starten</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">Neue Sitzung</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">Anhalten</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">Fortsetzen</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Beenden</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">Daten löschen</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">Möchten Sie die Daten löschen?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">Automatisches Scrollen: Ein</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">Automatisches Scrollen: Aus</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">Ausgeblendeten Bereich umschalten</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">Spalten bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Nächste Zeichenfolge suchen</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Vorhergehende Zeichenfolge suchen</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Profiler starten</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">Filtern...</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">Filter löschen</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">Möchten Sie die Filter löschen?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">Ereignisse (gefiltert): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">Ereignisse: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">Ereignisanzahl</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">Keine Daten verfügbar.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">Ergebnisse</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">Meldungen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">Beim Aufruf des ausgewählten Skripts für das Objekt wurde kein Skript zurückgegeben. </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">Auswählen</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">Erstellen</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">Einfügen</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">Aktualisieren</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Löschen</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">Bei der Skripterstellung als "{0}" für Objekt "{1}" wurde kein Skript zurückgegeben.</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">Fehler bei Skripterstellung.</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">Bei der Skripterstellung als "{0}" wurde kein Skript zurückgegeben.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">Hintergrundfarbe für Tabellenüberschrift</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">Vordergrundfarbe für Tabellenüberschrift</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">Hintergrundfarbe von Listen/Tabellen für das ausgewählte und fokussierte Element, wenn die Liste/Tabelle aktiv ist</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">Farbe der Kontur einer Zelle.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">Hintergrund für deaktiviertes Eingabefeld.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">Vordergrund für deaktiviertes Eingabefeld.</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">Konturfarbe der Schaltfläche, wenn diese den Fokus hat.</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">Vordergrundfarbe für deaktiviertes Kontrollkästchen.</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">Hintergrundfarbe für die SQL-Agent-Tabelle.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">Hintergrundfarbe für die SQL-Agent-Tabellenzellen.</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">Hintergrundfarbe für die SQL-Agent-Tabelle, wenn darauf gezeigt wird.</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">Hintergrundfarbe für SQL-Agent-Überschriften.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">Rahmenfarbe für SQL-Agent-Tabellenzellen.</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">Farbe für Fehler bei Ergebnismeldungen.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">Backup-Name</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">Wiederherstellungsmodell</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">Sicherungstyp</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">Sicherungsdateien</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">Algorithmus</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">Zertifikat oder asymmetrischer Schlüssel</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">Medien</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">Sicherung im vorhandenen Mediensatz</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">Sicherung in einem neuen Mediensatz</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">An vorhandenem Sicherungssatz anhängen</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">Alle vorhandenen Sicherungssätze überschreiben</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">Name des neuen Mediensatzes</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">Beschreibung des neuen Mediensatzes</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">Vor dem Schreiben auf Medium Prüfsumme berechnen</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">Sicherung nach Abschluss überprüfen</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">Bei Fehler fortsetzen</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">Ablauf</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">Aufbewahrungsdauer der Sicherung in Tagen festlegen</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">Kopiesicherung</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">Erweiterte Konfiguration</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">Komprimierung</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">Sicherungskomprimierung festlegen</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">Verschlüsselung</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">Transaktionsprotokoll</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">Transaktionsprotokoll abschneiden</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">Sicherung des Protokollfragments</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">Zuverlässigkeit</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">Der Name des Mediums muss angegeben werden.</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">Es ist kein Zertifikat oder asymmetrischer Schlüssel verfügbar.</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">Datei hinzufügen</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">Dateien entfernen</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">Ungültige Eingabe. Wert muss größer oder gleich 0 sein.</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Skript</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Sicherung</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">Es wird nur das Sichern in einer Datei unterstützt.</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">Der Pfad für die Sicherungsdatei muss angegeben werden.</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">Das Speichern von Ergebnissen in einem anderen Format ist für diesen Datenanbieter deaktiviert.</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">Daten können nicht serialisiert werden, weil kein Anbieter registriert wurde.</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">Unbekannter Fehler bei der Serialisierung.</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">Es ist kein Datenanbieter registriert, der Sichtdaten bereitstellen kann.</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">Hintergrundfarbe für Tabellenüberschrift</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aktualisieren</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">Vordergrundfarbe für Tabellenüberschrift</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Alle reduzieren</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">Hintergrundfarbe von Listen/Tabellen für das ausgewählte und fokussierte Element, wenn die Liste/Tabelle aktiv ist</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">Fehler beim Ausführen des Befehls {1}: {0}. Dies wird vermutlich durch die Erweiterung verursacht, die {1} beiträgt.</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">Farbe der Kontur einer Zelle.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">Hintergrund für deaktiviertes Eingabefeld.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">Vordergrund für deaktiviertes Eingabefeld.</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">Konturfarbe der Schaltfläche, wenn diese den Fokus hat.</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">Vordergrundfarbe für deaktiviertes Kontrollkästchen.</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">Hintergrundfarbe für die SQL-Agent-Tabelle.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">Hintergrundfarbe für die SQL-Agent-Tabellenzellen.</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">Hintergrundfarbe für die SQL-Agent-Tabelle, wenn darauf gezeigt wird.</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">Hintergrundfarbe für SQL-Agent-Überschriften.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">Rahmenfarbe für SQL-Agent-Tabellenzellen.</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">Farbe für Fehler bei Ergebnismeldungen.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">Wählen Sie eine aktive Zelle aus, und versuchen Sie es noch mal.</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">Einige der geladenen Erweiterungen verwenden veraltete APIs. Ausführliche Informationen finden Sie auf der Registerkarte "Konsole" des Fensters "Entwicklertools".</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">Zelle ausführen</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">Ausführung abbrechen</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">Fehler bei der letzten Ausführung. Klicken Sie, um den Vorgang zu wiederholen.</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Nicht mehr anzeigen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">Die Aufgabe konnte nicht abgebrochen werden.</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Skript</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">Weitere ein-/ausblenden</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Wird geladen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">Start</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">Der Abschnitt "{0}" umfasst ungültige Inhalte. Kontaktieren Sie den Besitzer der Erweiterung.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">Aufträge</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Warnungen</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">Proxys</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">Operatoren</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">Servereigenschaften</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">Datenbankeigenschaften</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">Alles auswählen/Gesamte Auswahl aufheben</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">Filter anzeigen</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">Löschen</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Letzte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">Sicherungsdateien</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">Alle Dateien</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">Suche: Geben Sie den Suchbegriff ein, und drücken Sie die EINGABETASTE, um zu suchen, oder ESC, um den Vorgang abzubrechen.</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Suchen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Fehler beim Ändern der Datenbank.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">Letztes Vorkommen</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Aktiviert</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">Verzögerung zwischen Antworten (in Sek.)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">Kategoriename</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">E-Mail-Adresse</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Aktiviert</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">Kontoname</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">Name der Anmeldeinformationen</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Beschreibung</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Aktiviert</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">Objekte werden geladen.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">Datenbanken werden geladen.</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">Objekte wurden vollständig geladen.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">Datenbanken wurden vollständig geladen.</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">Suche nach Namen des Typs (t:, v:, f: oder sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">Datenbanken suchen</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">Objekte können nicht geladen werden.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">Datenbanken können nicht geladen werden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">Eigenschaften werden geladen.</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">Eigenschaften wurden vollständig geladen.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">Die Dashboardeigenschaften können nicht geladen werden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">"{0}" wird geladen.</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">"{0}" vollständig geladen.</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">Automatische Aktualisierung: AUS</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">Letzte Aktualisierung: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">Keine Ergebnisse zur Anzeige vorhanden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Schritte</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Als CSV speichern</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Als JSON speichern</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Als Excel speichern</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Als XML speichern</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">Die Ergebniscodierung wird beim Exportieren in JSON nicht gespeichert. Nachdem die Datei erstellt wurde, speichern Sie sie mit der gewünschten Codierung.</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">Das Speichern in einer Datei wird von der zugrunde liegenden Datenquelle nicht unterstützt.</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Kopieren</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Mit Headern kopieren</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Alle auswählen</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">Maximieren</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Wiederherstellen</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Diagramm</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">Schnellansicht</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">Zur Verwendung der F5-Tastenkombination muss eine Codezelle ausgewählt sein. Wählen Sie eine Codezelle für die Ausführung aus.</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">Zum Löschen des Ergebnisses muss eine Zelle ausgewählt sein. Wählen Sie eine Codezelle für die Ausführung aus.</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">Schritt-ID</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Fertig</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">Schrittname</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">Meldung</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Skript generieren</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Weiter</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">Zurück</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">Registerkarten sind nicht initialisiert.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Suchen</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">Es wurde keine Strukturansicht mit der ID "{0}" registriert.</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Suchen</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">An diese Klasse muss ein NotebookProvider mit gültiger providerId übergeben werden.</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Vorherige Übereinstimmung</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">Kein Notebook-Anbieter gefunden.</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Nächste Übereinstimmung</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">Kein Manager gefunden.</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">Der Notebook-Manager für das Notebook "{0}" umfasst keinen Server-Manager. Es können keine Aktionen ausgeführt werden.</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">Der Notebook-Manager für das Notebook "{0}" umfasst keinen Inhalts-Manager. Es können keine Aktionen ausgeführt werden.</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">Der Notebook-Manager für das Notebook "{0}" umfasst keinen Sitzungs-Manager. Es können keine Aktionen ausgeführt werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">An diese Klasse muss ein NotebookProvider mit gültiger providerId übergeben werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Verwalten</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Details anzeigen</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">Weitere Informationen</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">Alle gespeicherten Konten löschen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">Vorschaufeatures</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">Nicht veröffentlichte Vorschaufeatures aktivieren</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">Beim Start Verbindungsdialogfeld anzeigen</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">Benachrichtigung zu veralteter API</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">Benachrichtigung bei Verwendung veralteter APIs aktivieren/deaktivieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">Fehler beim Verbinden der Datenbearbeitungssitzung.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">Nicht verbunden</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">Die XEvent Profiler-Sitzung wurde auf dem Server "{0}" unerwartet beendet.</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">Fehler beim Starten der neuen Sitzung.</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">Die XEvent Profiler-Sitzung für "{0}" hat Ereignisse verloren.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Aktionen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Ressourcen-Viewer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">Information</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Warnung</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Fehler</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Details anzeigen</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Kopieren</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">Schließen</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">Für Ihre Suche wurden sehr viele Ergebnisse zurückgegeben. Es werden nur die ersten 999 Übereinstimmungen hervorgehoben.</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">Zurück</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} von {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Keine Ergebnisse</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">Details ausblenden</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">Horizontale Leiste</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">Balken</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">Linie</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">Kreis</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">Punkt</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">Zeitreihe</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Bild</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">Anzahl</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">Table</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">Ring</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">Fehler beim Einfügen von Zeilen für das Dataset in das Diagramm.</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">Der Diagrammtyp "{0}" wird nicht unterstützt.</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">Parameter</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated"> ist erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">Ungültige Eingabe. Es wird ein numerischer Wert erwartet.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">Verbunden mit</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">Der Index "{0}" ist ungültig.</target>
       </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">Leer</target>
+      </trans-unit>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">Alle Kontrollkästchen in folgender Spalte aktivieren: {0}</target>
+      </trans-unit>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Aktionen anzeigen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Wird geladen</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Ladevorgang abgeschlossen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">Ungültiger Wert.</target>
+      </trans-unit>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}. {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Wird geladen</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Ladevorgang abgeschlossen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">Modellansichts-Code-Editor für Ansichtsmodell.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">Die Komponente für den Typ "{0}" wurde nicht gefunden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">Das Ändern von Editor-Typen für nicht gespeicherte Dateien wird nicht unterstützt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Oberste 1000 auswählen</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">10 zurückgeben</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Skripterstellung als EXECUTE</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Skripterstellung als ALTER</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Daten bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Skripterstellung als CREATE</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Skripterstellung als DROP</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">Beim Aufruf des ausgewählten Skripts für das Objekt wurde kein Skript zurückgegeben. </target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">Auswählen</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">Erstellen</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">Einfügen</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Löschen</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">Bei der Skripterstellung als "{0}" für Objekt "{1}" wurde kein Skript zurückgegeben.</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">Fehler bei Skripterstellung.</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">Bei der Skripterstellung als "{0}" wurde kein Skript zurückgegeben.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
         <target state="translated">Getrennt</target>
       </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">Nicht gespeicherte Verbindungen</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
+        <target state="translated">Erweiterung</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">Durchsuchen (Vorschau)</target>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">Hintergrundfarbe für aktive Registerkarten für vertikale Tabstopps</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">Geben Sie hier Text ein, um die Liste zu filtern</target>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">Farbe für Rahmen im Dashboard</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">Verbindungen filtern</target>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">Farbe des Titels des Dashboardgadgets</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">Filter wird angewendet.</target>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">Farbe für Dashboard-Widget-Subtext</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">Filter wird entfernt.</target>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">Farbe für Eigenschaftswerte, die in der Eigenschaftencontainerkomponente angezeigt werden</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">Filter angewendet</target>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">Farbe für Eigenschaftennamen, die in der Eigenschaftencontainerkomponente angezeigt werden</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">Filter entfernt</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Gespeicherte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Gespeicherte Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">Struktur des Verbindungsbrowsers</target>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">Schattenfarbe für Symbolleistenüberlauf</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Diese Erweiterung wird von Azure Data Studio empfohlen.</target>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">Bezeichner des Kontotyps</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(Optional) Symbol zur Darstellung des Kontos in der Benutzeroberfläche. Es handelt sich entweder um einen Dateipfad oder um eine designfähige Konfiguration.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Symbolpfad, wenn ein helles Design verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Symbolpfad, wenn ein dunkles Design verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">Stellt Symbole für den Kontoanbieter zur Verfügung.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Nicht mehr anzeigen</target>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">Anwendbare Regeln anzeigen</target>
       </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio enthält Erweiterungsempfehlungen.</target>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">Anwendbare Regeln für "{0}" anzeigen</target>
       </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio enthält Erweiterungsempfehlungen für die Datenvisualisierung.
-Nach der Installation können Sie das Schnellansichtssymbol auswählen, um Ihre Abfrageergebnisse zu visualisieren.</target>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">Bewertung aufrufen</target>
       </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">Alle installieren</target>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">Bewertung für "{0}" aufrufen</target>
       </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Empfehlungen anzeigen</target>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">Als Skript exportieren</target>
       </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">Der Szenariotyp für Erweiterungsempfehlungen muss angegeben werden.</target>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">Alle Regeln anzeigen und weitere Informationen auf GitHub erhalten</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">Diese Featureseite befindet sich in der Vorschauphase. Durch die Vorschaufeatures werden neue Funktionen eingeführt, die demnächst als dauerhafter Bestandteil in das Produkt integriert werden. Sie sind stabil, erfordern jedoch zusätzliche Verbesserungen im Hinblick auf die Barrierefreiheit. Wir freuen uns über Ihr frühes Feedback, solange die Features noch entwickelt werden.</target>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">HTML-Bericht erstellen</target>
       </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">Vorschau</target>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">Der Bericht wurde gespeichert. Möchten Sie ihn öffnen?</target>
       </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">Verbindung erstellen</target>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Öffnen</target>
       </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">Stellen Sie über das Verbindungsdialogfeld eine Verbindung mit einer Datenbankinstanz her.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">Abfrage ausführen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">Interagieren Sie mit Daten über einen Abfrage-Editor.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">Notebook erstellen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">Erstellen Sie ein neues Notebook mithilfe eines nativen Notebook-Editors.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Server bereitstellen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">Erstellen Sie eine neue Instanz eines relationalen Datendiensts auf der Plattform Ihrer Wahl.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">Ressourcen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">Verlauf</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">Standort</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">Mehr anzeigen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Beim Start Willkommensseite anzeigen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">Nützliche Links</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">Erste Schritte</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Lernen Sie die von Azure Data Studio bereitgestellten Funktionen kennen, und erfahren Sie, wie Sie diese optimal nutzen können.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Dokumentation</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">Im Dokumentationscenter finden Sie Schnellstarts, Anleitungen und Referenzdokumentation zu PowerShell, APIs usw.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Übersicht über Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Einführung in Azure Data Studio-Notebooks | Verfügbare Daten</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Erweiterungen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">Alle anzeigen</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">Weitere Informationen </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">Erstellungsdatum: </target>
-      </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Notebook-Fehler: </target>
-      </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">Auftragsfehler: </target>
-      </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">Angeheftet</target>
-      </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">Aktuelle Ausführungen</target>
-      </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">Vergangene Ausführungen</target>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Nach der Installation können Sie das Schnellansichtssymbol auswählen, um Ihre 
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">Die Datenbank "{0}" entspricht vollständig den empfohlenen Methoden. Gut gemacht!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Diagramm</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">Vorgang</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">Objekt</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">Geschätzte Kosten</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">Geschätzte Kosten für Unterstruktur</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">Tatsächliche Zeilen</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">Geschätzte Zeilen</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">Tatsächliche Ausführungen</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">Geschätzte CPU-Kosten</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">Geschätzte E/A-Kosten</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">Parallel</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">Tatsächliche erneute Bindungen</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">Geschätzte erneute Bindungen</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">Tatsächliche Rückläufe</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">Geschätzte Rückläufe</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">Partitioniert</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">Wichtigste Vorgänge</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">Keine Verbindungen gefunden.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">Verbindung hinzufügen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">Konto hinzufügen...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Standard&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Wird geladen...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">Servergruppe</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Standard&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">Neue Gruppe hinzufügen...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;Nicht speichern&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">"{0}" ist erforderlich.</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">"{0}" wird gekürzt.</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">Kennwort speichern</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">Konto</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">Kontoanmeldeinformationen aktualisieren</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Azure AD-Mandant</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">Name (optional)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">Erweitert...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">Sie müssen ein Konto auswählen.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Datenbank</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">Dateien und Dateigruppen</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">Vollständig</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">Differenziell</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">Transaktionsprotokoll</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">Datenträger</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">Standardservereinstellung verwenden</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">Sicherung komprimieren</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">Sicherung nicht komprimieren</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">Serverzertifikat</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">Asymmetrischer Schlüssel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">Sie haben keinen Ordner geöffnet, der Notebooks/Bücher enthält. </target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">Notebooks öffnen</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">Das Resultset enthält nur eine Teilmenge aller Übereinstimmungen. Verfeinern Sie Ihre Suche, um die Ergebnisse einzugrenzen.</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">Suche wird durchgeführt... – </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">Keine Ergebnisse in "{0}" unter Ausschluss von "{1}" gefunden – </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">Keine Ergebnisse in "{0}" gefunden – </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">Keine Ergebnisse gefunden, die "{0}" ausschließen – </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">Es wurden keine Ergebnisse gefunden. Überprüfen Sie die Einstellungen für konfigurierte Ausschlüsse, und überprüfen Sie Ihre gitignore-Dateien - </target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">Erneut suchen</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Suche abbrechen</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">Erneut in allen Dateien suchen</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">Einstellungen öffnen</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">Die Suche hat {0} Ergebnisse in {1} Dateien zurückgegeben.</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">Zu- und Aufklappen umschalten</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Suche abbrechen</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">Alle erweitern</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Alle reduzieren</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">Suchergebnisse löschen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Verbindungen</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">Über SQL Server, Azure und weitere Plattformen können Sie Verbindungen herstellen, abfragen und verwalten.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Weiter</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">Beginnen Sie an einer zentralen Stelle mit der Erstellung Ihres eigenen Notebooks oder einer Sammlung von Notebooks.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Erweiterungen</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Erweitern Sie die Funktionalität von Azure Data Studio durch die Installation von Erweiterungen, die von uns/Microsoft und von der Drittanbietercommunity (von Ihnen!) entwickelt wurden.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Einstellungen</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">Passen Sie Azure Data Studio basierend auf Ihren Einstellungen an. Sie können Einstellungen wie automatisches Speichern und Registerkartengröße konfigurieren, Ihre Tastenkombinationen personalisieren und zu einem Farbdesign Ihrer Wahl wechseln.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">Willkommensseite</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">Entdecken Sie wichtige Features, zuletzt geöffneten Dateien und empfohlene Erweiterungen auf der Willkommensseite. Weitere Informationen zum Einstieg in Azure Data Studio finden Sie in den Videos und in der Dokumentation.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">Fertig stellen</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">Einführungstour für Benutzer</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">Einführungstour ausblenden</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">Weitere Informationen</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Hilfe</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">Zeile löschen</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">Aktuelle Zeile zurücksetzen</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Nach der Installation können Sie das Schnellansichtssymbol auswählen, um Ihre 
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">Meldungspanel</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Kopieren</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">Alle kopieren</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">In Azure-Portal öffnen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Wird geladen</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">Backup-Name</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Ladevorgang abgeschlossen</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">Wiederherstellungsmodell</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">Sicherungstyp</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">Sicherungsdateien</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">Algorithmus</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">Zertifikat oder asymmetrischer Schlüssel</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">Medien</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">Sicherung im vorhandenen Mediensatz</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">Sicherung in einem neuen Mediensatz</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">An vorhandenem Sicherungssatz anhängen</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">Alle vorhandenen Sicherungssätze überschreiben</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">Name des neuen Mediensatzes</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">Beschreibung des neuen Mediensatzes</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">Vor dem Schreiben auf Medium Prüfsumme berechnen</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">Sicherung nach Abschluss überprüfen</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">Bei Fehler fortsetzen</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">Ablauf</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">Aufbewahrungsdauer der Sicherung in Tagen festlegen</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">Kopiesicherung</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">Erweiterte Konfiguration</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">Komprimierung</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">Sicherungskomprimierung festlegen</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">Verschlüsselung</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">Transaktionsprotokoll</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">Transaktionsprotokoll abschneiden</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">Sicherung des Protokollfragments</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">Zuverlässigkeit</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">Der Name des Mediums muss angegeben werden.</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">Es ist kein Zertifikat oder asymmetrischer Schlüssel verfügbar.</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">Datei hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">Dateien entfernen</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">Ungültige Eingabe. Wert muss größer oder gleich 0 sein.</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Skript</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Sicherung</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">Es wird nur das Sichern in einer Datei unterstützt.</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">Der Pfad für die Sicherungsdatei muss angegeben werden.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">Klicken Sie auf</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ Code</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">oder</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ Text</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">zum Hinzufügen einer Code- oder Textzelle</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Sicherung</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">StdIn:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">Sie müssen die Vorschaufeatures aktivieren, um die Sicherung verwenden zu können.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">Der Sicherungsbefehl wird außerhalb eines Datenbankkontexts nicht unterstützt. Wählen Sie eine Datenbank aus, und versuchen Sie es noch mal.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">Der Sicherungsbefehl wird für Azure SQL-Datenbank-Instanzen nicht unterstützt.</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Sicherung</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">Codezelleninhalt erweitern</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Datenbank</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">Codezelleninhalt reduzieren</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">Dateien und Dateigruppen</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">Vollständig</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">Differenziell</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">Transaktionsprotokoll</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">Datenträger</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">Standardservereinstellung verwenden</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">Sicherung komprimieren</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">Sicherung nicht komprimieren</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">Serverzertifikat</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">Asymmetrischer Schlüssel</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">XML-Showplan</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">Ergebnisraster</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Zelle hinzufügen</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Codezelle</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Textzelle</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">Zelle nach unten verschieben</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">Zelle nach oben verschieben</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Löschen</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Zelle hinzufügen</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Codezelle</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Textzelle</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">SQL-Kernelfehler</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">Sie müssen eine Verbindung auswählen, um Notebook-Zellen auszuführen.</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">Die ersten {0} Zeilen werden angezeigt.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Letzte Ausführung</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Nächste Ausführung</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Aktiviert</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Status</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Kategorie</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">Ausführbar</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">Zeitplan</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Ergebnis der letzten Ausführung</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Vorherigen Ausführungen</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Für diesen Auftrag sind keine Schritte verfügbar.</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Fehler: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">Die Komponente für den Typ "{0}" wurde nicht gefunden.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Suchen</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Suchen</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Vorherige Übereinstimmung</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Nächste Übereinstimmung</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Schließen</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">Für Ihre Suche wurden sehr viele Ergebnisse zurückgegeben. Es werden nur die ersten 999 Übereinstimmungen hervorgehoben.</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} von {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Keine Ergebnisse</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">Schema</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Typ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Abfrage ausführen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Für die Ausgabe wurde kein {0}-Renderer gefunden. Folgende MIME-Typen sind enthalten: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">Sicher </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">Für Selektor "{0}" wurde keine Komponente gefunden.</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">Fehler beim Rendern der Komponente: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Wird geladen...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Wird geladen...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">Beenden</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aktualisieren</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Aktionen anzeigen</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">Widget löschen</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">Zum Lösen klicken</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">Zum Anheften klicken</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">Installierte Features öffnen</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">Widget reduzieren</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">Widget erweitern</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">"{0}" ist ein unbekannter Container.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Name</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Zieldatenbank</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Letzte Ausführung</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Nächste Ausführung</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Status</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Ergebnis der letzten Ausführung</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Vorherigen Ausführungen</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Für diesen Auftrag sind keine Schritte verfügbar.</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Fehler: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Notebook-Fehler: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">Fehler wird geladen...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Aktionen anzeigen</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">Kein übereinstimmendes Element gefunden</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">Die Suchliste wurde auf 1 Element gefiltert.</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">Die Suchliste wurde auf {0} Elemente gefiltert.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">Fehlerhaft</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">Erfolgreich</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">Wiederholen</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">Abgebrochen</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">In Bearbeitung</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">Status unbekannt</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">Wird ausgeführt</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">Warten auf Thread</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">Zwischen Wiederholungen</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">Im Leerlauf</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">Angehalten</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[Veraltet]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Ja</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Nein</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">Nicht geplant</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">Nie ausführen</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">Fett</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">Kursiv</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">Unterstrichen</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">Hervorheben</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Code</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">Link</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">Liste</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">Sortierte Liste</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Bild</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Markdownvorschau umschalten – aus</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">Überschrift</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">Überschrift 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">Überschrift 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">Überschrift 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">Absatz</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">Link einfügen</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">Bild einfügen</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">Rich-Text-Ansicht</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">Geteilte Ansicht</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Markdownansicht</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">Erkenntnisse generieren</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">Es können keine Erkenntnisse generiert werden, weil der aktive Editor kein SQL-Editor ist.</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">My-Widget</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">Diagramm konfigurieren</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">Als Bild kopieren</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">Das zu speichernde Diagramm wurde nicht gefunden.</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">Als Bild speichern</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">Diagramm in Pfad gespeichert: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Nach der Installation können Sie das Schnellansichtssymbol auswählen, um Ihre 
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Diagramm</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">Horizontale Leiste</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">Balken</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">Linie</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">Kreis</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">Punkt</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">Zeitreihe</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Bild</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">Anzahl</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">Table</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">Ring</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">Fehler beim Einfügen von Zeilen für das Dataset in das Diagramm.</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">Der Diagrammtyp "{0}" wird nicht unterstützt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Integrierte Diagramme</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">Die maximale Anzahl von Zeilen, die in Diagrammen angezeigt werden sollen. Warnung: Durch Erhöhen dieses Werts kann die Leistung beeinträchtigt werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">Schließen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">Es ist bereits eine Servergruppe mit diesem Namen vorhanden.</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">Reihe "{0}"</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">Die Tabelle enthält kein gültiges Bild.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">Die maximale Zeilenanzahl für integrierte Diagramme wurde überschritten, nur die ersten {0} Zeilen werden verwendet. Um den Wert zu konfigurieren, öffnen Sie die Benutzereinstellungen, und suchen Sie nach "builtinCharts.maxRowCount".</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Nicht mehr anzeigen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">Verbindung wird hergestellt: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">Befehl wird ausgeführt: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">Neue Abfrage wird geöffnet: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">Keine Verbindung möglich, weil keine Serverinformationen bereitgestellt wurden.</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">Die URL konnte aufgrund eines Fehlers nicht geöffnet werden: {0}</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">Hiermit wird eine Verbindung mit dem Server "{0}" hergestellt.</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">Möchten Sie die Verbindung herstellen?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">&amp;&amp;Öffnen</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">Abfragedatei wird verbunden</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">"{0}" wurde in Ihren Benutzereinstellungen durch "{1}" ersetzt.</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">"{0}" wurde in Ihren Arbeitsbereichseinstellungen durch "{1}" ersetzt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">Die maximale Anzahl der zuletzt verwendeten Verbindungen in der Verbindungsliste.</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">Die zu verwendende Standard-SQL-Engine. Diese Einstellung legt den Standardsprachanbieter in SQL-Dateien und die Standardeinstellungen für neue Verbindungen fest.</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">Hiermit wird versucht, die Inhalte der Zwischenablage zu analysieren, wenn das Verbindungsdialogfeld geöffnet ist oder ein Element eingefügt wird.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">Verbindungsstatus</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">Allgemeine ID für den Anbieter</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">Anzeigename für den Anbieter</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">Notebook-Kernelalias für den Anbieter</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">Symbolpfad für den Servertyp</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">Verbindungsoptionen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">Sichtbarer Benutzername für den Strukturanbieter</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">Die ID für den Anbieter muss mit der ID übereinstimmen, die zur Registrierung des Strukturdatenanbieters verwendet wurde, und mit "connectionDialog/" beginnen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">Eindeutiger Bezeichner für diesen Container.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">Der Container, der auf der Registerkarte angezeigt wird.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">Stellt einen einzelnen oder mehrere Dashboardcontainer zur Verfügung, die Benutzer zu ihrem Dashboard hinzufügen können.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">Im Dashboardcontainer für die Erweiterung wurde keine ID angegeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">Für die Erweiterung wurde kein Container im Dashboardcontainer angegeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Es muss genau 1 Dashboardcontainer pro Bereich definiert sein.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">Im Dashboardcontainer für die Erweiterung wurde ein unbekannter Containertyp definiert.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">Der Steuerelementhost, der auf dieser Registerkarte angezeigt wird.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">Der Abschnitt "{0}" umfasst ungültige Inhalte. Kontaktieren Sie den Besitzer der Erweiterung.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">Die Liste der Widgets oder Webansichten, die auf dieser Registerkarte angezeigt werden.</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">Widgets oder Webansichten werden im Widgetcontainer für die Erweiterung erwartet.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">Die modellgestützte Ansicht, die auf dieser Registerkarte angezeigt wird.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">Eindeutiger Bezeichner für diesen Navigationsbereich. Wird bei allen Anforderungen an die Erweiterung übergeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Optional) Symbol zur Darstellung dieses Navigationsbereichs in der Benutzeroberfläche. Erfordert einen Dateipfad oder eine Konfiguration, der ein Design zugeordnet werden kann.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Symbolpfad, wenn ein helles Design verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Symbolpfad, wenn ein dunkles Design verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">Der Titel des Navigationsbereichs, der dem Benutzer angezeigt werden soll.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">Der Container, der in diesem Navigationsbereich angezeigt wird.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">Die Liste der Dashboardcontainer, die in diesem Navigationsabschnitt angezeigt wird.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">Für die Erweiterung wurde kein Titel im Navigationsbereich angegeben.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">Für die Anwendung wurde kein Container im Navigationsbereich angegeben.</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Es muss genau 1 Dashboardcontainer pro Bereich definiert sein.</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION in NAV_SECTION ist ein ungültiger Container für die Erweiterung.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">Die Webansicht, die auf dieser Registerkarte angezeigt wird.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">Die Liste der Widgets, die auf dieser Registerkarte angezeigt werden.</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">Die Liste der Widgets, die im Widgetcontainer für die Erweiterung erwartet werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">Beenden</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Aktionen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">Widget löschen</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">Zum Lösen klicken</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">Zum Anheften klicken</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">Installierte Features öffnen</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">Widget reduzieren</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">Widget erweitern</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">"{0}" ist ein unbekannter Container.</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Nach der Installation können Sie das Schnellansichtssymbol auswählen, um Ihre 
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">Erkenntnisse generieren</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Eindeutiger Bezeichner für diese Registerkarte. Wird bei allen Anforderungen an die Erweiterung übergeben.</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">Es können keine Erkenntnisse generiert werden, weil der aktive Editor kein SQL-Editor ist.</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">Titel der Registerkarte, die dem Benutzer angezeigt wird.</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">My-Widget</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">Beschreibung dieser Registerkarte, die dem Benutzer angezeigt werden.</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">Diagramm konfigurieren</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Eine Bedingung, die TRUE lauten muss, damit dieses Element angezeigt wird.</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">Als Bild kopieren</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">Definiert die Verbindungstypen, mit denen diese Registerkarte kompatibel ist. Der Standardwert lautet "MSSQL", wenn kein anderer Wert festgelegt wird.</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">Das zu speichernde Diagramm wurde nicht gefunden.</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">Der Container, der auf dieser Registerkarte angezeigt wird.</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">Als Bild speichern</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">Legt fest, ob diese Registerkarte immer angezeigt werden soll oder nur dann, wenn der Benutzer sie hinzufügt.</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">Legt fest, ob diese Registerkarte als Startseite für einen Verbindungstyp verwendet werden soll.</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">Diagramm in Pfad gespeichert: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">Der eindeutige Bezeichner der Gruppe, zu der diese Registerkarte gehört. Wert für Startgruppe: Start.</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Optional) Symbol zur Darstellung dieser Registerkarte in der Benutzeroberfläche. Erfordert einen Dateipfad oder eine Konfiguration, der ein Design zugeordnet werden kann.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Symbolpfad, wenn ein helles Design verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Symbolpfad, wenn ein dunkles Design verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">Stellt eine einzelne oder mehrere Registerkarten zur Verfügung, die Benutzer zu ihrem Dashboard hinzufügen können.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">Für die Erweiterung wurde kein Titel angegeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">Es wurde keine Beschreibung zur Anzeige angegeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">Für die Erweiterung wurde kein Container angegeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">Pro Bereich muss genau 1 Dashboardcontainer definiert werden.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">Eindeutiger Bezeichner für diese Registerkartengruppe.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">Titel der Registerkartengruppe.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">Stellt eine einzelne oder mehrere Registerkartengruppen zur Verfügung, die Benutzer ihrem Dashboard hinzufügen können.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">Für die Registerkartengruppe wurde keine ID angegeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">Für die Registerkartengruppe wurde kein Titel angegeben.</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">Verwaltung</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">Überwachung</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">Leistung</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">Sicherheit</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">Problembehandlung</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">Registerkarte "Datenbanken"</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">Datenbanken</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">Code hinzufügen</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Verwalten</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">Text hinzufügen</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Dashboard</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">Datei erstellen</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Verwalten</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">Inhalt konnte nicht angezeigt werden: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">Die Eigenschaft "icon" kann ausgelassen werden oder muss eine Zeichenfolge oder ein Literal wie "{dark, light}" sein.</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Zelle hinzufügen</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">Definiert eine Eigenschaft, die im Dashboard angezeigt werden soll</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Codezelle</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">Gibt an, welcher Wert soll als Beschriftung für die Eigenschaft verwendet werden soll.</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Textzelle</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">Gibt an, auf welchen Wert im Objekt zugegriffen werden soll, um den Wert zu ermitteln.</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">Alle ausführen</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">Geben Sie Werte an, die ignoriert werden sollen.</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">Zelle</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">Standardwert, der angezeigt werden soll, wenn der Wert ignoriert wird oder kein Wert angegeben ist</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Code</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">Eine Variante für das Definieren von Dashboardeigenschaften</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Text</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">ID der Variante</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">Zellen ausführen</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">Bedingung für die Verwendung dieser Variante</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; Zurück</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">Feld für Vergleich</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">Weiter &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">Hiermit wird angegeben, welcher Operator für den Vergleich verwendet werden soll.</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">Die Zelle mit dem URI "{0}" wurde in diesem Modell nicht gefunden.</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">Wert, mit dem das Feld verglichen werden soll</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">Fehler beim Ausführen von Zellen: Weitere Informationen finden Sie im Fehler in der Ausgabe der aktuell ausgewählten Zelle.</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">Eigenschaften, die für die Datenbankseite angezeigt werden sollen</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">Eigenschaften, die für die Serverseite angezeigt werden sollen</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">Hiermit wird definiert, dass dieser Anbieter das Dashboard unterstützt.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">Anbieter-ID (z. B. MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">Eigenschaftswerte, die im Dashboard angezeigt werden sollen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Eine Bedingung, die TRUE lauten muss, damit dieses Element angezeigt wird.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">Gibt an, ob die Kopfzeile des Widgets ausgeblendet werden soll. Standardwert: FALSE.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">Der Titel des Containers</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">Die Zeile der Komponente im Raster</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">Die RowSpan-Eigenschaft der Komponente im Raster. Der Standardwert ist 1. Verwenden Sie "*", um die Anzahl von Zeilen im Raster festzulegen.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">Die Spalte der Komponente im Raster</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">Der ColSpan-Wert der Komponente im Raster. Der Standardwert ist 1. Verwenden Sie "*", um die Anzahl von Spalten im Raster festzulegen.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Eindeutiger Bezeichner für diese Registerkarte. Wird bei allen Anforderungen an die Erweiterung übergeben.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">Die Registerkarte "Erweiterung" ist unbekannt oder nicht installiert.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">Datenbankeigenschaften</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Eigenschaftswidget aktivieren oder deaktivieren</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Anzuzeigende Eigenschaftswerte</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Anzeigename der Eigenschaft</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">Wert im Objekt mit Datenbankinformationen</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">Spezifische zu ignorierende Werte angeben</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">Wiederherstellungsmodell</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">Letzte Datenbanksicherung</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">Letzte Protokollsicherung</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">Kompatibilitätsgrad</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Besitzer</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">Hiermit wird die Dashboardseite für die Datenbank angepasst.</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Suchen</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">Hiermit werden die Dashboardregisterkarten für die Datenbank angepasst.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">Servereigenschaften</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Eigenschaftswidget aktivieren oder deaktivieren</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Anzuzeigende Eigenschaftswerte</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Anzeigename der Eigenschaft</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">Wert im Objekt mit Serverinformationen</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Version</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">Edition</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">Computername</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">Betriebssystemversion</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Suchen</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">Hiermit wird die Dashboardseite des Servers angepasst.</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">Hiermit werden die Dashboardregisterkarten des Servers angepasst.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">Start</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Fehler beim Ändern der Datenbank.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Aktionen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">Kein übereinstimmendes Element gefunden</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">Die Suchliste wurde auf 1 Element gefiltert.</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">Die Suchliste wurde auf {0} Elemente gefiltert.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">Schema</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Typ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">Objekte werden geladen.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">Datenbanken werden geladen.</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">Objekte wurden vollständig geladen.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">Datenbanken wurden vollständig geladen.</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">Suche nach Namen des Typs (t:, v:, f: oder sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">Datenbanken suchen</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">Objekte können nicht geladen werden.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">Datenbanken können nicht geladen werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Abfrage ausführen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">"{0}" wird geladen.</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">"{0}" vollständig geladen.</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">Automatische Aktualisierung: AUS</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">Letzte Aktualisierung: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">Keine Ergebnisse zur Anzeige vorhanden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">Fügt ein Widget hinzu, das einen Server oder eine Datenbank abfragen und die Ergebnisse in unterschiedlicher Form anzeigen kann – als Diagramm, summierte Anzahl und mehr.</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">Eindeutiger Bezeichner, der zum Zwischenspeichern der Erkenntnisergebnisse verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">Auszuführende SQL-Abfrage. Es sollte genau 1 Resultset zurückgegeben werden.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[Optional] Pfad zu einer Datei, die eine Abfrage enthält. Verwenden Sie diese Einstellung, wenn "query" nicht festgelegt ist.</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[Optional] Intervall für die automatische Aktualisierung in Minuten. Ist kein Wert festgelegt, wird keine automatische Aktualisierung durchgeführt.</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">Zu verwendende Aktionen</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Zieldatenbank für die Aktion. Kann das Format "${ columnName }" verwenden, um einen datengesteuerten Spaltennamen zu nutzen.</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Zielserver für die Aktion. Kann das Format "${ columnName }" verwenden, um einen datengesteuerten Spaltennamen zu nutzen.</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Zielbenutzer für die Aktion. Kann das Format "${ columnName }" verwenden, um einen datengesteuerten Spaltennamen zu nutzen.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">Bezeichner für Erkenntnisse</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">Stellt Erkenntnisse in der Dashboardpalette zur Verfügung.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">Das Diagramm kann mit den angegebenen Daten nicht angezeigt werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">Zeigt die Ergebnisse einer Abfrage als Diagramm im Dashboard an.</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">Ordnet den Spaltennamen einer Farbe zu. Fügen Sie z. B. "'column1': red" hinzu, damit in dieser Spalte die Farbe Rot verwendet wird.</target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">Hiermit wird die bevorzugte Position und Sichtbarkeit der Diagrammlegende angegeben. Darin werden die Spaltennamen aus der Abfrage der Bezeichnung der einzelnen Diagrammeinträge zugeordnet.</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">Wenn "dataDirection" auf "horizontal" festgelegt ist, werden die Werte aus der ersten Spalten als Legende verwendet.</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">Wenn "dataDirection" auf "vertical" festgelegt ist, werden für die Legende die Spaltennamen verwendet.</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">Legt fest, ob die Daten aus einer Spalte (vertikal) oder eine Zeile (horizontal) gelesen werden. Für Zeitreihen wird diese Einstellung ignoriert, da die Richtung vertikal sein muss.</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">Wenn "showTopNData" festgelegt ist, werden nur die ersten n Daten im Diagramm angezeigt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Minimalwert der Y-Achse</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Maximalwert der Y-Achse</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Bezeichnung für die Y-Achse</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">Minimalwert der X-Achse</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">Maximalwert der X-Achse</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">Bezeichnung für die X-Achse</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">Zeigt die Dateneigenschaft eines Datensatzes für ein Diagramm an.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">Zeigt für jede Spalte in einem Resultset den Wert in Zeile 0 als Zählwert gefolgt vom Spaltennamen an. Unterstützt beispielsweise "1 Healthy" oder "3 Unhealthy", wobei "Healthy" dem Spaltennamen und 1 dem Wert in Zeile 1/Zelle 1 entspricht.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">Zeigt ein Bild an, beispielsweise ein Bild, das durch eine R-Abfrage unter Verwendung von ggplot2 zurückgegeben wurde.</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">Welches Format wird erwartet – JPEG, PNG oder ein anderes Format?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">Erfolgt eine Codierung im Hexadezimal-, Base64- oder einem anderen Format?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">Stellt die Ergebnisse in einer einfachen Tabelle dar.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">Eigenschaften werden geladen.</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">Eigenschaften wurden vollständig geladen.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">Die Dashboardeigenschaften können nicht geladen werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">Datenbankverbindungen</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">Datenquellenverbindungen</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">Datenquellengruppen</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">Gespeicherte Verbindungen werden nach dem Datum sortiert, an dem sie hinzugefügt wurden.</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">Gespeicherte Verbindungen werden alphabetisch nach ihren Anzeigenamen sortiert.</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">Steuert die Sortierreihenfolge gespeicherter Verbindungen und Verbindungsgruppen.</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">Startkonfiguration</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">Bei Festlegung auf TRUE wird beim Start von Azure Data Studio standardmäßig die Serveransicht angezeigt. Bei Festlegung auf FALSE wird die zuletzt geöffnete Ansicht angezeigt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">Bezeichner der Sicht. Hiermit können Sie einen Datenanbieter über die API "vscode.window.registerTreeDataProviderForView" registrieren. Dient auch zum Aktivieren Ihrer Erweiterung, indem Sie das Ereignis "onView:${id}" für "activationEvents" registrieren.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Der lesbare Name der Sicht. Dieser wird angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">Eine Bedingung, die TRUE lauten muss, damit diese Sicht angezeigt wird.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">Stellt Sichten für den Editor zur Verfügung.</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">Stellt Sichten für den Data Explorer-Container in der Aktivitätsleiste zur Verfügung.</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">Stellt Sichten für den Container mit bereitgestellten Sichten zur Verfügung.</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">Es können nicht mehrere Sichten mit derselben ID ({0}) im Container "{1}" mit Sichten registriert werden.</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">Im Container "{1}" mit Sichten ist bereits eine Sicht mit der ID {0} registriert.</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">Sichten müssen als Array vorliegen.</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">Die Eigenschaft "{0}" ist erforderlich und muss vom Typ "string" sein.</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">Die Eigenschaft "{0}" kann ausgelassen werden oder muss vom Typ "string" sein.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Verbindungen</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">Verbindungen anzeigen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Trennen</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">SQL-Bereich zum Bearbeiten von Daten beim Start anzeigen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Ausführen</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">Fehler beim Verwerfen der Bearbeitung: </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Beenden</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">SQL-Bereich anzeigen</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">SQL-Bereich schließen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">Max. Zeilen:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">Zeile löschen</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">Aktuelle Zeile zurücksetzen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Als CSV speichern</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Als JSON speichern</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Als Excel speichern</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Als XML speichern</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Kopieren</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Mit Headern kopieren</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Alle auswählen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">Dashboardregisterkarten ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Titel</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">Dashboarderkenntnisse ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">Zeitpunkt</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">Ruft Erweiterungsinformationen aus dem Katalog ab.</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">Erweiterungs-ID</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">Die Erweiterung '{0}' wurde nicht gefunden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Empfehlungen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">Erweiterungen installieren</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">Erweiterung erstellen...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Nicht mehr anzeigen</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio enthält Erweiterungsempfehlungen.</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio enthält Erweiterungsempfehlungen für die Datenvisualisierung.
+Nach der Installation können Sie das Schnellansichtssymbol auswählen, um Ihre Abfrageergebnisse zu visualisieren.</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">Alle installieren</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Empfehlungen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Der Szenariotyp für Erweiterungsempfehlungen muss angegeben werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Diese Erweiterung wird von Azure Data Studio empfohlen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">Aufträge</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Warnungen</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">Proxys</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">Operatoren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">Letztes Vorkommen</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">Verzögerung zwischen Antworten (in Sek.)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">Kategoriename</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Fehler: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">Anwendbare Regeln anzeigen</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">Schritt-ID</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">Anwendbare Regeln für "{0}" anzeigen</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">Schrittname</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">Bewertung aufrufen</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">Bewertung für "{0}" aufrufen</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">Als Skript exportieren</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">Alle Regeln anzeigen und weitere Informationen auf GitHub erhalten</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">HTML-Bericht erstellen</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">Der Bericht wurde gespeichert. Möchten Sie ihn öffnen?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Öffnen</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Abbrechen</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">Meldung</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">Daten</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Verbindung</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Abfrage-Editor</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Dashboard</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Schritte</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">Dashboardregisterkarten ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">Titel</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Beschreibung</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">Dashboarderkenntnisse ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">Name</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">Zeitpunkt</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Letzte Ausführung</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Nächste Ausführung</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Status</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Kategorie</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">Ausführbar</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">Zeitplan</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Ergebnis der letzten Ausführung</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Vorherigen Ausführungen</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Für diesen Auftrag sind keine Schritte verfügbar.</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Fehler: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">Die Tabelle enthält kein gültiges Bild.</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">Erstellungsdatum: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Notebook-Fehler: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">Auftragsfehler: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">Angeheftet</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">Aktuelle Ausführungen</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">Vergangene Ausführungen</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">Mehr</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Bearbeiten</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Zieldatenbank</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Schließen</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Letzte Ausführung</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">Zelle konvertieren</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Nächste Ausführung</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">Alle Zellen oberhalb ausführen</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Status</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">Alle Zellen unterhalb ausführen</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Ergebnis der letzten Ausführung</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">Code oberhalb einfügen</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Vorherigen Ausführungen</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">Code unterhalb einfügen</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Für diesen Auftrag sind keine Schritte verfügbar.</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">Text oberhalb einfügen</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Fehler: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">Text unterhalb einfügen</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">Zelle reduzieren</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">Zelle erweitern</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">Parameterzelle erstellen</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">Parameterzelle entfernen</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">Ergebnis löschen</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Notebook-Fehler: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">Fehler beim Starten der Notebook-Sitzung.</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">Der Server wurde aus unbekannten Gründen nicht gestartet.</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">E-Mail-Adresse</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">Der Kernel "{0}" wurde nicht gefunden. Es wird stattdessen der Standardkernel verwendet.</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Aktiviert</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">Reihe "{0}"</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">Kontoname</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Schließen</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">Name der Anmeldeinformationen</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated"># Eingefügte Parameter
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Beschreibung</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">Wählen Sie eine Verbindung zum Ausführen von Zellen für diesen Kernel aus.</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">Fehler beim Löschen der Zelle.</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">Der Kernel konnte nicht geändert werden. Es wird der Kernel "{0}" verwendet. Fehler: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">Der Kernel konnte aufgrund des folgenden Fehlers nicht geändert werden: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">Fehler beim Ändern des Kontexts: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">Sitzung konnte nicht gestartet werden: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">Clientsitzungsfehler beim Schließen des Notebooks "{0}".</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">Der Notebook-Manager für den Anbieter "{0}" wurde nicht gefunden.</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Aktiviert</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Fehler: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">Mehr</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Schließen</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">Zelle konvertieren</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">Alle Zellen oberhalb ausführen</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">Alle Zellen unterhalb ausführen</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">Code oberhalb einfügen</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">Code unterhalb einfügen</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">Text oberhalb einfügen</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">Text unterhalb einfügen</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">Zelle reduzieren</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">Zelle erweitern</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">Parameterzelle erstellen</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">Parameterzelle entfernen</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">Ergebnis löschen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Zelle hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Codezelle</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Textzelle</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">Zelle nach unten verschieben</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">Zelle nach oben verschieben</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Löschen</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Zelle hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Codezelle</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Textzelle</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">Parameter</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">Wählen Sie eine aktive Zelle aus, und versuchen Sie es noch mal.</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">Zelle ausführen</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">Ausführung abbrechen</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">Fehler bei der letzten Ausführung. Klicken Sie, um den Vorgang zu wiederholen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">Codezelleninhalt erweitern</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">Codezelleninhalt reduzieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">Fett</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">Kursiv</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">Unterstrichen</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">Hervorheben</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Code</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">Link</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">Liste</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">Sortierte Liste</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Bild</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Markdownvorschau umschalten – aus</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">Überschrift</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">Überschrift 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">Überschrift 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">Überschrift 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">Absatz</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">Link einfügen</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">Bild einfügen</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">Rich-Text-Ansicht</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Geteilte Ansicht</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Markdownansicht</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Für die Ausgabe wurde kein {0}-Renderer gefunden. Folgende MIME-Typen sind enthalten: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">Sicher </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">Für Selektor "{0}" wurde keine Komponente gefunden.</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">Fehler beim Rendern der Komponente: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">Klicken Sie auf</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ Code</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">oder</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ Text</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">zum Hinzufügen einer Code- oder Textzelle</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">Eine Codezelle hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">Eine Textzelle hinzufügen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">StdIn:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Zum Bearbeiten doppelklicken&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Hier Inhalte hinzufügen... &lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Suchen</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Suchen</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Vorherige Übereinstimmung</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Nächste Übereinstimmung</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Schließen</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">Für Ihre Suche wurden sehr viele Ergebnisse zurückgegeben. Es werden nur die ersten 999 Übereinstimmungen hervorgehoben.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} von {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Keine Ergebnisse</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">Code hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">Text hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">Datei erstellen</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">Inhalt konnte nicht angezeigt werden: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Zelle hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Codezelle</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Textzelle</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">Alle ausführen</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">Zelle</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Code</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Text</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">Zellen ausführen</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; Zurück</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">Weiter &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">Die Zelle mit dem URI "{0}" wurde in diesem Modell nicht gefunden.</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Fehler beim Ausführen von Zellen: Weitere Informationen finden Sie im Fehler in der Ausgabe der aktuell ausgewählten Zelle.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Neues Notebook</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Neues Notebook</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">Arbeitsbereich festlegen und öffnen</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">SQL-Kernel: Notebook-Ausführung bei Fehler in Zelle beenden</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(Vorschau) Zeigen Sie alle Kernel für den aktuellen Notebook-Anbieter an.</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">Hiermit wird Notebooks das Ausführen von Azure Data Studio-Befehlen ermöglicht.</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">Hiermit wird ein Doppelklick zum Bearbeiten von Textzellen in Notebooks aktiviert.</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">Text wird als Rich-Text (auch bekannt als WSSIWYG) angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">Auf der linken Seite wird ein Markdown mit einer Vorschau des gerenderten Texts auf der rechten Seite angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">Der Text wird als Markdown angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">Der Standardbearbeitungsmodus, der für Textzellen verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(Vorschau) Speichern Sie den Verbindungsnamen in den Notebook-Metadaten.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">Hiermit wird die in der Notebook-Markdownvorschau verwendete Zeilenhöhe gesteuert. Diese Zahl ist relativ zum Schriftgrad.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(Vorschau) Gerendertes Notebook im Diff-Editor anzeigen.</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">Die maximale Anzahl von Änderungen, die im Verlauf des Rücksetzens für den Notizbuch-Rich-Text-Editor gespeichert sind.</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">Notebooks suchen</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">Konfigurieren Sie Globmuster für das Ausschließen von Dateien und Ordnern aus Volltextsuchen und Quick Open. Alle Globmuster werden von der Einstellung #files.exclude# geerbt. Weitere Informationen zu Globmustern finden Sie [hier](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">Das Globmuster, mit dem Dateipfade verglichen werden sollen. Legen Sie diesen Wert auf "true" oder "false" fest, um das Muster zu aktivieren bzw. zu deaktivieren.</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">Zusätzliche Überprüfung der gleichgeordneten Elemente einer entsprechenden Datei. Verwenden Sie "$(basename)" als Variable für den entsprechenden Dateinamen.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">Diese Einstellung ist veraltet und greift jetzt auf "search.usePCRE2" zurück.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">Veraltet. Verwenden Sie "search.usePCRE2" für die erweiterte Unterstützung von RegEx-Features.</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">Wenn diese Option aktiviert ist, bleibt der SearchService-Prozess aktiv, anstatt nach einer Stunde Inaktivität beendet zu werden. Dadurch wird der Cache für Dateisuchen im Arbeitsspeicher beibehalten.</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Steuert, ob bei der Dateisuche GITIGNORE- und IGNORE-Dateien verwendet werden.</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Steuert, ob bei der Dateisuche globale GITIGNORE- und IGNORE-Dateien verwendet werden.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">Konfiguriert, ob Ergebnisse aus einer globalen Symbolsuche in die Dateiergebnisse für Quick Open eingeschlossen werden sollen.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">Gibt an, ob Ergebnisse aus zuletzt geöffneten Dateien in den Dateiergebnissen für Quick Open aufgeführt werden.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">Verlaufseinträge werden anhand des verwendeten Filterwerts nach Relevanz sortiert. Relevantere Einträge werden zuerst angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">Verlaufseinträge werden absteigend nach Datum sortiert. Zuletzt geöffnete Einträge werden zuerst angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">Legt die Sortierreihenfolge des Editor-Verlaufs beim Filtern in Quick Open fest.</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">Steuert, ob Symlinks während der Suche gefolgt werden.</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">Sucht ohne Berücksichtigung von Groß-/Kleinschreibung, wenn das Muster kleingeschrieben ist, andernfalls wird mit Berücksichtigung von Groß-/Kleinschreibung gesucht.</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">Steuert, ob die Suchansicht die freigegebene Suchzwischenablage unter macOS lesen oder verändern soll.</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">Steuert, ob die Suche als Ansicht in der Seitenleiste oder als Panel angezeigt wird, damit horizontal mehr Platz verfügbar ist.</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">Diese Einstellung ist veraltet. Verwenden Sie stattdessen das Kontextmenü der Suchansicht.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">Dateien mit weniger als 10 Ergebnissen werden erweitert. Andere bleiben reduziert.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">Steuert, ob die Suchergebnisse zu- oder aufgeklappt werden.</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">Steuert, ob die Vorschau für das Ersetzen geöffnet werden soll, wenn eine Übereinstimmung ausgewählt oder ersetzt wird.</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">Steuert, ob Zeilennummern für Suchergebnisse angezeigt werden.</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">Gibt an, ob die PCRE2-RegEx-Engine bei der Textsuche verwendet werden soll. Dadurch wird die Verwendung einiger erweiterter RegEx-Features wie Lookahead und Rückverweise ermöglicht. Allerdings werden nicht alle PCRE2-Features unterstützt, sondern nur solche, die auch von JavaScript unterstützt werden.</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">Veraltet. PCRE2 wird beim Einsatz von Features für reguläre Ausdrücke, die nur von PCRE2 unterstützt werden, automatisch verwendet.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">Hiermit wird die Aktionsleiste auf der rechten Seite positioniert, wenn die Suchansicht schmal ist, und gleich hinter dem Inhalt, wenn die Suchansicht breit ist.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">Hiermit wird die Aktionsleiste immer auf der rechten Seite positioniert.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">Steuert die Positionierung der Aktionsleiste auf Zeilen in der Suchansicht.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">Alle Dateien während der Eingabe durchsuchen</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">Aktivieren Sie das Starten der Suche mit dem Wort, das dem Cursor am nächsten liegt, wenn der aktive Editor keine Auswahl aufweist.</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">Hiermit wird die Suchabfrage für den Arbeitsbereich auf den ausgewählten Editor-Text aktualisiert, wenn die Suchansicht den Fokus hat. Dies geschieht entweder per Klick oder durch Auslösen des Befehls "workbench.views.search.focus".</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">Wenn #search.searchOnType aktiviert ist, wird dadurch das Timeout in Millisekunden zwischen einem eingegebenen Zeichen und dem Start der Suche festgelegt. Diese Einstellung keine Auswirkung, wenn search.searchOnType deaktiviert ist.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">Durch Doppelklicken wird das Wort unter dem Cursor ausgewählt.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">Durch Doppelklicken wird das Ergebnis in der aktiven Editor-Gruppe geöffnet.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">Durch Doppelklicken wird das Ergebnis in der Editorgruppe an der Seite geöffnet, wodurch ein Ergebnis erstellt wird, wenn noch keines vorhanden ist.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">Konfiguriert den Effekt des Doppelklickens auf ein Ergebnis in einem Such-Editor.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">Ergebnisse werden nach Ordner- und Dateinamen in alphabetischer Reihenfolge sortiert.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">Die Ergebnisse werden nach Dateinamen in alphabetischer Reihenfolge sortiert. Die Ordnerreihenfolge wird ignoriert.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">Die Ergebnisse werden nach Dateiendungen in alphabetischer Reihenfolge sortiert.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">Die Ergebnisse werden nach dem Datum der letzten Dateiänderung in absteigender Reihenfolge sortiert.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">Ergebnisse werden nach Anzahl pro Datei und in absteigender Reihenfolge sortiert.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">Die Ergebnisse werden nach Anzahl pro Datei in aufsteigender Reihenfolge sortiert.</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">Steuert die Sortierreihenfolge der Suchergebnisse.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">Kernel werden geladen...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">Kernel wird geändert...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">Anfügen an </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">Kernel </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">Kontexte werden geladen...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Verbindung ändern</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">Verbindung auswählen</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">Kein Kernel</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Dieses Notizbuch kann nicht mit Parametern ausgeführt werden, da der Kernel nicht unterstützt wird. Verwenden Sie die unterstützten Kernel und das unterstützte Format. [Weitere Informationen] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Dieses Notebook kann erst mit Parametern ausgeführt werden, wenn eine Parameterzelle hinzugefügt wird. [Weitere Informationen](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Dieses Notizbuch kann erst mit Parametern ausgeführt werden, wenn der Parameterzelle Parameter hinzugefügt wurden. [Weitere Informationen](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">Ergebnisse löschen</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">Vertrauenswürdig</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">Nicht vertrauenswürdig</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">Zellen reduzieren</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">Zellen erweitern</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">Mit Parametern ausführen</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">Keine</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Neues Notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Nächste Zeichenfolge suchen</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Vorhergehende Zeichenfolge suchen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">Suchergebnisse</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">Der Suchpfad wurde nicht gefunden: {0}.</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">Sie haben keinen Ordner geöffnet, der Notebooks/Bücher enthält. </target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">Notebooks öffnen</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">Das Resultset enthält nur eine Teilmenge aller Übereinstimmungen. Verfeinern Sie Ihre Suche, um die Ergebnisse einzugrenzen.</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">Suche wird durchgeführt... – </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">Keine Ergebnisse in "{0}" unter Ausschluss von "{1}" gefunden – </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">Keine Ergebnisse in "{0}" gefunden – </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">Keine Ergebnisse gefunden, die "{0}" ausschließen – </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">Es wurden keine Ergebnisse gefunden. Überprüfen Sie die Einstellungen für konfigurierte Ausschlüsse, und überprüfen Sie Ihre gitignore-Dateien - </target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">Erneut suchen</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">Erneut in allen Dateien suchen</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">Einstellungen öffnen</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">Die Suche hat {0} Ergebnisse in {1} Dateien zurückgegeben.</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">Zu- und Aufklappen umschalten</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">Suche abbrechen</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">Alle erweitern</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Alle reduzieren</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">Suchergebnisse löschen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">Suche: Geben Sie den Suchbegriff ein, und drücken Sie die EINGABETASTE, um zu suchen, oder ESC, um den Vorgang abzubrechen.</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Suchen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">Die Zelle mit dem URI "{0}" wurde in diesem Modell nicht gefunden.</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Fehler beim Ausführen von Zellen: Weitere Informationen finden Sie im Fehler in der Ausgabe der aktuell ausgewählten Zelle.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">Führen Sie diese Zelle aus, um Ausgaben anzuzeigen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">Diese Ansicht ist leer. Fügen Sie dieser Ansicht eine Zelle hinzu, indem Sie auf die Schaltfläche „Zellen einfügen“ klicken.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Fehler beim Kopieren: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">Diagramm anzeigen</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">Tabelle anzeigen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Für die Ausgabe wurde kein {0}-Renderer gefunden. Folgende MIME-Typen sind enthalten: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(sicher) </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">Fehler beim Anzeigen des Plotly-Graphen: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">Keine Verbindungen gefunden.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">Verbindung hinzufügen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">Farbpalette für die Servergruppe, die im Objekt-Explorer-Viewlet verwendet wird.</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">Servergruppen im Objekt-Explorer-Viewlet automatisch erweitern</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(Vorschau) Verwenden Sie die neue asynchrone Serverstruktur für die Serveransicht und das Verbindungsdialogfeld. Sie bietet Unterstützung für neue Features wie die dynamische Knotenfilterung.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">Daten</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Verbindung</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Abfrage-Editor</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Dashboard</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Integrierte Diagramme</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">Gibt Ansichtsvorlagen an.</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">Gibt Sitzungsvorlagen an.</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Profilerfilter</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Verbinden</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Trennen</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Starten</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">Neue Sitzung</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">Anhalten</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">Fortsetzen</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Beenden</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">Daten löschen</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">Möchten Sie die Daten löschen?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">Automatisches Scrollen: Ein</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">Automatisches Scrollen: Aus</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">Ausgeblendeten Bereich umschalten</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">Spalten bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Nächste Zeichenfolge suchen</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Vorhergehende Zeichenfolge suchen</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Profiler starten</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">Filtern...</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">Filter löschen</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">Möchten Sie die Filter löschen?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">Ansicht auswählen</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">Sitzung auswählen</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">Sitzung auswählen:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">Ansicht auswählen:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Text</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">Beschriftung</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Wert</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Details</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Suchen</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Suchen</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Vorherige Übereinstimmung</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Nächste Übereinstimmung</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Schließen</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">Für Ihre Suche wurden sehr viele Ergebnisse zurückgegeben. Es werden nur die ersten 999 Übereinstimmungen hervorgehoben.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} von {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Keine Ergebnisse</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">Profiler-Editor für Ereignistext (schreibgeschützt)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">Ereignisse (gefiltert): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">Ereignisse: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">Ereignisanzahl</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Als CSV speichern</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Als JSON speichern</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Als Excel speichern</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Als XML speichern</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">Die Ergebniscodierung wird beim Exportieren in JSON nicht gespeichert. Nachdem die Datei erstellt wurde, speichern Sie sie mit der gewünschten Codierung.</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">Das Speichern in einer Datei wird von der zugrunde liegenden Datenquelle nicht unterstützt.</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Kopieren</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Mit Headern kopieren</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Alle auswählen</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">Maximieren</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Wiederherstellen</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Diagramm</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">Schnellansicht</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">SQL-Sprache auswählen</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">SQL-Sprachanbieter ändern</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">SQL-Sprachvariante</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">SQL-Engine-Anbieter ändern</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">Es besteht eine Verbindung über die Engine "{0}". Um die Verbindung zu ändern, trennen oder wechseln Sie die Verbindung.</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">Momentan ist kein Text-Editor aktiv.</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">Sprachanbieter auswählen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">XML-Showplan</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">Ergebnisraster</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">Die maximale Zeilenanzahl für das Filtern/ Sortieren wurde überschritten. Um sie zu aktualisieren, können Sie zu "Benutzereinstellungen" wechseln und die Einstellung "queryEditor.results.inMemoryDataProcessingThreshold" ändern.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">Fokus auf aktuelle Abfrage</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Abfrage ausführen</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">Aktuelle Abfrage ausführen</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">Abfrage mit Ergebnissen kopieren</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">Die Abfrage und die Ergebnisse wurden erfolgreich kopiert.</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">Aktuelle Abfrage mit Istplan ausführen</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">Abfrage abbrechen</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">IntelliSense-Cache aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">Abfrageergebnisse umschalten</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">Fokus zwischen Abfrage und Ergebnissen umschalten</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">Editor-Parameter zum Ausführen einer Tastenkombination erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">Abfrage analysieren</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">Die Befehle wurden erfolgreich ausgeführt.</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">Fehler bei Befehl:</target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">Stellen Sie eine Verbindung mit einem Server her.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">Meldungspanel</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Kopieren</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">Alle kopieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">Abfrageergebnisse</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Neue Abfrage</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Abfrage-Editor</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">Bei Festlegung auf TRUE werden beim Speichern der Ergebnisse als CSV auch die Spaltenüberschriften einbezogen.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">Benutzerdefiniertes Trennzeichen zwischen Werten, das beim Speichern der Ergebnisse als CSV verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">Zeichen für die Trennung von Zeilen, das beim Speichern der Ergebnisse als CSV verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">Zeichen für das Umschließen von Textfeldern, das beim Speichern der Ergebnisse als CSV verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">Dateicodierung, die beim Speichern der Ergebnisse als CSV verwendet wird</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">Bei Festlegung auf TRUE wird die XML-Ausgabe formatiert, wenn die Ergebnisse im XML-Format gespeichert werden.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">Beim Speichern der Ergebnisse im XML-Format verwendete Dateicodierung</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">Hiermit wird das Streamen der Ergebnisse aktiviert. Diese Option weist einige geringfügige Darstellungsprobleme auf.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">Konfigurationsoptionen für das Kopieren von Ergebnissen aus der Ergebnisansicht</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">Konfigurationsoptionen für das Kopieren mehrzeiliger Ergebnisse aus der Ergebnisansicht</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(Experimentell) Verwenden Sie eine optimierte Tabelle in der Ergebnisausgabe. Möglicherweise fehlen einige Funktionen oder befinden sich in Bearbeitung.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">Steuert die maximale Anzahl von Zeilen, die im Arbeitsspeicher gefiltert und sortiert werden dürfen. Wenn die Zahl überschritten wird, werden die Sortier- und Filterfunktionen deaktiviert. Warnung: die Erhöhung dieser Anzahl kann sich auf die Leistung auswirken.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">Gibt an, ob die Datei in Azure Data Studio geöffnet werden soll, nachdem das Ergebnis gespeichert wurde.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">Gibt an, ob die Ausführungszeit für einzelne Batches angezeigt werden soll.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">Meldungen zu Zeilenumbrüchen</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">Dieser Diagrammtyp wird standardmäßig verwendet, wenn der Diagramm-Viewer von Abfrageergebnissen aus geöffnet wird.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">Das Einfärben von Registerkarten wird deaktiviert.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">Der obere Rand der einzelnen Editor-Registerkarten wird entsprechend der jeweiligen Servergruppe eingefärbt.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">Die Hintergrundfarbe der Editor-Registerkarten entspricht der jeweiligen Servergruppe.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">Steuert die Farbe von Registerkarten basierend auf der Servergruppe der aktiven Verbindung.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">Legt fest, ob die Verbindungsinformationen für eine Registerkarte im Titel angezeigt werden.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">Aufforderung zum Speichern generierter SQL-Dateien</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">Legen Sie "workbench.action.query.shortcut{0}" für die Tastenzuordnung fest, um den Verknüpfungstext als Prozeduraufruf oder Abfrageausführung auszuführen. Der ausgewählte Text im Abfrage-Editor wird am Ende der Abfrage als Parameter übergeben, oder Sie können mit "{arg}" darauf verweisen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Neue Abfrage</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Ausführen</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">Erklärung</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">Tatsächlich</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Trennen</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Verbindung ändern</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Verbinden</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">SQLCMD aktivieren</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">SQLCMD deaktivieren</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Datenbank auswählen</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Fehler beim Ändern der Datenbank.</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">Fehler beim Ändern der Datenbank: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">Als Notebook exportieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">Ergebnisse</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">Meldungen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">Verstrichene Zeit</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">Zeilenanzahl</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} Zeilen</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">Abfrage wird ausgeführt...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">Ausführungsstatus</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">Zusammenfassung der Auswahl</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">Durchschnitt: {0}, Anzahl: {1}, Summe: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">Ergebnisraster und Meldungen</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">Steuert die Schriftfamilie.</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">Steuert die Schriftbreite.</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">Legt die Schriftgröße in Pixeln fest.</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">Legt den Abstand der Buchstaben in Pixeln fest.</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">Legt die Zeilenhöhe in Pixeln fest.</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">Legt den Zellenabstand in Pixeln fest.</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">Hiermit wird die Spaltenbreite der ersten Ergebnisse automatisch angepasst. Diese Einstellung kann bei einer großen Anzahl von Spalten oder großen Zellen zu Leistungsproblemen führen.</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">Die maximale Breite in Pixeln für Spalten mit automatischer Größe</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">Abfrageverlauf umschalten</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Löschen</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Gesamten Verlauf löschen</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">Abfrage öffnen</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Abfrage ausführen</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">Erfassung des Abfrageverlaufs umschalten</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Erfassung des Abfrageverlaufs anhalten</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Erfassung des Abfrageverlaufs starten</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">Erfolgreich</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">Fehlerhaft</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">Keine Abfragen zur Anzeige vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">Abfrageverlauf</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">Abfrageverlauf</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">Gibt an, ob die Erfassung des Abfrageverlaufs aktiviert ist. Bei Festlegung auf FALSE werden ausgeführte Abfragen nicht erfasst.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Gesamten Verlauf löschen</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Erfassung des Abfrageverlaufs anhalten</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Erfassung des Abfrageverlaufs starten</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Sicht</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Abfrageverlauf</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">Abfrageverlauf</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">Abfrageplan</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">Vorgang</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">Objekt</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">Geschätzte Kosten</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">Geschätzte Kosten für Unterstruktur</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">Tatsächliche Zeilen</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">Geschätzte Zeilen</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">Tatsächliche Ausführungen</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">Geschätzte CPU-Kosten</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">Geschätzte E/A-Kosten</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">Parallel</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">Tatsächliche erneute Bindungen</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">Geschätzte erneute Bindungen</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">Tatsächliche Rückläufe</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">Geschätzte Rückläufe</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">Partitioniert</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">Wichtigste Vorgänge</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Ressourcen-Viewer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">Fehler beim Öffnen des Links: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">Fehler beim Ausführen des Befehls "{0}": {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">Ressourcen-Viewer-Struktur</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">Bezeichner der Ressource.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Der lesbare Name der Sicht. Dieser wird angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">Pfad zum Ressourcensymbol.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">Trägt die Ressource zur Ressourcenansicht bei.</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">Die Eigenschaft "{0}" ist erforderlich und muss vom Typ "string" sein.</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">Die Eigenschaft "{0}" kann ausgelassen werden oder muss vom Typ "string" sein.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Wiederherstellen</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Wiederherstellen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">Sie müssen die Vorschaufeatures aktivieren, um die Wiederherstellung zu verwenden.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">Der Wiederherstellungsbefehl wird außerhalb eines Serverkontexts nicht unterstützt. Wählen Sie einen Server oder eine Datenbank aus, und versuchen Sie es noch mal.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">Der Wiederherstellungsbefehl wird für Azure SQL-Datenbank-Instanzen nicht unterstützt.</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Wiederherstellen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Skripterstellung als CREATE</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Skripterstellung als DROP</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Oberste 1000 auswählen</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Skripterstellung als EXECUTE</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Skripterstellung als ALTER</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Daten bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Oberste 1000 auswählen</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">10 zurückgeben</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Skripterstellung als CREATE</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Skripterstellung als EXECUTE</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Skripterstellung als ALTER</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Skripterstellung als DROP</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">Fehler beim Aktualisieren des Knotens "{0}": {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} Aufgaben werden ausgeführt</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Sicht</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">Aufgaben</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Aufgaben</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">Aufgaben umschalten</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">Erfolgreich</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">Fehlerhaft</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">In Bearbeitung</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">Nicht gestartet</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">Abgebrochen</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">Wird abgebrochen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">Kein Aufgabenverlauf zur Anzeige vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">Aufgabenverlauf</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">Aufgabenfehler</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">Der Task konnte nicht abgebrochen werden.</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Skript</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">Es ist kein Datenanbieter registriert, der Sichtdaten bereitstellen kann.</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Alle reduzieren</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">Fehler beim Ausführen des Befehls {1}: {0}. Dies wird vermutlich durch die Erweiterung verursacht, die {1} beiträgt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Schließen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">Vorschaufeatures verbessern die Benutzerfreundlichkeit von Azure Data Studio, indem sie Ihnen Vollzugriff auf neue Features und Verbesserungen ermöglichen. Weitere Informationen zu Vorschaufeatures finden Sie [hier]({0}). Möchten Sie Vorschaufeatures aktivieren?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">Ja (empfohlen)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">Nein, nicht mehr anzeigen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">Diese Featureseite befindet sich in der Vorschauphase. Durch die Vorschaufeatures werden neue Funktionen eingeführt, die demnächst als dauerhafter Bestandteil in das Produkt integriert werden. Sie sind stabil, erfordern jedoch zusätzliche Verbesserungen im Hinblick auf die Barrierefreiheit. Wir freuen uns über Ihr frühes Feedback, solange die Features noch entwickelt werden.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">Vorschau</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">Verbindung erstellen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">Stellen Sie über das Verbindungsdialogfeld eine Verbindung mit einer Datenbankinstanz her.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">Abfrage ausführen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">Interagieren Sie mit Daten über einen Abfrage-Editor.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">Notebook erstellen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">Erstellen Sie ein neues Notebook mithilfe eines nativen Notebook-Editors.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Server bereitstellen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">Erstellen Sie eine neue Instanz eines relationalen Datendiensts auf der Plattform Ihrer Wahl.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">Ressourcen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">Verlauf</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Name</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">Standort</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">Mehr anzeigen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Beim Start Willkommensseite anzeigen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">Nützliche Links</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">Erste Schritte</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Lernen Sie die von Azure Data Studio bereitgestellten Funktionen kennen, und erfahren Sie, wie Sie diese optimal nutzen können.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Dokumentation</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">Im Dokumentationscenter finden Sie Schnellstarts, Anleitungen und Referenzdokumentation zu PowerShell, APIs usw.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">Videos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Übersicht über Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Einführung in Azure Data Studio-Notebooks | Verfügbare Daten</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Erweiterungen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">Alle anzeigen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">Weitere Informationen </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Verbindungen</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">Über SQL Server, Azure und weitere Plattformen können Sie Verbindungen herstellen, abfragen und verwalten.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Weiter</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">Beginnen Sie an einer zentralen Stelle mit der Erstellung Ihres eigenen Notebooks oder einer Sammlung von Notebooks.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Erweiterungen</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Erweitern Sie die Funktionalität von Azure Data Studio durch die Installation von Erweiterungen, die von uns/Microsoft und von der Drittanbietercommunity (von Ihnen!) entwickelt wurden.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">Passen Sie Azure Data Studio basierend auf Ihren Einstellungen an. Sie können Einstellungen wie automatisches Speichern und Registerkartengröße konfigurieren, Ihre Tastenkombinationen personalisieren und zu einem Farbdesign Ihrer Wahl wechseln.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">Willkommensseite</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">Entdecken Sie wichtige Features, zuletzt geöffneten Dateien und empfohlene Erweiterungen auf der Willkommensseite. Weitere Informationen zum Einstieg in Azure Data Studio finden Sie in den Videos und in der Dokumentation.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">Fertig stellen</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">Einführungstour für Benutzer</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">Einführungstour ausblenden</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">Weitere Informationen</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Hilfe</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Willkommen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL-Administratorpaket</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL-Administratorpaket</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">Das Administratorpaket für SQL Server ist eine Sammlung gängiger Erweiterungen für die Datenbankverwaltung, die Sie beim Verwalten von SQL Server unterstützen.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server-Agent</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">SQL Server-Import</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server-DACPAC</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Hiermit werden PowerShell-Skripts mithilfe des umfangreichen Abfrage-Editors von Azure Data Studio geschrieben und ausgeführt.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">Datenvirtualisierung</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">Hiermit werden Daten mit SQL Server 2019 virtualisiert und externe Tabellen mithilfe interaktiver Assistenten erstellt.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">Mit Azure Data Studio können Sie PostgreSQL-Datenbanken verbinden, abfragen und verwalten.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">Unterstützung für {0} ist bereits installiert.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">Nach dem Installieren zusätzlicher Unterstützung für {0} wird das Fenster neu geladen.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">Zusätzliche Unterstützung für {0} wird installiert...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">Unterstützung für {0} mit der ID {1} wurde nicht gefunden.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Neue Verbindung</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Neue Abfrage</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Neues Notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Server bereitstellen</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Willkommen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">Neu</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">Öffnen…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">Datei öffnen…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">Ordner öffnen…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">Tour starten</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">Leiste für Schnelleinführung schließen</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">Möchten Sie eine kurze Einführung in Azure Data Studio erhalten?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">Willkommen!</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">Ordner {0} mit Pfad {1} öffnen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Installieren</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">Tastenzuordnung {0} öffnen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">Zusätzliche Unterstützung für {0} installieren</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">Installiert</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">Die Tastaturzuordnung {0} ist bereits installiert.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">Unterstützung für {0} ist bereits installiert.</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Details</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">Hintergrundfarbe für die Startseite.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Starten</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Neue Verbindung</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Neue Abfrage</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Neues Notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Datei öffnen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Datei öffnen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">Bereitstellen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">Neue Bereitstellung…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Zuletzt verwendet</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">Mehr...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">Keine kürzlich verwendeten Ordner</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Hilfe</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">Erste Schritte</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Dokumentation</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">Problem melden oder Feature anfragen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">GitHub-Repository</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">Versionshinweise</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Beim Start Willkommensseite anzeigen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">Anpassen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Erweiterungen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">Laden Sie die von Ihnen benötigten Erweiterungen herunter, z. B. die SQL Server-Verwaltungsprogramme und mehr.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">Tastenkombinationen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">Bevorzugte Befehle finden und anpassen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">Farbdesign</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">Passen Sie das Aussehen von Editor und Code an Ihre Wünsche an.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">Informationen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">Alle Befehle suchen und ausführen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">Über die Befehlspalette ({0}) können Sie schnell auf Befehle zugreifen und nach Befehlen suchen.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">Neuerungen in der aktuellen Version erkunden</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">Monatliche Vorstellung neuer Features in Blogbeiträgen</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Folgen Sie uns auf Twitter</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">Informieren Sie sich darüber, wie die Community Azure Data Studio verwendet, und kommunizieren Sie direkt mit den Technikern.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">Konten</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">Verknüpfte Konten</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Schließen</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">Es ist kein verknüpftes Konto vorhanden. Fügen Sie ein Konto hinzu.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">Konto hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">Es sind keine Clouds aktiviert. Wechseln Sie zu "Einstellungen", durchsuchen Sie die Azure-Kontokonfiguration, und aktivieren Sie mindestens eine Cloud.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">Sie haben keinen Authentifizierungsanbieter ausgewählt. Versuchen Sie es noch mal.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Fehler beim Hinzufügen des Kontos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">Die Anmeldeinformationen für dieses Konto müssen aktualisiert werden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Schließen</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">Konto wird hinzugefügt...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">Die Kontoaktualisierung wurde durch den Benutzer abgebrochen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Azure-Konto</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Azure-Mandant</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">Kopieren und öffnen</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">Benutzercode</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">Website</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">Starten einer automatischen OAuth-Authentifizierung nicht möglich. Es wird bereits eine automatische OAuth-Authentifizierung ausgeführt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">Für eine Interaktion mit dem Verwaltungsdienst ist eine Verbindung erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Kein Handler registriert.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">Für die Interaktion mit dem Bewertungsdienst ist eine Verbindung erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Kein Handler registriert.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">Erweiterte Eigenschaften</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Verwerfen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">Serverbeschreibung (optional)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">Liste löschen</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">Die Liste der zuletzt verwendeten Verbindungen wurde gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">Möchten Sie alle Verbindungen aus der Liste löschen?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Löschen</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">Aktuelle Verbindungszeichenfolge abrufen</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">Die Verbindungszeichenfolge ist nicht verfügbar.</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">Keine aktive Verbindung verfügbar.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Durchsuchen</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">Geben Sie hier Text ein, um die Liste zu filtern</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">Verbindungen filtern</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">Filter wird angewendet.</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">Filter wird entfernt.</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">Filter angewendet</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">Filter entfernt</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Gespeicherte Verbindungen</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Gespeicherte Verbindungen</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">Struktur des Verbindungsbrowsers</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">Verbindungsfehler</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">Fehler bei Verbindung aufgrund eines Kerberos-Fehlers.</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">Hilfe zum Konfigurieren von Kerberos finden Sie hier: {0}</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">Wenn Sie zuvor eine Verbindung hergestellt haben, müssen Sie "kinit" möglicherweise erneut ausführen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Verbindung</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">Verbindung wird hergestellt</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">Verbindungstyp</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Zuletzt verwendet</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">Verbindungsdetails</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Verbinden</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Letzte Verbindungen</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">Keine aktuelle Verbindung</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">Fehler beim Abrufen des Azure-Kontotokens für die Verbindung.</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">Verbindung nicht akzeptiert.</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">Möchten Sie diese Verbindung abbrechen?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">Konto hinzufügen...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Standard&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Wird geladen...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">Servergruppe</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Standard&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">Neue Gruppe hinzufügen...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;Nicht speichern&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">"{0}" ist erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">"{0}" wird gekürzt.</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">Kennwort speichern</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">Konto</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">Kontoanmeldeinformationen aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Azure AD-Mandant</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">Name (optional)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">Erweitert...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">Sie müssen ein Konto auswählen.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">Verbunden mit</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">Getrennt</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">Nicht gespeicherte Verbindungen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">Dashboarderweiterungen öffnen</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">Aktuell sind keine Dashboarderweiterungen installiert. Wechseln Sie zum Erweiterungs-Manager, um die empfohlenen Erweiterungen zu erkunden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">Schritt {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Fertig</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">Fehler beim Initialisieren der Datenbearbeitungssitzung: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Schließen</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Aktion</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">Details kopieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Fehler</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Warnung</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">Info</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">Ignorieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">Ausgewählter Pfad</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">Dateien vom Typ</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Verwerfen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">Datei auswählen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">Dateibrowserstruktur</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">Fehler beim Laden des Dateibrowsers.</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">Fehler beim Dateibrowser</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">Alle Dateien</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">Zelle kopieren</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">Es wurde kein Verbindungsprofil an das Flyout mit Erkenntnissen übergeben.</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">Erkenntnisfehler</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">Fehler beim Lesen der Abfragedatei: </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">Fehler beim Analysieren der Konfiguration für Erkenntnisse. Das Abfragearray/die Abfragezeichenfolge oder die Abfragedatei wurde nicht gefunden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">Element</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Wert</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">Details zu Erkenntnissen</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">Eigenschaft</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Wert</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">Erkenntnisse</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">Elemente</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">Details zum Element</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">Die Abfragedatei wurde in keinem der folgenden Pfade gefunden:
+{0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">Fehlerhaft</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">Erfolgreich</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">Wiederholen</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">Abgebrochen</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">In Bearbeitung</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">Status unbekannt</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">Wird ausgeführt</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">Warten auf Thread</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">Zwischen Wiederholungen</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">Im Leerlauf</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">Angehalten</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[Veraltet]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">Nicht geplant</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">Nie ausführen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">Für die Interaktion mit "JobManagementService" ist eine Verbindung erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Kein Handler registriert.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Fehler: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">Fehler beim Starten der Notebook-Sitzung.</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">Der Server wurde aus unbekannten Gründen nicht gestartet.</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">Der Kernel "{0}" wurde nicht gefunden. Es wird stattdessen der Standardkernel verwendet.</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Fehler: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="de">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="de">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">Das Ändern von Editor-Typen für nicht gespeicherte Dateien wird nicht unterstützt.</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated"># Eingefügte Parameter
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">Wählen Sie eine Verbindung zum Ausführen von Zellen für diesen Kernel aus.</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">Fehler beim Löschen der Zelle.</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">Der Kernel konnte nicht geändert werden. Es wird der Kernel "{0}" verwendet. Fehler: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">Der Kernel konnte aufgrund des folgenden Fehlers nicht geändert werden: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">Fehler beim Ändern des Kontexts: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">Sitzung konnte nicht gestartet werden: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">Clientsitzungsfehler beim Schließen des Notebooks "{0}".</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">Der Notebook-Manager für den Anbieter "{0}" wurde nicht gefunden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">Bei der Erstellung eines Notebook-Managers wurde kein URI übergeben.</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">Der Notebook-Anbieter ist nicht vorhanden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">Eine Ansicht mit dem Namen {0} ist in diesem Notizbuch bereits vorhanden.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">SQL-Kernelfehler</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">Sie müssen eine Verbindung auswählen, um Notebook-Zellen auszuführen.</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">Die ersten {0} Zeilen werden angezeigt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">Rich Text</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Geteilte Ansicht</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">nbformat v{0}.{1} nicht erkannt.</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">Diese Datei weist kein gültiges Notebook-Format auf.</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">Unbekannter Zellentyp "{0}".</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Der Ausgabetyp "{0}" wurde nicht erkannt.</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">Als Daten für "{0}" wird eine Zeichenfolge oder ein Array aus Zeichenfolgen erwartet.</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Der Ausgabetyp "{0}" wurde nicht erkannt.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">Bezeichner des Notebook-Anbieters.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">Gibt an, welche Dateierweiterungen für diesen Notebook-Anbieter registriert werden sollen.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">Gibt an, welche Kernel für diesen Notebook-Anbieter als Standard festgelegt werden sollen.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">Stellt Notebook-Anbieter zur Verfügung.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">Name des Magic-Befehls für die Zelle, z. B. "%%sql".</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">Die zu verwendende Zellensprache, wenn dieser Zellen-Magic-Befehl in der Zelle enthalten ist.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">Optionales Ausführungsziel, das von diesem Magic-Befehl angegeben wird, z. B. Spark oder SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">Optionaler Kernelsatz, auf den dies zutrifft, z. B. python3, pyspark, sql</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">Stellt die Notebook-Sprache zur Verfügung.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Wird geladen...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">Verbindung bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Trennen</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">Neue Verbindung</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">Neue Servergruppe</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">Servergruppe bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">Aktive Verbindungen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">Alle Verbindungen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">Verbindung löschen</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">Gruppe löschen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">Fehler beim Erstellen der Objekt-Explorer-Sitzung.</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">Mehrere Fehler:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">Erweiterung nicht möglich, weil der erforderliche Verbindungsanbieter "{0}" nicht gefunden wurde.</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">Vom Benutzer abgebrochen</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">Firewalldialogfeld abgebrochen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Wird geladen...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Letzte Verbindungen</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">Nach Ereignis sortieren</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">Nach Spalte sortieren</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">Alle löschen</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Anwenden</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">Filter</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">Diese Klausel entfernen</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">Filter speichern</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">Filter laden</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">Klausel hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">Feld</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">Operator</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Wert</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">Ist NULL</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">Ist nicht NULL</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">Enthält</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">Enthält nicht</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">Beginnt mit</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">Beginnt nicht mit</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">Fehler bei Zeilencommit: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">Ausführung der Abfrage gestartet um </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">Die Ausführung der Abfrage "{0}" wurde gestartet.</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">Zeile {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">Fehler beim Abbrechen der Abfrage: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">Fehler beim Aktualisieren der Zelle: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">Die Ausführung war aufgrund eines unerwarteten Fehlers nicht möglich: {0}	{1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">Ausführungszeit gesamt: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">Die Abfrageausführung wurde in Zeile {0} gestartet.</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">Die Ausführung von Batch "{0}" wurde gestartet.</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">Batchausführungszeit: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Fehler beim Kopieren: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">Fehler beim Speichern der Ergebnisse. </target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">Ergebnisdatei auswählen</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (durch Trennzeichen getrennte Datei)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Excel-Arbeitsmappe</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">Nur-Text</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">Datei wird gespeichert...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">Ergebnisse wurden erfolgreich in "{0}" gespeichert.</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Datei öffnen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">Von</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">An</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">Neue Firewallregel erstellen</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">Ihre Client-IP-Adresse hat keinen Zugriff auf den Server. Melden Sie sich bei einem Azure-Konto an, und erstellen Sie eine neue Firewallregel für die Aktivierung des Zugriffs.</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">Weitere Informationen zu Firewalleinstellungen</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">Firewallregel</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">Meine Client-IP-Adresse hinzufügen </target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">Meinen Subnetz-IP-Adressbereich hinzufügen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Fehler beim Hinzufügen des Kontos</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">Fehler bei Firewallregel</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">Pfad zur Sicherungsdatei</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">Zieldatenbank</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Wiederherstellen</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Datenbank wiederherstellen</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Datenbank</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">Sicherungsdatei</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Datenbank wiederherstellen</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Skript</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Quelle</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">Wiederherstellen aus</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">Sie müssen einen Pfad für die Sicherungsdatei angeben.</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">Geben Sie einen oder mehrere Dateipfade (durch Kommas getrennt) ein.</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Datenbank</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">Ziel</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">Wiederherstellen in</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">Wiederherstellungsplan</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">Wiederherzustellende Sicherungssätze</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">Datenbankdateien wiederherstellen als</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">Details zu Datenbankdateien wiederherstellen</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">Logischer Dateiname</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">Dateityp</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">Ursprünglicher Dateiname</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">Wiederherstellen als</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">Wiederherstellungsoptionen</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">Sicherung des Protokollfragments</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">Serververbindungen</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">Allgemein</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Dateien</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Optionen</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">Sicherungsdateien</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">Alle Dateien</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">Servergruppen</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">Name der Servergruppe</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">Der Gruppenname ist erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">Gruppenbeschreibung</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">Gruppenfarbe</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">Servergruppe hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">Servergruppe bearbeiten</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">Mindestens eine Aufgabe wird zurzeit ausgeführt. Möchten Sie den Vorgang abbrechen?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Ja</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Nein</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">Erste Schritte</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">"Erste Schritte" anzeigen</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Erste &amp;&amp;Schritte</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/es/admin-tool-ext-win.es.xlf
+++ b/resources/xlf/es/admin-tool-ext-win.es.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/es/agent.es.xlf
+++ b/resources/xlf/es/agent.es.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">Nueva programación</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">Aceptar</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nombre de la programación</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Programaciones</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">Crear proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">Editar Proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">General</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">Nombre del proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">Nombre de credencial</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descripción</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">Subsistema</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">Sistema operativo (CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">Instantánea de replicación</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">Lector del registro de transacciones de replicación</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">Distribuidor de replicación</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">Fusión de replicación</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">Lector de cola de replicación</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">Consulta de SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">Comando de SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">Paquete de SQL Server Integration Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">Activo en los subsistemas siguientes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">Programas de trabajos</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">Programaciones disponibles:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">Id.</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descripción</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">Crear operador</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">Editar operador</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">General</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notificaciones</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">Nombre de correo electrónico</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">Nombre de correo electrónico del buscapersonas</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">Lunes</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">Martes</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">Miércoles</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">Jueves</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">Viernes  </target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">Sábado</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">Domingo</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">Inicio del día laborable</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">Final del día laborable</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">Buscapersonas en horario de trabajo</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">Lista de alerta</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">Nombre de alerta</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">Correo electrónico</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">Buscapersonas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">General</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">Programas de trabajos</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Pasos</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Programaciones</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Alertas</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">Programaciones disponibles:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notificaciones</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">El nombre del trabajo no puede estar en blanco.</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">Nombre</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Propietario</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">Id.</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Categoría</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">Descripción</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">Lista de paso de trabajo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">Paso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">En caso de éxito</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">En caso de error</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">Nuevo paso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">Editar paso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">Eliminar paso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">Subir un paso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">Bajar un paso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">Iniciar paso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">Acciones para realizar cuando se completa el trabajo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">Correo electrónico</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">Página</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">Escribir en el registro de eventos de la aplicación de Windows</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">Eliminar automáticamente el trabajo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">Lista de programaciones</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">Elegir programación</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nombre de la programación</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">Lista de alertas</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">Nueva alerta</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">Nombre de alerta</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">Nuevo trabajo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">Editar trabajo</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">Mensaje de notificación adicional para enviar</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">Retardo entre las respuestas</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">Minutos de retardo</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">Crear operador</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">Editar operador</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">General</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notificaciones</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">Nombre de correo electrónico</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">Nombre de correo electrónico del buscapersonas</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">Lunes</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">Martes</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">Miércoles</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">Jueves</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">Viernes  </target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">Sábado</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">Domingo</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">Inicio del día laborable</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">Final del día laborable</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">Buscapersonas en horario de trabajo</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">Lista de alerta</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">Nombre de alerta</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">Correo electrónico</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">Buscapersonas</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">Error de la actualización de proxy "{0}"</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">General</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">El proxy "{0}" se actualizó correctamente</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Pasos</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">Proxy "{0}" creado correctamente</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">Programaciones</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Alertas</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notificaciones</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">El nombre del trabajo no puede estar en blanco.</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Propietario</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Categoría</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descripción</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">Lista de paso de trabajo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">Paso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">En caso de éxito</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">En caso de error</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">Nuevo paso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">Editar paso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">Eliminar paso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">Subir un paso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">Bajar un paso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">Iniciar paso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">Acciones para realizar cuando se completa el trabajo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">Correo electrónico</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">Página</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">Escribir en el registro de eventos de la aplicación de Windows</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">Eliminar automáticamente el trabajo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Lista de programaciones</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Elegir programación</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Quitar programación</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">Lista de alertas</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">Nueva alerta</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">Nombre de alerta</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">Nuevo trabajo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">Editar trabajo</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">Error de actualización en el paso "{0}"</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">Debe proporcionarse el nombre del trabajo</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">Debe proporcionarse el nombre del paso</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">Error de actualización en el paso "{0}"</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">Debe proporcionarse el nombre del trabajo</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">Debe proporcionarse el nombre del paso</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">Esta característica está en desarrollo. ¡Obtenga la última versión para Insiders si desea probar los cambios más recientes!</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">Plantilla actualizada correctamente</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">Error de actualización de plantilla</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">Debe guardar el cuaderno antes de programarlo. Guarde y vuelva a intentar programar de nuevo.</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">Agregar nueva conexión</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">Seleccionar una conexión</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">Seleccione una conexión válida</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">Esta característica está en desarrollo. ¡Obtenga la última versión para Insiders si desea probar los cambios más recientes!</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">Crear proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">Editar Proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">General</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">Nombre del proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">Nombre de credencial</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descripción</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">Subsistema</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">Sistema operativo (CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">Instantánea de replicación</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">Lector del registro de transacciones de replicación</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">Distribuidor de replicación</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">Fusión de replicación</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">Lector de cola de replicación</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">Consulta de SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">Comando de SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">Paquete de SQL Server Integration Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">Error de la actualización de proxy "{0}"</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">El proxy "{0}" se actualizó correctamente</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">Proxy "{0}" creado correctamente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">Nuevo trabajo de cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">Editar trabajo del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">General</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">Detalles del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">Ruta de acceso del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">Base de datos del almacenamiento</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">Base de datos de ejecución</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Seleccionar la base de datos</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">Detalles del trabajo</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Propietario</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Lista de programaciones</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Elegir programación</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Quitar programación</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descripción</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">Seleccione un cuaderno para programar desde el equipo.</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">Seleccione una base de datos para almacenar todos los cuadernos y resultados del trabajo del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">Seleccione una base de datos en la que se ejecutarán las consultas de cuaderno</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">Cuando se complete el cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">Cuando se produzca un error en el cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">Cuando el cuaderno se ejecute correctamente</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">Se debe proporcionar el nombre del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">Se debe proporcionar la ruta de acceso de la plantilla</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">Ruta de acceso del cuaderno no válida</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">Seleccionar base de datos de almacenamiento</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">Seleccionar base de datos de ejecución</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">Un trabajo con un nombre similar ya existe</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">Error al actualizar el cuaderno "{0}"</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">Error al crear el cuaderno "{0}"</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">El cuaderno "{0}" se actualizó correctamente</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">El cuaderno "{0}" se ha creado correctamente</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/es/azurecore.es.xlf
+++ b/resources/xlf/es/azurecore.es.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">Error al obtener los grupos de recursos para la cuenta {0} ({1}), suscripción {2} ({3}), inquilino {4}: {5}.</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">Error al capturar ubicaciones para la cuenta {0} ({1}), suscripción {2} ({3}), inquilino {4}: {5}.</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">Consulta no válida</target>
@@ -379,7 +383,7 @@
         <target state="translated">SQL Server: Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
         <target state="translated">Hiperescala de PostgreSQL habilitada para Azure Arc</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
@@ -411,7 +415,7 @@
         <target state="translated">Error no identificado con la autenticación de Azure.</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">No se encuentra el inquilino especificado con el id. "{0}".</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,7 +423,7 @@
         <target state="translated">Ha habido algún error problema con la autenticación, o bien los tokens se han eliminado del sistema. Pruebe a volver a agregar la cuenta de Azure Data Studio.</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">Error al recuperar el token. Abra las herramientas de desarrollo para ver el error.</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">No se pudieron obtener las credenciales de la cuenta {0}. Vaya al cuadro de diálogo de las cuentas y actualice la cuenta.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">Las solicitudes de esta cuenta se han acelerado Para volver a intentarlo, seleccione un número menor de suscripciones.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">Se ha producido un error al cargar los recursos de Azure: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Clúster de Azure Data Explorer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/es/big-data-cluster.es.xlf
+++ b/resources/xlf/es/big-data-cluster.es.xlf
@@ -60,6 +60,126 @@
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">Ignorar los errores de verificación SSL en los puntos de conexión del clúster de macrodatos de SQL Server, como HDFS, Spark y Controller, si es true</target>
       </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">Clúster de macrodatos de SQL Server</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">El clúster de macrodatos de SQL Server le permite implementar clústeres escalables de contenedores de SQL Server, Spark y HDFS que se ejecutan en Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versión</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">Destino de implementación</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">Nuevo clúster de Azure Kubernetes Service</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">Clúster de Azure Kubernetes Service existente</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">Clúster Kubernetes existente (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">Clúster de Red Hat OpenShift en Azure existente</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">Clúster de OpenShift existente</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">Configuración del clúster de macrodatos de SQL Server</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">Nombre del clúster</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">Nombre de usuario del controlador</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">Contraseña</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">Confirmar contraseña</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Configuración de Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">Identificador de suscripción</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">Usar mi suscripción predeterminada de Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">Nombre del grupo de recursos</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">Región</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">Nombre del clúster de AKS</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">Tamaño de la máquina virtual</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">Recuento de máquinas virtuales</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">Nombre de la clase de almacenamiento</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">Capacidad para datos (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">Capacidad para registros (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">Acepto {0}, {1} y {2}.</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Declaración de privacidad de Microsoft</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">Términos de licencia de azdata</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">Términos de licencia de SQL Server</target>
+      </trans-unit>
     </body>
   </file>
   <file original="extensions/big-data-cluster/dist/bigDataCluster/utils" source-language="en" datatype="plaintext" target-language="es">

--- a/resources/xlf/es/cms.es.xlf
+++ b/resources/xlf/es/cms.es.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">Cargando...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">Error inesperado al cargar los servidores guardados {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">Cargando...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">El grupo de servidores de administración central ya tiene un servidor registrado con el nombre {0}</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Los servidores de Azure SQL Database no se pueden usar como servidores de administración central.</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Los servidores de Azure SQL no se pueden usar como servidores de administración central.</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/es/dacpac.es.xlf
+++ b/resources/xlf/es/dacpac.es.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="es">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Dacpac</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">Ruta de acceso completa a la carpeta donde. DACPAC y. Los archivos BACPAC se guardan de forma predeterminada</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Servidor de destino</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Servidor de origen</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Base de datos de origen</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Base de datos de destino</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">Ubicación del archivo</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">Seleccionar archivo</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">Resumen de la configuración</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versión</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">Valor de configuración</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">Nombre de la base de datos</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">Actualizar base de datos existente</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">Nueva base de datos</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">{0} de las acciones de implementación enumeradas pueden dar lugar a la pérdida de datos. Asegúrese de que tiene una copia de seguridad o una instantánea por si hay algún problema con la implementación.</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">Continuar a pesar de la posible pérdida de datos</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">Las acciones de implementación enumeradas no darán lugar a la pérdida de datos.</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">Guardar</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">Ubicación del archivo</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">Versión (use x.x.x.x, donde x es un número)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">Implementar un archivo .dacpac de una aplicación de la capa de datos en una instancia de SQL Server [Implementar Dacpac]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">Exportar el esquema y los datos de una base de datos al formato de archivo lógico .bacpac [Exportar Bacpac]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">Nombre de la base de datos</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">Actualizar base de datos existente</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">Nueva base de datos</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Base de datos de destino</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">Servidor de destino</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">Servidor de origen</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">Base de datos de origen</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Versión</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">Valor de configuración</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">predeterminado</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">Asistente para importar aplicaciones de capa de datos</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">Generar script</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">Puede ver el estado de la generación de scripts en la vista de tareas una vez que se cierra el asistente. El script generado se abrirá cuando se complete.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">predeterminado</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">Implementar operaciones de plan</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">Ya existe una base de datos con el mismo nombre en la instancia del servidor SQL</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">Nombre sin definir</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">El nombre del archivo no puede terminar con un punto.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">El nombre de archivo no puede ser un espacio en blanco.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">Caracteres de archivo no válidos</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">El nombre de este archivo está reservado para Windows. Elija otro nombre e inténtelo de nuevo.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">Nombre de archivo reservado. Elija otro nombre y vuelva a intentarlo</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">El nombre del archivo no puede terminar con un espacio en blanco</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">El nombre de archivo tiene más de 255 caracteres</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
+        <target state="translated">No se pudo generar el plan de implementación, "{0}"</target>
+      </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
         <target state="translated">No se pudo generar el plan de implementación, "{0}"</target>
       </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">Error en la operación ({0}, "{1}")</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">Puede ver el estado de la generación de scripts en la vista de tareas una vez que se cierra el asistente. El script generado se abrirá cuando se complete.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/es/import.es.xlf
+++ b/resources/xlf/es/import.es.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="es">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">Configuración de importación de archivos planos</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[Opcional] Registre la salida de depuración en a la consola (Ver -&gt; Salida) y después seleccione el canal de salida apropiado del menú desplegable</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">{0} iniciado</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">Iniciando {0}</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">No se pudo iniciar {0}: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">Instalando {0} en {1}</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">Instalando servicio {0}</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">{0} instalado</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Descargando {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Descargando {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">Descarga finalizada de {0}</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">Elementos extraídos {0} ({1} de {2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">Ofrecer comentarios</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">el componente de servicio no se pudo iniciar</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">El servidor de la base de datos está en</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">Base de datos en la que se crea la tabla</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">Ubicación de archivo no válida. Inténtelo con otro archivo de entrada</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Examinar</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">Ubicación del archivo para importar</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">Nuevo nombre de la tabla</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">Esquema de tabla</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">Importar datos</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Siguiente</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">Nombre de columna</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">Tipo de datos</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">Clave principal</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">Permitir valores NULL</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">Esta operación analizó la estructura del archivo de entrada para generar la vista previa siguiente para las primeras 50 filas.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">Esta operación no se completó correctamente. Pruebe con un archivo de entrada diferente.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">Información de la importación</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ Ha insertado correctamente los datos en una tabla.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">Esta operación analizó la estructura del archivo de entrada para generar la vista previa siguiente para las primeras 50 filas.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">Esta operación no se completó correctamente. Pruebe con un archivo de entrada diferente.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">Importar datos</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Siguiente</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">Nombre de columna</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">Tipo de datos</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">Clave principal</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">Permitir valores NULL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">El servidor de la base de datos está en</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">Base de datos en la que se crea la tabla</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">Examinar</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">Ubicación del archivo para importar</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">Nuevo nombre de la tabla</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">Esquema de tabla</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="es">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">Por favor, conéctese a un servidor antes de utilizar a este asistente.</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">La extensión de importación de SQL Server no admite este tipo de conexión</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">Importar nuevo archivo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">Ofrecer comentarios</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">el componente de servicio no se pudo iniciar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">Servicio iniciado</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">Iniciando servicio</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">No se pudo iniciar el servicio de importación {0}</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">Instalando servicio {0} en {1}</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">Instalando servicio</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Instalado</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">Descargando {0}</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">Descargando servicio</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">¡Listo!</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/es/notebook.es.xlf
+++ b/resources/xlf/es/notebook.es.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Ruta de acceso local a una instalación de Python preexistente utilizada por Notebooks.</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">No mostrar el mensaje para actualizar Python.</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">La cantidad de tiempo (en minutos) que se debe esperar antes de apagar un servidor después de cerrar todos los cuadernos. (Escriba 0 para no apagar)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Invalide la configuración predeterminada del editor en el editor de Notebook. Los ajustes incluyen el color de fondo, el color de la línea actual y el borde</target>
@@ -49,6 +57,10 @@
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
         <target state="translated">Cuadernos anclados por el usuario para el área de trabajo actual</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,24 +151,24 @@
         <target state="translated">Jupyter Books</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">Guardar libro</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Guardar el libro de Jupyter</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="translated">Libro de confianza</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Confiar en el libro de Jupyter</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">Buscar libro</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Buscar libro de Jupyter</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
         <target state="translated">Cuadernos</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="translated">Libros proporcionados</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">Libros de Jupyter proporcionados</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
@@ -174,17 +186,29 @@
         <source xml:lang="en">Close Jupyter Book</source>
         <target state="translated">Cierre del libro de Jupyter</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="translated">Cierre del cuaderno de Jupyter</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">Cerrar bloc de notas</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">Quitar el bloc de notas</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">Agregar el Bloc de notas</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">Agregar un archivo de Markdown</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
         <target state="translated">Visualización en libros</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="translated">Creación de un libro (versión preliminar)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Crear el libro de Jupyter</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
@@ -263,8 +287,8 @@
         <target state="translated">Seleccionar carpeta</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="translated">Seleccionar libro</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Seleccionar libro de Jupyter</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
@@ -283,40 +307,40 @@
         <target state="translated">Abrir vínculo externo</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="translated">El libro ahora es de confianza en el área de trabajo.</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">El libro de Jupyter ahora es de confianza en el área de trabajo.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="translated">El libro ya se ha marcado como que es de confianza en esta área de trabajo.</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">El libro Jupyter ya está marcado como de confianza en esta área de trabajo.</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="translated">El libro ya no es de confianza en esta área de trabajo.</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">El libro de Jupyter ya no es de confianza en esta área de trabajo</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="translated">El libro ya se ha marcado como que no es de confianza en esta área de trabajo.</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">El libro de Jupyter ya se ha marcado como que no es de confianza en esta área de trabajo.</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="translated">El libro {0} está ahora anclado en el área de trabajo.</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">El libro de Jupyter {0} está ahora anclado en el área de trabajo.</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="translated">El libro {0} ya no está anclado en esta área de trabajo.</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">El libro de Jupyter {0} ya no está anclado en esta área de trabajo.</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="translated">No se pudo encontrar un archivo de tabla de contenido en el libro especificado.</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">No se pudo encontrar un archivo de tabla de contenido en el libro de Jupyter especificado.</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="translated">Actualmente no hay ningún libro seleccionado en viewlet.</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">Actualmente no hay ningún libro de Jupyter seleccionado en viewlet.</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="translated">Seleccionar sección de libro</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Seleccionar sección del libro de Jupyter</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
@@ -339,12 +363,12 @@
         <target state="translated">Falta el archivo de configuración.</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="translated">Error al abrir el libro {0}: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">No se pudo abrir {0} el libro de Jupyter: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="translated">No se pudo leer el libro {0}: {1}.</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">No se pudo leer el libro de {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
@@ -363,8 +387,8 @@
         <target state="translated">Error al abrir el vínculo {0}: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="translated">Error al cerrar el libro {0}: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">No se pudo cerrar {0} el libro de Jupyter: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
@@ -373,12 +397,16 @@
  Se ha cambiado el nombre del archivo a {2} para evitar la pérdida de datos.</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="translated">Error al editar el libro {0}: {1}.</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Error al editar el libro de Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="translated">Error al seleccionar un libro o una sección para editarlo: {0}.</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">Error al seleccionar un libro de Jupyter o una sección para editarlo: {0}.</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">No se pudo encontrar la sección {0} en {1}.</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
@@ -393,8 +421,8 @@
         <target state="translated">Ubicación</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="translated">Agregar libro remoto</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">Adición de libro de Jupyter remoto</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
@@ -409,8 +437,8 @@
         <target state="translated">Versiones</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="translated">Libro</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter Book</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
@@ -421,8 +449,8 @@
         <target state="translated">Idioma</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="translated">Actualmente no hay ningún libro disponible en el vínculo proporcionado.</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">Actualmente no hay ningún libro de Juypyter disponible en el vínculo proporcionado</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
@@ -445,44 +473,44 @@
         <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="translated">La descarga del libro remoto está en curso.</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">La descarga del libro remoto de Jupyter está en progreso</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="translated">La descarga del libro remoto se ha completado.</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">La descarga del libro remoto de Jupyter se ha completado</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="translated">Error al descargar el libro remoto.</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">Error al descargar el libro de Jupyter remoto</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="translated">Error al descomprimir el libro remoto.</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">Error al descomprimir el libro de Jupyter remoto</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="translated">Error al crear el directorio de libros remotos.</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">Error al crear el directorio de libros de Jupyter remotos</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="translated">Descarga de libro remoto en curso</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">Descargar libro de Jupyter remoto</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
         <target state="translated">No se encuentra el recurso.</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="translated">No se ha encontrado ningún libro.</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">No se ha encontrado ningún libro de Jupyter</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
         <target state="translated">Versiones no encontradas</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="translated">El libro seleccionado no es válido.</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">El libro de Jupyter seleccionado no es válido</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
@@ -492,21 +520,21 @@
         <source xml:lang="en">Downloading to {0}</source>
         <target state="translated">Descarga en {0} en curso</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="translated">Nuevo grupo</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">Nuevo libro de Jupyter (versión preliminar)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="translated">Los grupos se usan para organizar los cuadernos.</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Los libros Jupyter se utilizan para organizar los bloc de notas.</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="translated">Examinar ubicaciones...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">Más información.</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="translated">Seleccionar carpeta de contenido</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">Carpeta de contenido</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
@@ -524,7 +552,7 @@
         <source xml:lang="en">Save location</source>
         <target state="translated">Guardar ubicación</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
         <target state="translated">Carpeta de contenido (opcional)</target>
       </trans-unit>
@@ -533,8 +561,44 @@
         <target state="translated">La ruta de acceso a la carpeta de contenido no existe.</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="translated">La ruta de acceso a la ubicación de guardado no existe.</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">La ruta de acceso a la ubicación no existe.</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">Error al intentar obtener acceso a: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">Nuevo bloc de notas (versión preliminar)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">Nuevo Markdown (versión preliminar)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">Extensión de archivo</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">El archivo ya existe. ¿Está seguro de que desea sobrescribirlo?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Título</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">Nombre de archivo</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">La ruta de acceso a la ubicación no es válida.</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">El archivo {0} ya existe en la carpeta de destino</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">Otra instalación de Python está actualmente en curso. Esperando a que se complete.</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">Las sesiones del cuaderno de Python activas se cerrarán para poder actualizarse. ¿Desea continuar ahora?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">Python {0} ya está disponible en Azure Data Studio. La versión actual de Python (3.6.6) dejará de recibir soporte en diciembre de 2021. ¿Le gustaría actualizar a Python {0} ahora?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">Se instalará Python {0} y reemplazará a Python 3.6.6. Es posible que algunos paquetes ya no sean compatibles con la nueva versión o que sea necesario volver a instalarlos. Se creará un cuaderno para ayudarle a reinstalar todos los paquetes de PIP. ¿Desea continuar con la actualización ahora?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">Error al instalar las dependencias de Notebook: {0}</target>
@@ -603,6 +679,18 @@
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
         <target state="translated">Se ha encontrado un error al obtener la ruta de acceso del usuario de Python: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">No volver a preguntar</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">No se admite la acción {0} para este controlador</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">No se puede abrir el vínculo {0} porque solo se admiten los vínculos HTTP y HTTPS</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">No se puede abrir el vínculo {0} porque solo se admiten vínculos HTTP, HTTPS y File.</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/es/profiler.es.xlf
+++ b/resources/xlf/es/profiler.es.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/es/resource-deployment.es.xlf
+++ b/resources/xlf/es/resource-deployment.es.xlf
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">Ejecutar la imagen de contenedor de SQL Server con Docker</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">Clúster de macrodatos de SQL Server</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">El clúster de macrodatos de SQL Server le permite implementar clústeres escalables de contenedores de SQL Server, Spark y HDFS que se ejecutan en Kubernetes</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">Versión</target>
@@ -45,34 +37,6 @@
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
         <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">Destino de implementación</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">Nuevo clúster de Azure Kubernetes Service</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">Clúster de Azure Kubernetes Service existente</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">Clúster Kubernetes existente (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="translated">Clúster de Red Hat OpenShift en Azure existente</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="translated">Clúster de OpenShift existente</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">Puerto</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">Configuración del clúster de macrodatos de SQL Server</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">Nombre del clúster</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">Nombre de usuario del controlador</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">Contraseña</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">Confirmar contraseña</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Configuración de Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">Identificador de suscripción</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">Usar mi suscripción predeterminada de Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">Nombre del grupo de recursos</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">Región</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">Nombre del clúster de AKS</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">Tamaño de la máquina virtual</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">Recuento de máquinas virtuales</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">Nombre de la clase de almacenamiento</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">Capacidad para datos (GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">Capacidad para registros (GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">SQL Server en Windows</target>
@@ -170,21 +70,9 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">Ejecute SQL Server en Windows y seleccione una versión para comenzar.</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">Acepto {0}, {1} y {2}.</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
         <target state="translated">Declaración de privacidad de Microsoft</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">Términos de licencia de azdata</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">Términos de licencia de SQL Server</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
@@ -485,6 +373,22 @@
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
         <target state="translated">Aceptar CLUF y seleccionar</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">Se requiere la extensión "{0}" para implementar este recurso, ¿desea instalarla ahora?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Instalar</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">Instalando la extensión "{0}"...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">Extensión "{0}" desconocida</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
@@ -1096,10 +1000,6 @@
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">No se ha podido cargar la extensión {0}. Error detectado en la definición de tipo de recurso en package.json, compruebe la consola de depuración para obtener más información.</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">El tipo de recurso {0} no está definido</target>
@@ -2222,13 +2122,13 @@ Seleccione otra suscripción que contenga al menos un servidor.</target>
         <source xml:lang="en">Deployment pre-requisites</source>
         <target state="translated">Requisitos previos de la implementación</target>
       </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="translated">Para continuar, debe aceptar los términos del Contrato de licencia para el usuario final (CLUF).</target>
-      </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
         <target state="translated">Hay algunas herramientas que no se han detectado. Asegúrese de que estén instaladas, se estén ejecutando y se puedan detectar.</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">Para continuar, debe aceptar los términos del Contrato de licencia para el usuario final (CLUF).</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
@@ -2378,6 +2278,10 @@ Seleccione otra suscripción que contenga al menos un servidor.</target>
         <source xml:lang="en">Azure Data CLI</source>
         <target state="translated">CLI de datos de Azure</target>
       </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">La extensión CLI de datos de Azure debe estar instalada para implementar este recurso. Instálela a través de la galería de extensiones y vuelva a intentarlo.</target>
+      </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
         <target state="translated">Error al recuperar la información de la versión. Consulte el canal de salida "{0}" para obtener más detalles.</target>
@@ -2385,46 +2289,6 @@ Seleccione otra suscripción que contenga al menos un servidor.</target>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
         <target state="translated">Error al recuperar la información de la versión. {0}Se ha recibido una salida no válida; salida del comando GET de la versión: "{1}". </target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="translated">Se está eliminando el archivo Azdata.msi descargado anteriormente, si existe...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="translated">Se está descargando Azdata.msi e instalando azdata-cli...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="translated">Se muestra el registro de la instalación...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="translated">Se está accediendo al repositorio de brew para azdata-cli...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="translated">Se está actualizando el repositorio de brew para la instalación de azdata-cli...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="translated">Se está instalando azdata...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="translated">Se está actualizando la información del repositorio...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="translated">Se están obteniendo los paquetes necesarios para la instalación de azdata...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="translated">Se está descargando e instalando la clave de firma para azdata...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="translated">Se está agregando la información del repositorio de azdata...</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/es/schema-compare.es.xlf
+++ b/resources/xlf/es/schema-compare.es.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">Aceptar</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Origen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">Destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">Archivo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">Archivo de aplicación de capa de datos (.dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de datos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">Servidor</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de datos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">Comparación de esquemas</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Se ha seleccionado un esquema de origen diferente. ¿Comparar para ver la comparación?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Se ha seleccionado un esquema de destino diferente. ¿Comparar para ver la comparación?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">Se han seleccionado diferentes esquemas de origen y destino. ¿Comparar para ver la comparación?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">Archivo de código fuente</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">Archivo de destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Base de datos de origen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Base de datos de destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Servidor de origen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Servidor de destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">predeterminado</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">Seleccionar archivo de origen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">Selección del archivo de destino</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">Restablecer</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">Incluir tipos de objeto</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">Comparar detalles</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">¿Seguro de que desea actualizar el destino?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">Presione Comparar para actualizar la comparación.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">Generar script para implementar cambios en el destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">No hay cambios en el script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">Aplicar cambios al objetivo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">No hay cambios que aplicar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">Tenga en cuenta que las operaciones de inclusión o exclusión pueden tardar unos instantes en calcular las dependencias afectadas</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Eliminar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">Cambiar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">Agregar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">Comparación entre el origen y el destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">Iniciando comparación. Esto podría tardar un momento.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">Para comparar dos esquemas, seleccione primero un esquema de origen y un esquema de destino y, a continuación, presione Comparar.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">No se encontraron diferencias de esquema.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">Nombre de origen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">Incluir</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Acción</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">Nombre de destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">La generación de script se habilita cuando el destino es una base de datos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">Aplicar está habilitado cuando el objetivo es una base de datos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">No se puede excluir {0}. Existen dependientes incluidos, como {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">No se puede incluir {0}. Existen dependientes excluidos, como {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">No se pueden excluir {0}. Existen dependientes incluidos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">No se puede incluir {0}. Existen dependientes excluidos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">Comparar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Detener</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Generar script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Opciones</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Aplicar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">Intercambiar dirección</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">Intercambiar origen y destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">Seleccionar origen</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">Seleccionar destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">Abrir el archivo .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">Cargue el origen, el destino y las opciones guardadas en un archivo .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">Guardar archivo .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">Guardar origen y destino, opciones y elementos excluidos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">Guardar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">¿Quiere conectar con {0}?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">Seleccionar conexión</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,8 +663,8 @@
         <target state="translated">Roles de base de datos</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
-        <target state="translated">Desencadenadores de base de datos</target>
+        <source xml:lang="en">Database Triggers</source>
+        <target state="translated">Desencadenadores de bases de datos</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
         <source xml:lang="en">Defaults</source>
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">Formatos de archivo externos</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">Flujos externos</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">Trabajos de streaming externos</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">Tablas externas</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">Grupos de archivos</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Archivos</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">Firmas</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">Procedimientos almacenados</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">Claves simétricas</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">Especifica si hay que ignorar las diferencias en el orden de columnas de una tabla o bien hay que actualizarlas al publicar en una base de datos.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Origen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">Archivo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">Archivo de aplicación de capa de datos (.dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de datos</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">Servidor</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de datos</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">Sin conexiones activas</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Comparación de esquemas</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Se ha seleccionado un esquema de origen diferente. ¿Comparar para ver la comparación?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Se ha seleccionado un esquema de destino diferente. ¿Comparar para ver la comparación?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">Se han seleccionado diferentes esquemas de origen y destino. ¿Comparar para ver la comparación?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">predeterminado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">Comparar detalles</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">¿Seguro de que desea actualizar el destino?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">Presione Comparar para actualizar la comparación.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">Generar script para implementar cambios en el destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">No hay cambios en el script</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">Aplicar cambios al objetivo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">No hay cambios que aplicar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Eliminar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">Cambiar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">Agregar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Comparación de esquemas</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Origen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">Iniciando comparación. Esto podría tardar un momento.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">Para comparar dos esquemas, seleccione primero un esquema de origen y un esquema de destino y, a continuación, presione Comparar.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">No se encontraron diferencias de esquema.</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">Error en la comparación de esquemas: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">Nombre de origen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">Incluir</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Acción</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">Nombre de destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">La generación de script se habilita cuando el destino es una base de datos</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">Aplicar está habilitado cuando el objetivo es una base de datos</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Comparar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Comparar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Detener</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Detener</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">Error al guardar scmp: "{0}"</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">Error al cancelar la comparación de esquemas: "{0}"</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Generar script</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">Error al generar el script "{0}"</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opciones</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opciones</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Aplicar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">Error en la aplicación de comparación de esquemas "0"</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">Intercambiar dirección</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">Intercambiar origen y destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">Seleccionar origen</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">Seleccionar destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">Abrir el archivo .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">Cargue el origen, el destino y las opciones guardadas en un archivo .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">Error al abrir el scmp "{0}"</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">Guardar archivo .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">Guardar origen y destino, opciones y elementos excluidos</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">Guardar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">Error al guardar scmp: "{0}"</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/es/sql.es.xlf
+++ b/resources/xlf/es/sql.es.xlf
@@ -1,2559 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">No se admite la copia de imágenes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">Introducción</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">Ver introducción</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">I&amp;&amp;ntroducción</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">Historial de consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">Si la captura del historial de consultas está habilitada. De no ser así, las consultas ejecutadas no se capturarán.</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Vista</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Historial de consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">Historial de consultas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">Conectando: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">Ejecutando comando: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">Abriendo nueva consulta: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">No se puede conectar ya que no se proporcionó información del servidor</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">No se pudo abrir la dirección URL debido a un error {0}</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">Esto se conectará al servidor {0}</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">¿Seguro que desea conectarse?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">&amp;&amp;Abrir</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">Conectando con el archivo de consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">1 o más tareas están en curso. ¿Seguro que desea salir?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">Las características en versión preliminar mejoran la experiencia en Azure Data Studio, ya que ofrecen acceso completo a nuevas funciones y mejoras. Puede obtener más información sobre las características en versión preliminar [aquí]({0}). ¿Quiere habilitar las características en versión preliminar?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">Sí (opción recomendada)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">No, no volver a mostrar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">Alternar el historial de consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Eliminar</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">Borrar todo el historial</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">Abrir consulta</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Ejecutar consulta</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">Alternar la captura del historial de consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">Pausar la captura del historial de consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">Iniciar la captura del historial de consultas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">No hay consultas que mostrar.</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">Historial de consultas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Error</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Advertencia</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">Información</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">Omitir</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">El guardado de resultados en diferentes formatos se ha deshabilitado para este proveedor de datos.</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">No se pueden serializar datos ya que no se ha registrado ningún proveedor</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">Error desconocido en la serialización</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">Se necesita la conexión para interactuar con el servicio de administración</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Ningún controlador registrado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">Seleccione un archivo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">Para interactuar con el servicio de evaluación, se necesita una conexión.</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">No hay ningún controlador registrado.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">Cuadrícula y mensajes de resultados</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">Controla la familia de fuentes.</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">Controla el grosor de la fuente.</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">Controla el tamaño de fuente en píxeles.</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">Controla el espacio entre letras en píxeles.</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">Controla la altura de la fila en píxeles</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">Controla el relleno de la celda en píxeles</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">Redimensione automáticamente el ancho de las columnas en los resultados iniciales. Podría tener problemas de rendimiento si hay muchas columnas o las celdas son grandes.</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">El máximo ancho en píxeles de las columnas de tamaño automático</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Vista</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">Conexiones de base de datos</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">Conexiones de fuentes de datos</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">grupos de origen de datos</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">Configuración de inicio</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">True para que la vista de servidores aparezca en la apertura predeterminada de Azure Data Studio; false si quiere aparezca la última vista abierta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">Características en versión preliminar</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">Habilitar las características de la versión preliminar sin publicar</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">Mostrar diálogo de conexión al inicio</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">Notificación de API obsoleta</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">Activar/desactivar la notificación de uso de API obsoleta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">Problemas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} tareas en curso</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Vista</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">Tareas</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Tareas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">Número máximo de conexiones usadas recientemente que se van a almacenar en la lista de conexiones.</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">Motor de SQL predeterminado para usar. Esto indica el proveedor de lenguaje predeterminado en los archivos .sql y los valores por defecto que se usarán al crear una nueva conexión.</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">Intente analizar el contenido del portapapeles cuando se abre el cuadro de diálogo de conexión o se realiza un pegado.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">Paleta de colores del grupo de servidores utilizada en el viewlet del Explorador de objetos.</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">Expanda automáticamente los grupos de servidores en el viewlet del Explorador de Objetos.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(Versión preliminar) Use el nuevo árbol de servidores asincrónicos para la vista Servidores y el cuadro de diálogo Conexión, con compatibilidad con nuevas características como el filtrado de nodos dinámicos.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">Identificador del tipo de cuenta</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(Opcional) El icono que se usa para representar la cuenta en la IU. Una ruta de acceso al archivo o una configuración con temas</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Ruta del icono cuando se usa un tema ligero</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Ruta de icono cuando se usa un tema oscuro</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">Aporta iconos al proveedor de la cuenta.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">Mostrar panel de edición de datos de SQL al iniciar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Valor mínimo del eje y</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Valor máximo del eje y</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Etiqueta para el eje y</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">Valor mínimo del eje x</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">Valor máximo del eje x</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">Etiqueta para el eje x</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visor de recursos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">Indica la propiedad de datos de un conjunto de datos para un gráfico.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">Para cada columna de un conjunto de resultados, muestra el valor de la fila 0 como un recuento seguido del nombre de la columna. Admite "1 Healthy", "3 Unhealthy", por ejemplo, donde "Healthy" es el nombre de la columna y 1 es el valor de la fila 1, celda 1</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">Muestra los resultados en una tabla simple</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">Muestra una imagen, por ejemplo uno devuelta por una consulta R con ggplot2</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">¿Qué formato se espera: es un archivo JPEG, PNG u otro formato?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">¿Está codificado como hexadecimal, base64 o algún otro formato?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Administrar</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Panel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">La vista web que se mostrará en esta pestaña.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">El control host que se mostrará en esta pestaña.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">La lista de widgets que se muestra en esta pestaña.</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">La lista de widgets que se espera dentro del contenedor de widgets para la extensión.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">La lista de widgets o vistas web que se muestran en esta pestaña.</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">Se esperan widgets o vistas web en el contenedor de widgets para la extensión.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">Identificador único para este contenedor.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">El contenedor que se mostrará en la pestaña.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">Contribuye con uno o varios contenedores de paneles para que los usuarios los agreguen a su propio panel.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">No se ha especificado ningún identificador en el contenedor de paneles para la extensión.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">No se ha especificado ningún contenedor en el contenedor de paneles para la extensión.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Debe definirse exactamente 1 contenedor de paneles por espacio.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">Tipo de contenedor desconocido definido en el contenedor de paneles para la extensión.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificador único para esta sección de navegación. Se pasará a la extensión de las solicitudes.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(opcional) Icono que se utiliza para representar esta sección de navegación en la IU. Una ruta de acceso al archivo o una configuración con temas</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Ruta del icono cuando se usa un tema ligero</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Ruta de icono cuando se usa un tema oscuro</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">Título de la sección de navegación para mostrar al usuario.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">El contenedor que se mostrará en esta sección de navegación.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">La lista de contenedores de paneles que se mostrará en esta sección de navegación.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">No hay título en la sección de navegación especificada para la extensión.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">No hay contenedor en la sección de navegación especificada para la extensión.</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Debe definirse exactamente 1 contenedor de paneles por espacio.</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION en NAV_SECTION es un contenedor no válido para la extensión.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">La vista respaldada por el modelo que se visualiza en esta pestaña.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Copia de seguridad</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">Abrir en Azure Portal</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">desconectado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">No se puede expandir porque no se encontró el proveedor de conexiones necesario "{0}"</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">Cancelado por el usuario</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">Diálogo de firewall cancelado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">Se necesita conexión para interactuar con JobManagementService</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">No hay ningún controlador registrado.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">Se ha producido un error al cargar el explorador de archivos.</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">Error del explorador de archivos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">Identificador común para el proveedor</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">Nombre para mostrar del proveedor</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">Alias de kernel del cuaderno para el proveedor</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">Ruta de acceso al icono para el tipo de servidor</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">Opciones para la conexión</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificador único para esta pestaña. Se pasará a la extensión para cualquier solicitud.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">Título de la pestaña para mostrar al usuario.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">Descripción de esta pestaña que se mostrará al usuario.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Condición que se debe cumplir para mostrar este elemento</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">Define los tipos de conexión con los que esta pestaña es compatible. El valor predeterminado es "MSSQL" si no se establece</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">El contenedor que se mostrará en esta pestaña.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">Si esta pestaña se debe mostrar siempre, o sólo cuando el usuario la agrega.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">Si esta pestaña se debe usar o no como la pestaña Inicio para un tipo de conexión.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">Id. único del grupo al que pertenece esta pestaña; valor para el grupo de inicio: Inicio.</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Opcional) Icono que se utiliza para representar esta pestaña en la interfaz de usuario; puede ser una ruta de acceso al archivo o una configuración con temas.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Ruta del icono cuando se usa un tema ligero</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Ruta de icono cuando se usa un tema oscuro</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">Aporta una o varias pestañas que los usuarios pueden agregar a su panel.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">No se ha especificado ningún título para la extensión.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">No se ha especificado ninguna descripción para mostrar.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">No se ha especificado ningún contenedor para la extensión.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">Debe definirse exactamente 1 contenedor de paneles por espacio</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">Identificador único para este grupo de pestañas.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">Título del grupo de pestañas.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">Aporta uno o varios grupos de pestañas que los usuarios pueden agregar a su panel.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">No se ha especificado ningún id. para el grupo de pestañas.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">No se ha especificado ningún título para el grupo de pestañas.</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">Administración</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">Supervisión</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">Rendimiento</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">Seguridad</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">Solución de problemas</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Configuración</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">pestaña de bases de datos</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">Bases de datos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">se realizó correctamente</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">error</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">Error de conexión</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">Error en la conexión debido a un error de Kerberos.</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">La ayuda para configurar Kerberos está disponible en {0}</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">Si se ha conectado anteriormente puede que necesite volver a ejecutar kinit.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Cerrar</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">Adición de cuenta en curso...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">El usuario canceló la actualización de la cuenta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">Resultados de consultas</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor de consultas</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nueva consulta</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor de Power Query</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">Si es "true", los encabezados de columna se incluirán al guardar los resultados como CSV.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">Delimitador personalizado para usar entre los valores al guardar como CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">Caracteres que se usan para separar las filas al guardar los resultados como CSV.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">Carácter que se usa para delimitar los campos de texto al guardar los resultados como CSV.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">Codificación de archivo empleada al guardar los resultados como CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">Si es "true", se dará formato a la salida XML al guardar los resultados como XML.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">Codificación de archivo empleada al guardar los resultados como XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">Permitir streaming de resultados; contiene algunos defectos visuales menores</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">Opciones de configuración para copiar los resultados de la vista de resultados.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">Opciones de configuración para copiar los resultados de varias líneas de la vista de resultados.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(Experimental) Use una tabla optimizada en los resultados. Es posible que falten algunas funciones porque todavía estén en desarrollo.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">Indica si debe mostrarse el tiempo de ejecución para los lotes individuales.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">Mensajes de ajuste automático de línea</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">Tipo de gráfico predeterminado para usar al abrir el visor de gráficos a partir de los resultados de una consulta</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">Se deshabilitará el coloreado de las pestañas</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">El borde superior de cada pestaña del editor se coloreará para que coincida con el grupo de servidores correspondiente</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">El color de fondo de la pestaña del editor coincidirá con el grupo de servidores pertinente</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">Controla cómo colorear las pestañas basadas en el grupo de servidores de la conexión activa</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">Controla si se muestra la información de conexión para una pestaña en el título.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">Solicitud para guardar los archivos SQL generados</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">Establece el enlace de teclado workbench.action.query.shortcut{0} para ejecutar el texto del acceso directo como un procedimiento almacenado. Cualquier texto seleccionado en el editor de consultas se pasará como un parámetro.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">Especifica plantillas de vista</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">Especifica plantillas de sesión</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Filtros de Profiler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script como crear</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script como borrar</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Seleccionar el top 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script como ejecutar</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script como modificar</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Editar datos</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Seleccionar el top 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Take 10</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script como crear</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script como ejecutar</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script como modificar</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script como borrar</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">Error al confirmar una fila: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">La consulta comenzó a ejecutarse a las </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">Comenzó a ejecutar la consulta "{0}"</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">Línea {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">Error al cancelar la consulta: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">Error en la actualización de la celda: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">No se pasó ninguna URI al crear el administrador de cuadernos</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">El proveedor de cuadernos no existe</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Editor de Notebook</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nuevo Notebook</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nuevo Notebook</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">Establecer área de trabajo y abrir</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">Kernel SQL: detenga la ejecución del Notebook cuando se produzca un error en una celda.</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(Versión preliminar) Consulte todos los kernel del proveedor del cuaderno actual.</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">Permita a los cuadernos ejecutar comandos de Azure Data Studio.</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">Habilitar doble clic para editar las celdas de texto en los cuadernos</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">Establecer modo de vista texto enriquecido de forma predeterminada para las celdas de texto</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(Versión preliminar) Guarde el nombre de la conexión en los metadatos del cuaderno.</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">Controla la altura de línea utilizada en la vista previa de Markdown del cuaderno. Este número es relativo al tamaño de la fuente.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Ver</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">Búsqueda de cuadernos</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">Configure patrones globales para excluir archivos y carpetas en búsquedas de texto completo y abrir los patrones de uso rápido. Hereda todos los patrones globales de la configuración "#files.exclude". Lea más acerca de los patrones globales [aquí](https://code.visualstudio.com/docs/editor/codebasics-_advanced-search-options).</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">El patrón global con el que se harán coincidir las rutas de acceso de los archivos. Establézcalo en true o false para habilitarlo o deshabilitarlo.</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">Comprobación adicional de los elementos del mismo nivel de un archivo coincidente. Use $(nombreBase) como variable para el nombre de archivo que coincide.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">Esta opción están en desuso y ahora se utiliza "search.usePCRE2".</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">En desuso. Considere la utilización de "search.usePCRE2" para admitir la característica de expresiones regulares avanzadas.</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">Cuando está habilitado, el proceso de servicio de búsqueda se mantendrá habilitado en lugar de cerrarse después de una hora de inactividad. Esto mantendrá la caché de búsqueda de archivos en la memoria.</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Controla si se deben usar los archivos ".gitignore" e ".ignore" al buscar archivos.</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Controla si deben usarse archivos ".ignore" y ".gitignore" globables cuando se buscan archivos.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">Indica si se incluyen resultados de una búsqueda global de símbolos en los resultados de archivos de Quick Open.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">Indica si se incluyen resultados de archivos abiertos recientemente en los resultados de archivos de Quick Open.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">Las entradas de historial se ordenan por pertinencia en función del valor de filtro utilizado. Las entradas más pertinentes aparecen primero.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">Las entradas de historial se ordenan por uso reciente. Las entradas abiertas más recientemente aparecen primero.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">Controla el orden de clasificación del historial del editor en apertura rápida al filtrar.</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">Controla si debe seguir enlaces simbólicos durante la búsqueda.</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">Buscar sin distinción de mayúsculas y minúsculas si el patrón es todo en minúsculas; de lo contrario, buscar con distinción de mayúsculas y minúsculas.</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">Controla si la vista de búsqueda debe leer o modificar el portapapeles de búsqueda compartido en macOS.</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">Controla si la búsqueda se muestra como una vista en la barra lateral o como un panel en el área de paneles para disponer de más espacio horizontal.</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">Esta configuración está en desuso. Utilice el menú contextual de la vista de búsqueda en su lugar.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">Los archivos con menos de 10 resultados se expanden. El resto están colapsados.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">Controla si los resultados de la búsqueda estarán contraídos o expandidos.</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">Controla si debe abrirse la vista previa de reemplazo cuando se selecciona o reemplaza una coincidencia.</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">Controla si deben mostrarse los números de línea en los resultados de la búsqueda.</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">Si se utiliza el motor de expresión regular PCRE2 en la búsqueda de texto. Esto permite utilizar algunas características avanzadas de regex como la búsqueda anticipada y las referencias inversas. Sin embargo, no todas las características de PCRE2 son compatibles: solo las características que también admite JavaScript.</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">En desuso. Se usará PCRE2 automáticamente al utilizar características de regex que solo se admiten en PCRE2.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">Posicione el actionbar a la derecha cuando la vista de búsqueda es estrecha, e inmediatamente después del contenido cuando la vista de búsqueda es amplia.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">Posicionar siempre el actionbar a la derecha.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">Controla el posicionamiento de la actionbar en las filas en la vista de búsqueda.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">Busque todos los archivos a medida que escribe.</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">Habilite la búsqueda de propagación a partir de la palabra más cercana al cursor cuando el editor activo no tiene ninguna selección.</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">Actualiza la consulta de búsqueda del área de trabajo al texto seleccionado del editor al enfocar la vista de búsqueda. Esto ocurre al hacer clic o al desencadenar el comando "workbench.views.search.focus".</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">Cuando '#search.searchOnType' está habilitado, controla el tiempo de espera en milisegundos entre un carácter que se escribe y el inicio de la búsqueda. No tiene ningún efecto cuando 'search.searchOnType' está deshabilitado.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">Al hacer doble clic, se selecciona la palabra bajo el cursor.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">Al hacer doble clic, se abre el resultado en el grupo de editor activo.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">Al hacer doble clic se abre el resultado en el grupo del editor a un lado, creando uno si aún no existe.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">Configure el efecto de hacer doble clic en un resultado en un editor de búsqueda.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">Los resultados se ordenan por nombre de carpeta y archivo, en orden alfabético.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">Los resultados estan ordenados alfabéticamente por nombres de archivo, ignorando el orden de las carpetas.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">Los resultados se ordenan por extensiones de archivo, en orden alfabético.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">Los resultados se ordenan por la última fecha de modificación del archivo, en orden descendente.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">Los resultados se ordenan de forma descendente por conteo de archivos.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">Los resultados se ordenan por recuento por archivo, en orden ascendente.</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">Controla el orden de los resultados de búsqueda.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nueva consulta</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Ejecutar</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">Explicar</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">Real</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Cambiar conexión</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Conectar</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">Habilitar SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">Desactivar SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">Seleccionar la base de datos</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">No se pudo cambiar la base de datos</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">No se pudo cambiar de base de datos {0}</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">Exportación como cuaderno</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Cerrar</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Acción</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">Copiar detalles</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">Agregar grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">Editar grupo de servidores</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">Extensión</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">Error al crear la sesión del Explorador de objetos</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">Varios errores:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Error al agregar la cuenta</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">Error de la regla de firewall</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">Algunas de las extensiones cargadas utilizan API obsoletas, consulte la información detallada en la pestaña Consola de la ventana Herramientas de desarrollo</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">No mostrar de nuevo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">Identificador de la vista. Úselo para registrar un proveedor de datos mediante la API "vscode.window.registerTreeDataProviderForView". También para desencadenar la activación de su extensión al registrar el evento "onView:${id}" en "activationEvents".</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Nombre de la vista en lenguaje natural. Se mostrará</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">Condición que se debe cumplir para mostrar esta vista</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">Aporta vistas al editor</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">Aporta vistas al contenedor del Explorador de datos en la barra de la actividad</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">Contribuye vistas al contenedor de vistas aportadas</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">No pueden registrar múltiples vistas con el mismo identificador "{0}" en el contenedor de vistas "{1}"</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">Una vista con el identificador "{0}" ya está registrada en el contenedor de vista "{1}"</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">Las vistas deben ser una matriz</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">la propiedad "{0}" es obligatoria y debe ser de tipo "string"</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">la propiedad "{0}" se puede omitir o debe ser de tipo "string"</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">{0} se ha reemplazado por {1} en la configuración de usuario.</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">{0} se ha reemplazado por {1} en la configuración del área de trabajo.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Administrar</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Mostrar detalles</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">Más información</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">Borrar todas las cuentas guardadas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">Alternar tareas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">Estado de conexión</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">Nombre de usuario visible para el proveedor de árbol</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">Id. del proveedor; debe ser el mismo que al registrar el proveedor de datos del árbol y debe empezar por "connectionDialog/".</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">Muestra los resultados de una consulta como un gráfico en el panel de información</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">Asigne "nombre de columna" -&gt; color. Por ejemplo, agregue "column1": red para asegurarse de que esta utilice un color rojo </target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">Indica la posición y visibilidad preferidas de la leyenda del gráfico. Estos son los nombres de columna de la consulta y se asignan a la etiqueta de cada entrada de gráfico</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">Si dataDirection es horizontal, al establecerlo como verdadero se utilizarán los valores de las primeras columnas para la leyenda.</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">Si dataDirection es vertical, al configurarlo como verdadero se utilizarán los nombres de columna para la leyenda.</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">Define si los datos se leen desde una columna (vertical) o una fila (horizontal). Para series de tiempo esto se omite, ya que la dirección debe ser vertical.</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">Si se establece showTopNData, se mostrarán solo los primeros N datos en la tabla.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilizado en los paneles</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostrar acciones</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visor de recursos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">Identificador del recurso.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Nombre de la vista en lenguaje natural. Se mostrará</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">Ruta de acceso al icono del recurso.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">Aporta recursos a la vista de recursos.</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">la propiedad "{0}" es obligatoria y debe ser de tipo "string"</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">la propiedad "{0}" se puede omitir o debe ser de tipo "string"</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">Árbol del visor de recursos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilizado en los paneles</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilizado en los paneles</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilizado en los paneles</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Condición que se debe cumplir para mostrar este elemento</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">Indica se oculta el encabezado del widget; el valor predeterminado es "false".</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">El título del contenedor</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">La fila del componente en la cuadrícula</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">El intervalo de fila del componente en la cuadrícula. El valor predeterminado es 1. Use "*" para establecer el número de filas en la cuadrícula.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">La columna del componente en la cuadrícula</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">El colspan del componente en la cuadrícula. El valor predeterminado es 1. Use "*" para definir el número de columnas en la cuadrícula.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificador único para esta pestaña. Se pasará a la extensión para cualquier solicitud.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">La pestaña de extensión es desconocida o no está instalada.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Activar o desactivar el widget de propiedades</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valores de la propiedad para mostrar</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nombre para mostrar de la propiedad</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">Valor en el objeto de la información de la base de datos</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">Especificar valores específicos para ignorar</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">Modelo de recuperación</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">Última copia de seguridad de la base de datos</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">Última copia de seguridad de registros</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">Nivel de compatibilidad</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Propietario</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">Personaliza la página del panel de base de datos</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Búsqueda</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">Personaliza las pestañas de consola de base de datos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Activar o desactivar el widget de propiedades</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valores de la propiedad para mostrar</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nombre para mostrar de la propiedad</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">Valor en el objeto de información de servidor</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Versión</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">Edición</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">Nombre del equipo</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">Versión del sistema operativo</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Búsqueda</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">Personaliza la página del panel de servidor</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">Personaliza las pestañas del panel de servidor</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Administrar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">la propiedad "icon" puede omitirse o debe ser una cadena o un literal como "{dark, light}"</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">Añade un widget que puede consultar un servidor o base de datos y mostrar los resultados de múltiples maneras, como un gráfico o una cuenta de resumen, entre otras.</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">Identificador único utilizado para almacenar en caché los resultados de la información.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">Consulta SQL para ejecutar. Esto debería devolver exactamente un conjunto de resultados.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[Opcional] Ruta de acceso a un archivo que contiene una consulta. Utilícelo si "query" no está establecido</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[Opcional] Intervalo de actualización automática en minutos, si no se establece, no habrá actualización automática</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">Acciones para utilizar</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Base de datos de destino para la acción; puede usar el formato "${ columnName }" para usar un nombre de columna controlado por datos.</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Servidor de destino para la acción; puede usar el formato "${ columnName }" para usar un nombre de columna controlado por datos.</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Usuario de destino para la acción; puede usar el formato "${ columnName }" para usar un nombre de columna controlado por datos.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">Identificador de la información</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">Aporta conocimientos a la paleta del panel.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">Debe habilitar las características en versión preliminar para utilizar la copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">No se admite el comando de copia de seguridad para bases de datos de Azure SQL.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">No se admite el comando de copia de seguridad en el contexto del servidor. Seleccione una base de datos y vuelva a intentarlo.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">Debe habilitar las características en versión preliminar para utilizar la restauración</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">No se admite el comando de restauración para bases de datos de Azure SQL.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Mostrar recomendaciones</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">Instalar extensiones</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">Crear una extensión...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">Error al conectar la sesión de edición de datos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">Abrir extensiones de panel</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">No hay extensiones de panel instaladas en este momento. Vaya al Administrador de extensiones para explorar las extensiones recomendadas.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">Ruta seleccionada</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">Archivos de tipo</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Descartar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">No se pasó ningún perfil de conexión al control flotante de información</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">Error de Insights</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">Error al leer el archivo de consulta: </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">Error al analizar la configuración de la conclusión; no se pudo encontrar la matriz/cadena de consulta o el archivo de consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Cuenta de Azure</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Inquilino de Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">Mostrar conexiones</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Servidores</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Conexiones</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">No hay un historial de tareas para mostrar.</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">Historial de tareas</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">Error de la tarea</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">Borrar lista</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">Lista de conexiones recientes borrada</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">¿Está seguro que desea eliminar todas las conexiones de la lista?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Eliminar</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">Obtener la cadena de conexión actual</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">La cadena de conexión no está disponible</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">Ninguna conexión activa disponible</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualizar</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">Editar conexión</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">Nueva conexión</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">Nuevo grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">Editar grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">Mostrar conexiones activas</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">Mostrar todas las conexiones</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexiones recientes</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">Eliminar conexión</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">Eliminar grupo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Ejecutar</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">Eliminar edición con error: </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Detener</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">Mostrar el panel de SQL</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">Cerrar el panel de SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">No conectado</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">La sesión de XEvent Profiler se detuvo inesperadamente en el servidor {0}.</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">Error al iniciar nueva sesión</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">La sesión de XEvent Profiler para {0} tiene eventos perdidos.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Cargando</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Carga completada</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">Grupos de servidores</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">Nombre del grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">Se requiere el nombre del grupo.</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">Descripción del grupo</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">Color del grupo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Error al agregar la cuenta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">Artículo</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">Detalles de la conclusión</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">Propiedad</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">Conclusiones</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">Artículos</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">Detalles del artículo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">No se puede iniciar OAuth automático. Ya hay un OAuth automático en curso.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">Ordenar por evento</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">Ordenar por columna</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">Borrar todo</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Aplicar</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">Filtros</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">Quitar esta cláusula</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">Guardar filtro</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">Cargar filtro</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">Agregar una cláusula</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">Campo</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">Operador</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">Es NULL</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">No es NULL</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">Contiene</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">No contiene</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">Comienza por</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">No comienza por</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Guardar como CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Guardar como JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Guardar como Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Guardar como XML</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copiar con encabezados</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Seleccionar todo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">Define una propiedad para mostrar en el panel</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">Qué valor utilizar como etiqueta de la propiedad</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">Valor en el objeto al que acceder para el valor</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">Especificar los valores que se ignorarán</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">Valor predeterminado para mostrar si se omite o no hay valor</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">Estilo para definir propiedades en un panel</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">Id. del estilo</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">Condición para utilizar este tipo</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">Campo con el que comparar</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">Operador para utilizar en la comparación</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">Valor con el que comparar el campo</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">Propiedades para mostrar por página de base de datos</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">Propiedades para mostrar por página de servidor</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">Define que este proveedor admite el panel de información</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">Id. de proveedor (por ejemplo MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">Valores de las propiedades para mostrar en el panel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">Valor no válido</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2565,435 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">vacío</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">Ocultar etiquetas de texto</target>
       </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">Marque todas las casillas de la columna: {0}</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">Mostrar etiquetas de texto</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">No se ha registrado ninguna vista del árbol con el id. "{0}".</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">Error al inicializar la sesión de edición de datos: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">Identificador del proveedor del cuaderno.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">Extensiones de archivo que deben estar registradas en este proveedor de cuadernos</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">Núcleos que deben ser estándar con este proveedor de cuadernos</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">Aporta proveedores de cuadernos.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">Nombre del magic de celda, como "%%sql".</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">El lenguaje de celda que se usará si este magic de celda se incluye en la celda</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">Objetivo de ejecución opcional indicado por este magic, por ejemplo Spark vs SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">Conjunto opcional de kernels para los que esto es válido, por ejemplo python3, pyspark, sql</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">Aporta el lenguaje del cuaderno.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">La tecla de método abreviado F5 requiere que se seleccione una celda de código. Seleccione una para ejecutar.</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">Para borrar el resultado es necesario seleccionar una celda de código. Seleccione una para ejecutar.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">Máximo de filas:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">Seleccionar vista</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">Seleccionar sesión</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">Seleccionar sesión:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">Seleccionar vista:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Texto</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">Etiqueta</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Detalles</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">Tiempo transcurrido</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">Recuento de filas</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} filas</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">Ejecutando consulta...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">Estado de ejecución</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">Resumen de la selección</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">Promedio: {0}; recuento: {1}; suma: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">Elegir lenguaje SQL</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">Cambiar proveedor de lenguaje SQL</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">Tipo de lenguaje SQL</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">Cambiar el proveedor del motor SQL</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">Existe una conexión mediante el motor {0}. Para cambiar, por favor desconecte o cambie la conexión</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">Ningún editor de texto activo en este momento</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">Seleccionar proveedor de lenguaje</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">Error al mostrar el gráfico de Plotly: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">No se ha encontrado ningún representador de {0} para la salida. Tiene los siguientes tipos MIME: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(seguro) </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Seleccionar el top 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Take 10</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script como ejecutar</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script como modificar</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Editar datos</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script como crear</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script como borrar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">Un NotebookProvider con providerId válido se debe pasar a este método</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">Un NotebookProvider con providerId válido se debe pasar a este método</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">no se encontró ningún proveedor de cuadernos</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">No se encontró ningún administrador</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">La instancia de Notebook Manager para el cuaderno {0} no tiene un administrador de servidores. No se pueden realizar operaciones en él</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">La instancia de Notebook Manager para el cuaderno {0} no tiene un administrador de contenido. No se pueden realizar operaciones en él</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">La instancia de Notebook Manager para el cuaderno {0} no tiene un administrador de sesiones. No se pueden realizar operaciones en él.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">Error al obtener el token de cuenta de Azure para conexión</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">Conexión no aceptada</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">¿Seguro que desea cancelar esta conexión?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">Cerrar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">Cargando kernels...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">Cambiando kernel...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">Adjuntar a </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">Kernel </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">Cargando contextos...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Cambiar conexión</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">Seleccionar conexión</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">Sin kernel</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">Borrar resultados</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">De confianza</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">No de confianza</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">Contraer celdas</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">Expandir celdas</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">Ninguno</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nuevo Notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Buscar cadena siguiente</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Buscar cadena anterior</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">Plan de consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">Paso {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">Debe ser una opción de la lista</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">Seleccionar cuadro</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Conexión</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">Conexión en curso</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">Tipo de conexión</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexiones recientes</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexiones guardadas</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">Detalles de conexión</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Conectar</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexiones recientes</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">Ninguna conexión reciente</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexiones guardadas</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">Ninguna conexión guardada</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">no hay datos disponibles</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">Árbol explorador de archivos</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">Seleccionar o deseleccionar todos</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">De</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">Mostrar filtro</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">A</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Seleccionar todo</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">Crear nueva regla de firewall</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Buscar</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} resultados</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">{0} seleccionado</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">Orden ascendente</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">Orden descendente</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">Aceptar</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">Borrar</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">La dirección IP del cliente no tiene acceso al servidor. Inicie sesión en una cuenta de Azure y cree una regla de firewall para habilitar el acceso.</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">Más información sobre configuración de firewall</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">Regla de firewall</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">Agregar mi IP de cliente </target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">Agregar mi rango IP de subred</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">Opciones de filtro</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">Todos los archivos</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Carga en curso</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">No se pudo encontrar el archivo de consulta en ninguna de las siguientes rutas:
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">Error de carga...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">Debe actualizar las credenciales para esta cuenta.</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">Alternar más</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">Habilitar la comprobación automática de actualizaciones. Azure Data Studio comprobará las actualizaciones de manera automática y periódica.</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">Habilitar para descargar e instalar nuevas versiones de Azure Data Studio en segundo plano en Windows</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">Mostrar notas de la versión después de una actualización. Las notas de la versión se abren en una nueva ventana del explorador web.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">Menú de acción de la barra de herramientas del panel</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">El menú de título de la celda del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">El menú de título del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">Menú de la barra de herramientas del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">Menú de acción del título del contenedor de la vista dataexplorer</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">Menú contextual del elemento dataexplorer</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">Menú contextual del elemento del explorador de objetos</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">Menú contextual del árbol de búsqueda del cuadro de diálogo de conexión</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">Menú contextual del elemento de cuadrícula de datos</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">Establece la directiva de seguridad para descargar extensiones.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">La directiva de extensión no permite instalar extensiones. Cambie la directiva de extensión e inténtelo de nuevo.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">Se ha completado la instalación de la extensión {0} de VSIX. Recargue Azure Data Studio para habilitarla.</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para completar la desinstalación de esta extensión.</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para habilitar la extensión actualizada.</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para habilitar esta extensión localmente.</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para habilitar esta extensión.</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para deshabilitar esta extensión.</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para completar la desinstalación de la extensión {0}.</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para habilitar esta extensión en {0}.</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">Se ha completado la instalación de la extensión {0}. Vuelva a cargar Azure Data Studio para habilitarlo.</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">Vuelva a cargar Azure Data Studio para completar la reinstalación de la extensión {0}.</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Marketplace</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Es necesario proporcionar el tipo de escenario para recibir recomendaciones de extensiones.</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">No se puede instalar la extensión "{0}" debido a que no es compatible con Azure Data Studio "{1}".</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nueva consulta</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Nueva &amp;&amp;consulta</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Nuevo cuaderno</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">Controla la memoria disponible para Azure Data Studio después de reiniciar cuando se intentan abrir archivos grandes. Tiene el mismo efecto que si se especifica "--max-memory=NEWSIZE" en la línea de comandos.</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">¿Desea cambiar el idioma de la interfaz de usuario de Azure Data Studio a {0} y reiniciar?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">Para poder usar Azure Data Studio en {0}, Azure Data Studio debe reiniciarse.</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">Nuevo archivo SQL</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuevo cuaderno</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Instalar extensión desde el paquete VSIX</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">Debe ser una opción de la lista</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">Seleccionar cuadro</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">Mostrar cuadernos</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">Resultados de la búsqueda</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">No se encuentra la ruta de búsqueda: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Cuadernos</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">No se admite la copia de imágenes</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">Centrarse en la consulta actual</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Ejecutar consulta</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">Ejecutar la consulta actual</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">Copiar consulta con resultados</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">La consulta y los resultados se han copiado correctamente.</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">Ejecutar la consulta actual con el plan real</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">Cancelar consulta</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">Actualizar caché de IntelliSense</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">Alternar resultados de la consulta</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">Alternar enfoque entre consulta y resultados</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">El parámetro de editor es necesario para la ejecución de un acceso directo</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">Analizar consulta</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">Comandos completados correctamente</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">Error del comando: </target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">Conéctese a un servidor</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">Ya existe un grupo de servidores con el mismo nombre.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">se realizó correctamente</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">error</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">en curso</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">no iniciado</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">cancelado</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">cancelando</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilizado en los paneles</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">No se puede mostrar el gráfico con los datos proporcionados</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilizado en los paneles</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilizado en los paneles</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilizado en los paneles</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">Error al abrir el vínculo: {0}.</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">Error al ejecutar el comando "{0}": {1}.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Error de copia {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">Mostrar gráfico</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">Mostrar tabla</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Haga doble clic para editar.&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Agregue contenido aquí...&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">Error al actualizar el nodo "{0}"; {1}.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Listo</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Generar script</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Siguiente</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">Anterior</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">Las pestañas no se han inicializado.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated"> se requiere.</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">Entrada no válida. Se espera un valor numérico.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">Ruta del archivo de copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">Base de datos de destino</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Restauración de una base de datos</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de datos</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">Archivo de copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Restauración de una base de datos</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Origen</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">Restaurar de</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">Se requiere la ruta de acceso del archivo de copia de seguridad.</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">Especifique una o más rutas de archivo separadas por comas</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de datos</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">Destino</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">Restaurar en</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">Plan de restauración</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">Grupos de copias de seguridad para restaurar</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">Restaurar archivos de base de datos como</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">Restaurar detalles del archivo de base de datos</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">Nombre lógico del archivo</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">Tipo de archivo</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">Nombre del archivo original</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">Restaurar como</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">Opciones de restauración</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">Copia del final del registro</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">Conexiones del servidor</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">General</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">Archivos</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opciones</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">Copiar celda</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Listo</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">Copiar y abrir</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">Código de usuario</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">Sitio web</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">El índice {0} no es válido.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">Descripción del servidor (opcional)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">Propiedades avanzadas</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Descartar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">nbformat v{0}. {1} no reconocido</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">Este archivo no tiene un formato válido de cuaderno</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">Celda de tipo {0} desconocido</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Tipo de salida {0} no reconocido</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">Se espera que los datos para {0} sean una cadena o una matriz de cadenas</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Tipo de salida {0} no reconocido</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Bienvenida</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Paquete de administración de SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Paquete de administración de SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">El paquete de administración para SQL Server es una colección de populares extensiones de administración de bases de datos para ayudarle a administrar SQL Server.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Escriba y ejecute scripts de PowerShell con el editor de consultas enriquecidas de Azure Data Studio.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">Virtualización de datos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">Virtualice datos con SQL Server 2019 y cree tablas externas por medio de asistentes interactivos.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">Conéctese a bases de datos Postgre, adminístrelas y realice consultas en ellas con Azure Data Studio.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">El soporte para '{0}' ya está instalado.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">La ventana se volverá a cargar después de instalar compatibilidad adicional con {0}.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">Instalando compatibilidad adicional con {0}...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">No se pudo encontrar el soporte para {0} con id {1}.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nueva conexión</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nueva consulta</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Nuevo cuaderno</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Implementar un servidor</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Bienvenida</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">Nuevo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">Abrir...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">Abrir archivo...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">Abrir carpeta...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">Iniciar paseo</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">Cerrar barra del paseo introductorio</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">¿Le gustaría dar un paseo introductorio por Azure Data Studio?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">¡Le damos la bienvenida!</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">Abrir la carpeta {0} con la ruta de acceso {1}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">Instalar</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">Instalar asignación de teclas de {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">Instalar compatibilidad adicional con {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Instalado</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">El mapa de teclas de {0} ya está instalado</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">La compatibilidad con {0} ya está instalada</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Detalles</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">Color de fondo para la página de bienvenida.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">Editor de Profiler para el texto del evento. Solo lectura</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">Error al guardar los resultados. </target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">Selección del archivo de resultados</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (delimitado por comas)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Libro de Excel</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">Texto sin formato</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">Se está guardando el archivo...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">Los resultados se han guardado correctamente en {0}.</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Abrir archivo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">Ocultar etiquetas de texto</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">Mostrar etiquetas de texto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">Editor de código de modelview para modelo de vista.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">Información</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Advertencia</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Error</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Mostrar detalles</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Cerrar</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">Atrás</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">Ocultar detalles</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">Cuentas</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">Cuentas vinculadas</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Cerrar</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">No hay ninguna cuenta vinculada. Agregue una cuenta.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">Agregar una cuenta</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">No tiene ninguna nube habilitada. Vaya a la configuración, busque la configuración de la cuenta de Azure y habilite por lo menos una nube.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">No ha seleccionado ningún proveedor de autenticación. Vuelva a intentarlo.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">La ejecución no se completó debido a un error inesperado: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">Tiempo total de ejecución: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">Comenzó a ejecutar la consulta en la línea {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">Se ha iniciado la ejecución del proceso por lotes ({0}).</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">Tiempo de ejecución por lotes: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Error de copia {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Inicio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nueva conexión</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nueva consulta</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Nuevo cuaderno</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Abrir archivo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Abrir archivo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">Implementar</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">Nueva implementación...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">Reciente</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">Más...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">No hay ninguna carpeta reciente.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Ayuda</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">Introducción</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentación</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">Notificar problema o solicitud de características</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">Repositorio de GitHub</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">Notas de la versión</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Mostrar página principal al inicio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">Personalizar</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensiones</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">Descargue las extensiones que necesite, incluido el paquete de administración de SQL Server y mucho más</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">Métodos abreviados de teclado</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">Encuentre sus comandos favoritos y personalícelos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">Tema de color</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">Modifique a su gusto la apariencia del editor y el código</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">Información</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">Encontrar y ejecutar todos los comandos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">Acceda rápidamente a los comandos y búsquelos desde la paleta de comandos ({0})</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">Descubra las novedades de esta última versión</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">Nuevas entradas del blog mensuales que muestran nuestras nuevas características</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Síganos en Twitter</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">Manténgase al día sobre cómo la comunidad usa Azure Data Studio y hable directamente con los ingenieros.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Conectar</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Inicio</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">Nueva sesión</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">Pausar</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">Reanudar</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Detener</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">Borrar los datos</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">¿Está seguro de que quiere borrar los datos?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">Desplazamiento automático: activado</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">Desplazamiento automático: desactivado</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">Alternar el panel contraído</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">Editar columnas</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Buscar la cadena siguiente</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Buscar la cadena anterior</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Iniciar Profiler</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">Filtrar...</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">Borrar filtro</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">¿Está seguro de que quiere borrar los filtros?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">Eventos (filtrados): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">Eventos: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">Recuento de eventos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">no hay datos disponibles</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">Resultados</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">Mensajes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">No se devolvió ningún script al llamar al script de selección en el objeto </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">Seleccionar</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">Crear</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">Insertar</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">Actualizar</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Eliminar</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">No se devolvió ningún script al escribir como {0} en el objeto {1}</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">Error de scripting</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">No se devolvió ningún script al ejecutar el script como {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">Color de fondo de encabezado de tabla</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">Color de primer plano de encabezado de tabla</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">Color de fondo de lista/tabla para el elemento seleccionado y elemento de enfoque cuando la lista/tabla está activa</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">Color del contorno de una celda.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">Se ha deshabilitado el fondo del cuadro de entrada.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">Se ha deshabilitado el primer plano del cuadro de entrada.</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">Contorno del botón resaltado cuando se enfoca</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">Se ha deshabilitado el primer plano de la casilla.</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">Color de fondo de la tabla del Agente SQL.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">Color de fondo de celda de la tabla del Agente SQL.</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">Color de fondo al mantener el mouse de la tabla del Agente SQL.</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">Color de fondo del encabezado del Agente SQL.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">Color del borde de la celda de la tabla del Agente SQL.</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">Color de error de mensajes de resultados.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">Nombre de copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">Modelo de recuperación</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">Tipo de copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">Archivos de copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">Algoritmo</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">Certificado o clave asimétrica</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">Multimedia</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">Realizar la copia de seguridad sobre el conjunto de medios existente</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">Realizar copia de seguridad en un nuevo conjunto de medios</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">Añadir al conjunto de copia de seguridad existente</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">Sobrescribir todos los conjuntos de copia de seguridad existentes</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">Nuevo nombre de conjunto de medios</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">Nueva descripción del conjunto de medios</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">Realizar la suma de comprobación antes de escribir en los medios</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">Comprobar copia de seguridad cuando haya terminado</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">Seguir en caso de error</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">Expiración</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">Configure los días de conservación de la copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">Copia de seguridad de solo copia</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">Configuración avanzada</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">Compresión</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">Establecer la compresión de copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">Cifrado</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">Registro de transacciones</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">Truncar el registro de transacciones</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">Hacer copia de seguridad de la cola del registro</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">Fiabilidad</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">El nombre del medio es obligatorio</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">No hay certificado o clave asimétrica disponible</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">Agregar un archivo</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">Eliminar archivos</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">Entrada no válida. El valor debe ser igual o mayor que 0.</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">Solo se admite la copia de seguridad en un archivo</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">La ruta del archivo de copia de seguridad es obligatoria</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">El guardado de resultados en diferentes formatos se ha deshabilitado para este proveedor de datos.</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">No se pueden serializar datos ya que no se ha registrado ningún proveedor</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">Error desconocido en la serialización</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">No hay ningún proveedor de datos registrado que pueda proporcionar datos de la vista.</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">Color de fondo de encabezado de tabla</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualizar</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">Color de primer plano de encabezado de tabla</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Contraer todo</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">Color de fondo de lista/tabla para el elemento seleccionado y elemento de enfoque cuando la lista/tabla está activa</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">Error al ejecutar el comando {1}: {0}. Probablemente esté provocado por la extensión que contribuye a {1}.</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">Color del contorno de una celda.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">Se ha deshabilitado el fondo del cuadro de entrada.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">Se ha deshabilitado el primer plano del cuadro de entrada.</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">Contorno del botón resaltado cuando se enfoca</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">Se ha deshabilitado el primer plano de la casilla.</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">Color de fondo de la tabla del Agente SQL.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">Color de fondo de celda de la tabla del Agente SQL.</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">Color de fondo al mantener el mouse de la tabla del Agente SQL.</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">Color de fondo del encabezado del Agente SQL.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">Color del borde de la celda de la tabla del Agente SQL.</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">Color de error de mensajes de resultados.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">Seleccione la celda activa y vuelva a intentarlo</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">Algunas de las extensiones cargadas utilizan API obsoletas, consulte la información detallada en la pestaña Consola de la ventana Herramientas de desarrollo</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">Ejecutar celda</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">Cancelar ejecución</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">Error en la última ejecución. Haga clic para volver a ejecutar</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">No mostrar de nuevo</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">La tarea no se pudo cancelar.</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">Alternar más</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Carga en curso</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">Inicio</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">La sección "{0}" tiene contenido no válido. Póngase en contacto con el propietario de la extensión.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">Trabajos</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Alertas</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">Servidores proxy</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">Operadores</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">Propiedades del servidor</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">Propiedades de la base de datos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">Seleccionar o deseleccionar todos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">Mostrar filtro</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">Aceptar</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">Borrar</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexiones recientes</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Servidores</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Servidores</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">Archivos de copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">Todos los archivos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">Búsqueda: Escriba el término de búsqueda y presione Entrar para buscar o Esc para cancelar</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Buscar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">No se pudo cambiar la base de datos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">Última aparición</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">Retraso entre las respuestas (en segundos)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">Nombre de la categoría</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">Dirección de correo electrónico</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">Nombre de la cuenta</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">Nombre de credencial</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descripción</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">Cargando de los objetos en curso</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">Carga de las bases de datos en curso</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">La carga de los objetos se ha completado.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">La carga de las bases de datos se ha completado.</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">Buscar por nombre de tipo (t:, v:, f: o sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">Buscar en las bases de datos</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">No se pueden cargar objetos</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">No se pueden cargar las bases de datos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">Carga de las propiedades en curso</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">La carga de las propiedades se ha completado.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">No se pueden cargar las propiedades del panel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">Carga de {0} en curso</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">Carga de {0} completada</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">Actualización automática: DESACTIVADA</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">Última actualización: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">No hay resultados para mostrar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Pasos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Guardar como CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Guardar como JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Guardar como Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Guardar como XML</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">La codificación de los resultados no se guardará al realizar la exportación en JSON. Recuerde guardarlos con la codificación deseada una vez que se cree el archivo.</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">El origen de datos de respaldo no admite la opción Guardar en archivo</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copiar con encabezados</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Seleccionar todo</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">Maximizar</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Gráfico</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">Visualizador</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">La tecla de método abreviado F5 requiere que se seleccione una celda de código. Seleccione una para ejecutar.</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">Para borrar el resultado es necesario seleccionar una celda de código. Seleccione una para ejecutar.</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">Id. de paso</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Listo</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">Nombre del paso</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">Mensaje</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Generar script</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Siguiente</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">Anterior</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">Las pestañas no se han inicializado.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Buscar</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">No se ha registrado ninguna vista del árbol con el id. "{0}".</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Buscar</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">Un NotebookProvider con providerId válido se debe pasar a este método</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Coincidencia anterior</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">no se encontró ningún proveedor de cuadernos</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Coincidencia siguiente</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">No se encontró ningún administrador</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">La instancia de Notebook Manager para el cuaderno {0} no tiene un administrador de servidores. No se pueden realizar operaciones en él</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">La instancia de Notebook Manager para el cuaderno {0} no tiene un administrador de contenido. No se pueden realizar operaciones en él</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">La instancia de Notebook Manager para el cuaderno {0} no tiene un administrador de sesiones. No se pueden realizar operaciones en él.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">Un NotebookProvider con providerId válido se debe pasar a este método</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Administrar</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Mostrar detalles</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">Más información</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">Borrar todas las cuentas guardadas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">Características en versión preliminar</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">Habilitar las características de la versión preliminar sin publicar</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">Mostrar diálogo de conexión al inicio</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">Notificación de API obsoleta</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">Activar/desactivar la notificación de uso de API obsoleta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">Error al conectar la sesión de edición de datos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">No conectado</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">La sesión de XEvent Profiler se detuvo inesperadamente en el servidor {0}.</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">Error al iniciar nueva sesión</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">La sesión de XEvent Profiler para {0} tiene eventos perdidos.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar acciones</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visor de recursos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">Información</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Advertencia</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Error</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Mostrar detalles</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">Cerrar</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">La búsqueda ha devuelto un gran número de resultados, se resaltarán solo las primeras 999 coincidencias.</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">Atrás</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} de {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">No hay ningún resultado.</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">Ocultar detalles</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">Barra horizontal</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">Barras</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">Línea</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">Circular</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">Dispersión</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">Serie temporal</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Imagen</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">Recuento</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">Tabla</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">Anillo</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">No se pudieron obtener las filas para el conjunto de datos en el gráfico.</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">No se admite el tipo de gráfico "{0}".</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">Parámetros</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated"> se requiere.</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">Entrada no válida. Se espera un valor numérico.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">Se ha conectado a</target>
-      </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
-        <target state="translated">Desconectado</target>
-      </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">Conexiones sin guardar</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">El índice {0} no es válido.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">Examinar (versión preliminar)</target>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">vacío</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">Escriba aquí para filtrar la lista</target>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">Marque todas las casillas de la columna: {0}</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">Filtrado de conexiones</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">Aplicación de filtro en curso</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">Eliminación del filtro en curso</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">Filtro aplicado</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">Filtro quitado</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexiones guardadas</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexiones guardadas</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">Árbol del explorador de conexiones</target>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar acciones</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Azure Data Studio recomienda esta extensión.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Carga en curso</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Carga completada</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">No volver a mostrar</target>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">Valor no válido</target>
       </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio cuenta con extensiones recomendadas.</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio cuenta con extensiones recomendadas para la visualización de datos.
-Una vez instaladas, podrá seleccionar el icono Visualizador para ver los resultados de las consultas.</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">Instalar todo</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Mostrar recomendaciones</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">Es necesario proporcionar el tipo de escenario para recibir recomendaciones de extensiones.</target>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}. {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">Esta página de características está en versión preliminar. Las características en versión preliminar presentan nuevas funcionalidades que están en proceso de convertirse en parte permanente del producto. Son estables, pero necesitan mejoras de accesibilidad adicionales. Agradeceremos sus comentarios iniciales mientras están en desarrollo.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Cargando</target>
       </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">Versión preliminar</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">Crear una conexión</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">Conéctese a una instancia de una base de datos por medio del cuadro de diálogo de conexión.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">Ejecutar una consulta</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">Interactúe con los datos por medio de un editor de consultas.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">Crear un cuaderno</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">Cree un nuevo cuaderno con un editor de cuadernos nativo.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Implementar un servidor</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">Cree una nueva instancia de un servicio de datos relacionales en la plataforma de su elección.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">Recursos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">Historial</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">Ubicación</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">Mostrar más</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Mostrar página principal al inicio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">Vínculos útiles</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">Introducción</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Descubra las funcionalidades que ofrece Azure Data Studio y aprenda a sacarles el máximo partido.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentación</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">Visite el centro de documentación para acceder a guías de inicio rápido y paso a paso, así como consultar referencias para PowerShell, API, etc.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Información general de Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Introducción a los cuadernos de Azure Data Studio | Datos expuestos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensiones</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">Mostrar todo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">Más información </target>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Carga completada</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">Fecha de creación: </target>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">Editor de código de modelview para modelo de vista.</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Error del Notebook: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">No pudo encontrar el componente para el tipo {0}</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">Error de trabajo: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">No se admite el cambio de tipos de editor en archivos no guardados</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">Anclado</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Seleccionar el top 1000</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">Ejecuciones recientes</target>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Take 10</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">Ejecuciones pasadas</target>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script como ejecutar</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script como modificar</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Editar datos</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script como crear</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script como borrar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">No se devolvió ningún script al llamar al script de selección en el objeto </target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">Seleccionar</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">Crear</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">Insertar</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Eliminar</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">No se devolvió ningún script al escribir como {0} en el objeto {1}</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">Error de scripting</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">No se devolvió ningún script al ejecutar el script como {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
+        <target state="translated">desconectado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
+        <target state="translated">Extensión</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">Color de fondo de la pestaña activa para pestañas verticales</target>
+      </trans-unit>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">Color de los bordes en el panel</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">Color del título del widget de panel</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">Color del subtexto del widget de panel</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">Color de los valores de propiedad que se muestran en el componente de contenedor de propiedades</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">Color de los nombres de la propiedad que se muestran en el componente del contenedor de propiedades</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">Color de sombra del texto de desbordamiento de la barra de herramientas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">Identificador del tipo de cuenta</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(Opcional) El icono que se usa para representar la cuenta en la IU. Una ruta de acceso al archivo o una configuración con temas</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Ruta del icono cuando se usa un tema ligero</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Ruta de icono cuando se usa un tema oscuro</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">Aporta iconos al proveedor de la cuenta.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">Ver reglas aplicables</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">Ver reglas aplicables para {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">Invocar evaluación</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">Invocar evaluación para {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">Exportar como script</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">Ver todas las reglas y obtener más información en GitHub</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">Crear informe en HTML</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">El informe se ha guardado. ¿Quiere abrirlo?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Una vez instaladas, podrá seleccionar el icono Visualizador para ver los result
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">La base de datos {0} es totalmente conforme con los procedimientos recomendados. ¡Buen trabajo!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Gráfico</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">Operación</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">Objeto</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">Costo estimado</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">Coste del subárbol estimado</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">Filas reales</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">Filas estimadas</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">Ejecuciones reales</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">Costo de CPU estimado</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">Costo de E/S estimado</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">Paralelo</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">Reenlaces reales</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">Reenlaces estimados</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">Rebobinados reales</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">Rebobinados estimados</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">Particionado</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">Operaciones principales</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">No se ha encontrado una conexión.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">Agregar conexión</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">Agregar una cuenta...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Predeterminado&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Cargando...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">Grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Predeterminado&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">Agregar nuevo grupo...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;No guardar&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} es necesario.</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0} se recortará.</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">Recordar contraseña</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">Cuenta</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">Actualizar credenciales de la cuenta</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Inquilino de Azure AD</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">Nombre (opcional)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">Avanzado...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">Debe seleccionar una cuenta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de datos</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">Archivos y grupos de archivos</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">Completa</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">Diferencial</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">Registro de transacciones</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">Disco</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">Utilizar la configuración del servidor predeterminada</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">Comprimir copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">No comprimir copia de seguridad</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">Certificado de servidor</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">Clave asimétrica</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">No ha abierto ninguna carpeta que contenga cuadernos o libros. </target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">Abrir cuaderno</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">El conjunto de resultados solo contiene un subconjunto de todas las coincidencias. Sea más específico en la búsqueda para acotar los resultados.</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">Búsqueda en curso... </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">No se encontraron resultados en '{0}' con exclusión de '{1}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">No se encontraron resultados en '{0}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">No se encontraron resultados con exclusión de '{0}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">No se encontraron resultados. Revise la configuración para configurar exclusiones y verificar sus archivos gitignore -</target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">Vuelva a realizar la búsqueda.</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Cancele la búsqueda.</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">Buscar de nuevo en todos los archivos</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">Abrir configuración</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">La búsqueda devolvió {0} resultados en {1} archivos</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">Alternar Contraer y expandir</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Cancelar búsqueda</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">Expandir todo</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Contraer todo</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">Borrar resultados de la búsqueda</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Conexiones</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">Conéctese a SQL Server y Azure, realice consultas, administre las conexiones y mucho más.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Siguiente</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Cuadernos</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">Empiece a crear su propio cuaderno o colección de cuadernos en un solo lugar.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensiones</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Amplíe la funcionalidad de Azure Data Studio mediante la instalación de extensiones desarrolladas por nosotros y Microsoft, así como por la comunidad de terceros (es decir, ¡usted!).</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Configuración</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">Personalice Azure Data Studio según sus preferencias. Puede configurar opciones como el autoguardado y el tamaño de las pestañas, personalizar los métodos abreviados de teclado y cambiar a un tema de color de su gusto.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">Página de bienvenida</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">Descubra las principales características, los archivos abiertos recientemente y las extensiones recomendadas en la página de bienvenida. Para obtener más información sobre cómo empezar a trabajar con Azure Data Studio, consulte los vídeos y la documentación.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">Finalizar</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">Paseo de bienvenida para el usuario</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">Ocultar paseo de presentación</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">Más información</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Ayuda</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">Eliminar fila</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">Revertir la fila actual</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Una vez instaladas, podrá seleccionar el icono Visualizador para ver los result
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">Panel de mensajes</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">Copiar todo</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">Abrir en Azure Portal</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Carga en curso</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">Nombre de copia de seguridad</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Carga completada</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">Modelo de recuperación</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">Tipo de copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">Archivos de copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">Algoritmo</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">Certificado o clave asimétrica</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">Multimedia</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">Realizar la copia de seguridad sobre el conjunto de medios existente</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">Realizar copia de seguridad en un nuevo conjunto de medios</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">Añadir al conjunto de copia de seguridad existente</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">Sobrescribir todos los conjuntos de copia de seguridad existentes</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">Nuevo nombre de conjunto de medios</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">Nueva descripción del conjunto de medios</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">Realizar la suma de comprobación antes de escribir en los medios</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">Comprobar copia de seguridad cuando haya terminado</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">Seguir en caso de error</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">Expiración</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">Configure los días de conservación de la copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">Copia de seguridad de solo copia</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">Configuración avanzada</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">Compresión</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">Establecer la compresión de copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">Cifrado</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">Registro de transacciones</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">Truncar el registro de transacciones</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">Hacer copia de seguridad de la cola del registro</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">Fiabilidad</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">El nombre del medio es obligatorio</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">No hay certificado o clave asimétrica disponible</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">Agregar un archivo</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">Eliminar archivos</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">Entrada no válida. El valor debe ser igual o mayor que 0.</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">Solo se admite la copia de seguridad en un archivo</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">La ruta del archivo de copia de seguridad es obligatoria</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">Haga clic en</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ Código</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">o</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ Texto</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">para agregar una celda de código o texto</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Copia de seguridad</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">StdIn:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">Debe habilitar las características en versión preliminar para utilizar la copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">No se admite el comando de copia de seguridad en el contexto del servidor. Seleccione una base de datos y vuelva a intentarlo.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">No se admite el comando de copia de seguridad para bases de datos de Azure SQL.</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Copia de seguridad</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">Expandir contenido de la celda de código</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de datos</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">Contraer contenido de la celda de código</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">Archivos y grupos de archivos</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">Completa</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">Diferencial</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">Registro de transacciones</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">Disco</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">Utilizar la configuración del servidor predeterminada</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">Comprimir copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">No comprimir copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">Certificado de servidor</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">Clave asimétrica</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">Plan de presentación XML</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">Cuadrícula de resultados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Agregar celda</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Celda de código</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Celda de texto</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">Bajar celda</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">Subir celda</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Eliminar</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Agregar celda</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Celda de código</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Celda de texto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">Error del kernel SQL</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">Se debe elegir una conexión para ejecutar celdas de cuaderno</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">Mostrando las primeras {0} filas.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Última ejecución</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Próxima ejecución</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Estado</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Categoría</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">Se puede ejecutar</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">Programación</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Último resultado ejecutado</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Ejecuciones anteriores</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">No hay pasos disponibles para este trabajo.</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Error: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">No pudo encontrar el componente para el tipo {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Buscar</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Buscar</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Coincidencia anterior</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Coincidencia siguiente</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Cerrar</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">La búsqueda ha devuelto un gran número de resultados, se resaltarán solo las primeras 999 coincidencias.</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} de {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">No hay resultados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">Esquema</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Ejecutar consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">No se ha encontrado ningún representador {0} para la salida. Tiene los siguientes tipos MIME: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">seguro </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">No se encontró un componente para el selector {0}</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">Error al representar el componente: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Carga en curso...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Carga en curso...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Editar</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">Salir</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualizar</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostrar acciones</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">Eliminar widget</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">Haga clic para desanclar</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">Haga clic para anclar</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">Abrir características instaladas</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">Contraer widget</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">Expandir widget</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} es un contenedor desconocido.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Base de datos de destino</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Última ejecución</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Próxima ejecución</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Estado</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Último resultado ejecutado</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Ejecuciones anteriores</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">No hay pasos disponibles para este trabajo.</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Error: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Error del Notebook: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">Error de carga...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostrar acciones</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">No se encontraron elementos coincidentes</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">La lista de la búsqueda se ha filtrado en un elemento.</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">La lista de la búsqueda se ha filtrado en {0} elementos.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">Error</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">Correcto</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">Reintentar</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">Cancelado</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">En curso</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">Estado desconocido</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">En ejecución</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">A la espera de un subproceso</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">Entre reintentos</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">Inactivo</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">Suspendido</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[Obsoleto]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sí</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">No programado</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">No ejecutar nunca</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">Negrita</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">Cursiva</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">Subrayado</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">Resaltar</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Código</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">Vínculo</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">Lista</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">Lista ordenada</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Imagen</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Alternancia de la vista previa de Markdown: desactivada</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">Encabezado</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">Encabezado 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">Encabezado 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">Encabezado 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">Párrafo</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">Inserción de un vínculo</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">Inserción de una imagen</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">Vista de texto enriquecido</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">Vista En dos paneles</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Vista de Markdown</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">Crear conclusión</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">No se puede crear la conclusión porque el editor activo no es un Editor de SQL</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">Mi Widget</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">Configurar gráfico</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">Copiar como imagen</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">No se pudo encontrar el gráfico a guardar</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">Guardar como imagen</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">Png</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">Gráfico guardado en la ruta: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Una vez instaladas, podrá seleccionar el icono Visualizador para ver los result
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Gráfico</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">Barra horizontal</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">Barras</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">Línea</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">Circular</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">Dispersión</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">Serie temporal</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Imagen</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">Recuento</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">Tabla</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">Anillo</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">No se pudieron obtener las filas para el conjunto de datos en el gráfico.</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">No se admite el tipo de gráfico "{0}".</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Gráficos integrados</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">El número máximo de filas para gráficos que se mostrarán. Advertencia: incrementar esto podría afectar al rendimiento.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">Cerrar</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">Ya existe un grupo de servidores con el mismo nombre.</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">Serie {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">La tabla no contiene una imagen válida</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">Se ha superado el número máximo de filas para gráficos integrados, solo se usan las primeras {0} filas. Para configurar el valor, puede abrir la configuración de usuario y buscar: "builtinCharts. maxRowCount".</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">No volver a mostrar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">Conectando: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">Ejecutando comando: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">Abriendo nueva consulta: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">No se puede conectar ya que no se proporcionó información del servidor</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">No se pudo abrir la dirección URL debido a un error {0}</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">Esto se conectará al servidor {0}</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">¿Seguro que desea conectarse?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">&amp;&amp;Abrir</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">Conectando con el archivo de consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">{0} se ha reemplazado por {1} en la configuración de usuario.</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">{0} se ha reemplazado por {1} en la configuración del área de trabajo.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">Número máximo de conexiones usadas recientemente que se van a almacenar en la lista de conexiones.</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">Motor de SQL predeterminado para usar. Esto indica el proveedor de lenguaje predeterminado en los archivos .sql y los valores por defecto que se usarán al crear una nueva conexión.</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">Intente analizar el contenido del portapapeles cuando se abre el cuadro de diálogo de conexión o se realiza un pegado.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">Estado de conexión</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">Identificador común para el proveedor</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">Nombre para mostrar del proveedor</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">Alias de kernel del cuaderno para el proveedor</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">Ruta de acceso al icono para el tipo de servidor</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">Opciones para la conexión</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">Nombre de usuario visible para el proveedor de árbol</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">Id. del proveedor; debe ser el mismo que al registrar el proveedor de datos del árbol y debe empezar por "connectionDialog/".</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">Identificador único para este contenedor.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">El contenedor que se mostrará en la pestaña.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">Contribuye con uno o varios contenedores de paneles para que los usuarios los agreguen a su propio panel.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">No se ha especificado ningún identificador en el contenedor de paneles para la extensión.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">No se ha especificado ningún contenedor en el contenedor de paneles para la extensión.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Debe definirse exactamente 1 contenedor de paneles por espacio.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">Tipo de contenedor desconocido definido en el contenedor de paneles para la extensión.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">El control host que se mostrará en esta pestaña.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">La sección "{0}" tiene contenido no válido. Póngase en contacto con el propietario de la extensión.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">La lista de widgets o vistas web que se muestran en esta pestaña.</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">Se esperan widgets o vistas web en el contenedor de widgets para la extensión.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">La vista respaldada por el modelo que se visualiza en esta pestaña.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificador único para esta sección de navegación. Se pasará a la extensión de las solicitudes.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(opcional) Icono que se utiliza para representar esta sección de navegación en la IU. Una ruta de acceso al archivo o una configuración con temas</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Ruta del icono cuando se usa un tema ligero</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Ruta de icono cuando se usa un tema oscuro</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">Título de la sección de navegación para mostrar al usuario.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">El contenedor que se mostrará en esta sección de navegación.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">La lista de contenedores de paneles que se mostrará en esta sección de navegación.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">No hay título en la sección de navegación especificada para la extensión.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">No hay contenedor en la sección de navegación especificada para la extensión.</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Debe definirse exactamente 1 contenedor de paneles por espacio.</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION en NAV_SECTION es un contenedor no válido para la extensión.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">La vista web que se mostrará en esta pestaña.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">La lista de widgets que se muestra en esta pestaña.</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">La lista de widgets que se espera dentro del contenedor de widgets para la extensión.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Editar</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">Salir</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar acciones</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">Eliminar widget</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">Haga clic para desanclar</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">Haga clic para anclar</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">Abrir características instaladas</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">Contraer widget</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">Expandir widget</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} es un contenedor desconocido.</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Una vez instaladas, podrá seleccionar el icono Visualizador para ver los result
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">Crear conclusión</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificador único para esta pestaña. Se pasará a la extensión para cualquier solicitud.</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">No se puede crear la conclusión porque el editor activo no es un Editor de SQL</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">Título de la pestaña para mostrar al usuario.</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">Mi Widget</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">Descripción de esta pestaña que se mostrará al usuario.</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">Configurar gráfico</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Condición que se debe cumplir para mostrar este elemento</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">Copiar como imagen</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">Define los tipos de conexión con los que esta pestaña es compatible. El valor predeterminado es "MSSQL" si no se establece</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">No se pudo encontrar el gráfico a guardar</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">El contenedor que se mostrará en esta pestaña.</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">Guardar como imagen</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">Si esta pestaña se debe mostrar siempre, o sólo cuando el usuario la agrega.</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">Png</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">Si esta pestaña se debe usar o no como la pestaña Inicio para un tipo de conexión.</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">Gráfico guardado en la ruta: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">Id. único del grupo al que pertenece esta pestaña; valor para el grupo de inicio: Inicio.</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Opcional) Icono que se utiliza para representar esta pestaña en la interfaz de usuario; puede ser una ruta de acceso al archivo o una configuración con temas.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Ruta del icono cuando se usa un tema ligero</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Ruta de icono cuando se usa un tema oscuro</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">Aporta una o varias pestañas que los usuarios pueden agregar a su panel.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">No se ha especificado ningún título para la extensión.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">No se ha especificado ninguna descripción para mostrar.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">No se ha especificado ningún contenedor para la extensión.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">Debe definirse exactamente 1 contenedor de paneles por espacio</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">Identificador único para este grupo de pestañas.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">Título del grupo de pestañas.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">Aporta uno o varios grupos de pestañas que los usuarios pueden agregar a su panel.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">No se ha especificado ningún id. para el grupo de pestañas.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">No se ha especificado ningún título para el grupo de pestañas.</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">Administración</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">Supervisión</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">Rendimiento</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">Seguridad</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">Solución de problemas</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Configuración</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">pestaña de bases de datos</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">Bases de datos</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">Agregar código</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Administrar</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">Agregar texto</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Panel</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">Crear archivo</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Administrar</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">No se pudo mostrar contenido: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">la propiedad "icon" puede omitirse o debe ser una cadena o un literal como "{dark, light}"</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Agregar celda</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">Define una propiedad para mostrar en el panel</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Celda de código</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">Qué valor utilizar como etiqueta de la propiedad</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Celda de texto</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">Valor en el objeto al que acceder para el valor</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">Ejecutar todo</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">Especificar los valores que se ignorarán</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">Celda</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">Valor predeterminado para mostrar si se omite o no hay valor</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Código</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">Estilo para definir propiedades en un panel</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Texto</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">Id. del estilo</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">Ejecutar celdas</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">Condición para utilizar este tipo</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; Anterior</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">Campo con el que comparar</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">Siguiente &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">Operador para utilizar en la comparación</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">no se encontró la celda con URI {0} en este modelo</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">Valor con el que comparar el campo</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">Error al ejecutar las celdas. Para más información, vea el error en la salida de la celda seleccionada actualmente.</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">Propiedades para mostrar por página de base de datos</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">Propiedades para mostrar por página de servidor</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">Define que este proveedor admite el panel de información</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">Id. de proveedor (por ejemplo MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">Valores de las propiedades para mostrar en el panel</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Condición que se debe cumplir para mostrar este elemento</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">Indica se oculta el encabezado del widget; el valor predeterminado es "false".</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">El título del contenedor</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">La fila del componente en la cuadrícula</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">El intervalo de fila del componente en la cuadrícula. El valor predeterminado es 1. Use "*" para establecer el número de filas en la cuadrícula.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">La columna del componente en la cuadrícula</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">El colspan del componente en la cuadrícula. El valor predeterminado es 1. Use "*" para definir el número de columnas en la cuadrícula.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificador único para esta pestaña. Se pasará a la extensión para cualquier solicitud.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">La pestaña de extensión es desconocida o no está instalada.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">Propiedades de la base de datos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Activar o desactivar el widget de propiedades</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valores de la propiedad para mostrar</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nombre para mostrar de la propiedad</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">Valor en el objeto de la información de la base de datos</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">Especificar valores específicos para ignorar</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">Modelo de recuperación</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">Última copia de seguridad de la base de datos</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">Última copia de seguridad de registros</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">Nivel de compatibilidad</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Propietario</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">Personaliza la página del panel de base de datos</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Búsqueda</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">Personaliza las pestañas de consola de base de datos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">Propiedades del servidor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Activar o desactivar el widget de propiedades</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valores de la propiedad para mostrar</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nombre para mostrar de la propiedad</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">Valor en el objeto de información de servidor</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versión</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">Edición</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">Nombre del equipo</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">Versión del sistema operativo</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Búsqueda</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">Personaliza la página del panel de servidor</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">Personaliza las pestañas del panel de servidor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">Inicio</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">No se pudo cambiar la base de datos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar acciones</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">No se encontraron elementos coincidentes</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">La lista de la búsqueda se ha filtrado en un elemento.</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">La lista de la búsqueda se ha filtrado en {0} elementos.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">Esquema</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">Cargando de los objetos en curso</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">Carga de las bases de datos en curso</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">La carga de los objetos se ha completado.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">La carga de las bases de datos se ha completado.</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">Buscar por nombre de tipo (t:, v:, f: o sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">Buscar en las bases de datos</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">No se pueden cargar objetos</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">No se pueden cargar las bases de datos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Ejecutar consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">Carga de {0} en curso</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">Carga de {0} completada</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">Actualización automática: DESACTIVADA</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">Última actualización: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">No hay resultados para mostrar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">Añade un widget que puede consultar un servidor o base de datos y mostrar los resultados de múltiples maneras, como un gráfico o una cuenta de resumen, entre otras.</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">Identificador único utilizado para almacenar en caché los resultados de la información.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">Consulta SQL para ejecutar. Esto debería devolver exactamente un conjunto de resultados.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[Opcional] Ruta de acceso a un archivo que contiene una consulta. Utilícelo si "query" no está establecido</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[Opcional] Intervalo de actualización automática en minutos, si no se establece, no habrá actualización automática</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">Acciones para utilizar</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Base de datos de destino para la acción; puede usar el formato "${ columnName }" para usar un nombre de columna controlado por datos.</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Servidor de destino para la acción; puede usar el formato "${ columnName }" para usar un nombre de columna controlado por datos.</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Usuario de destino para la acción; puede usar el formato "${ columnName }" para usar un nombre de columna controlado por datos.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">Identificador de la información</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">Aporta conocimientos a la paleta del panel.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">No se puede mostrar el gráfico con los datos proporcionados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">Muestra los resultados de una consulta como un gráfico en el panel de información</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">Asigne "nombre de columna" -&gt; color. Por ejemplo, agregue "column1": red para asegurarse de que esta utilice un color rojo </target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">Indica la posición y visibilidad preferidas de la leyenda del gráfico. Estos son los nombres de columna de la consulta y se asignan a la etiqueta de cada entrada de gráfico</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">Si dataDirection es horizontal, al establecerlo como verdadero se utilizarán los valores de las primeras columnas para la leyenda.</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">Si dataDirection es vertical, al configurarlo como verdadero se utilizarán los nombres de columna para la leyenda.</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">Define si los datos se leen desde una columna (vertical) o una fila (horizontal). Para series de tiempo esto se omite, ya que la dirección debe ser vertical.</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">Si se establece showTopNData, se mostrarán solo los primeros N datos en la tabla.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Valor mínimo del eje y</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Valor máximo del eje y</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Etiqueta para el eje y</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">Valor mínimo del eje x</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">Valor máximo del eje x</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">Etiqueta para el eje x</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">Indica la propiedad de datos de un conjunto de datos para un gráfico.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">Para cada columna de un conjunto de resultados, muestra el valor de la fila 0 como un recuento seguido del nombre de la columna. Admite "1 Healthy", "3 Unhealthy", por ejemplo, donde "Healthy" es el nombre de la columna y 1 es el valor de la fila 1, celda 1</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">Muestra una imagen, por ejemplo uno devuelta por una consulta R con ggplot2</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">¿Qué formato se espera: es un archivo JPEG, PNG u otro formato?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">¿Está codificado como hexadecimal, base64 o algún otro formato?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">Muestra los resultados en una tabla simple</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">Carga de las propiedades en curso</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">La carga de las propiedades se ha completado.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">No se pueden cargar las propiedades del panel</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">Conexiones de base de datos</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">Conexiones de fuentes de datos</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">grupos de origen de datos</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">Las conexiones guardadas se ordenan por las fechas en que se agregaron.</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">Las conexiones guardadas se ordenan alfabéticamente por sus nombres para mostrar.</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">Controla el criterio de ordenación de las conexiones guardadas y los grupos de conexiones.</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">Configuración de inicio</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">True para que la vista de servidores aparezca en la apertura predeterminada de Azure Data Studio; false si quiere aparezca la última vista abierta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">Identificador de la vista. Úselo para registrar un proveedor de datos mediante la API "vscode.window.registerTreeDataProviderForView". También para desencadenar la activación de su extensión al registrar el evento "onView:${id}" en "activationEvents".</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Nombre de la vista en lenguaje natural. Se mostrará</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">Condición que se debe cumplir para mostrar esta vista</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">Aporta vistas al editor</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">Aporta vistas al contenedor del Explorador de datos en la barra de la actividad</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">Contribuye vistas al contenedor de vistas aportadas</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">No pueden registrar múltiples vistas con el mismo identificador "{0}" en el contenedor de vistas "{1}"</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">Una vista con el identificador "{0}" ya está registrada en el contenedor de vista "{1}"</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">Las vistas deben ser una matriz</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">la propiedad "{0}" es obligatoria y debe ser de tipo "string"</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">la propiedad "{0}" se puede omitir o debe ser de tipo "string"</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Servidores</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Conexiones</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">Mostrar conexiones</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">Mostrar panel de edición de datos de SQL al iniciar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Ejecutar</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">Eliminar edición con error: </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Detener</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">Mostrar el panel de SQL</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">Cerrar el panel de SQL</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">Máximo de filas:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">Eliminar fila</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">Revertir la fila actual</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Guardar como CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Guardar como JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Guardar como Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Guardar como XML</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copiar con encabezados</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Seleccionar todo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">Pestañas del panel ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">Id.</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Título</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descripción</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">Información del panel ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">Id.</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">Cuándo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">Obtiene información de extensión de la galería</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">Id. de extensión</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">La extensión '{0}' no se encontró.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Mostrar recomendaciones</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">Instalar extensiones</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">Crear una extensión...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">No volver a mostrar</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio cuenta con extensiones recomendadas.</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio cuenta con extensiones recomendadas para la visualización de datos.
+Una vez instaladas, podrá seleccionar el icono Visualizador para ver los resultados de las consultas.</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">Instalar todo</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Mostrar recomendaciones</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Es necesario proporcionar el tipo de escenario para recibir recomendaciones de extensiones.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Azure Data Studio recomienda esta extensión.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">Trabajos</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Alertas</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">Servidores proxy</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">Operadores</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">Última aparición</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">Retraso entre las respuestas (en segundos)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">Nombre de la categoría</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Error: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">Ver reglas aplicables</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">Id. de paso</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">Ver reglas aplicables para {0}</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">Nombre del paso</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">Invocar evaluación</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">Invocar evaluación para {0}</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">Exportar como script</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">Ver todas las reglas y obtener más información en GitHub</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">Crear informe en HTML</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">El informe se ha guardado. ¿Quiere abrirlo?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">Mensaje</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">Datos</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Conexión</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor de Power Query</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Panel</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Pasos</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">Pestañas del panel ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">Id.</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">Título</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descripción</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">Información del panel ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">Id.</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">Nombre</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">Cuándo</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Última ejecución</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Próxima ejecución</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Estado</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Categoría</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">Se puede ejecutar</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">Programación</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Último resultado ejecutado</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Ejecuciones anteriores</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">No hay pasos disponibles para este trabajo.</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Error: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">La tabla no contiene una imagen válida</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">Fecha de creación: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Error del Notebook: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">Error de trabajo: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">Anclado</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">Ejecuciones recientes</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">Ejecuciones pasadas</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">Más</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Editar</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Base de datos de destino</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Cerrar</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Última ejecución</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">Convertir celda</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Próxima ejecución</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">Ejecutar celdas de arriba</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Estado</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">Ejecutar celdas de abajo</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Último resultado ejecutado</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">Insertar código arriba</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Ejecuciones anteriores</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">Insertar código abajo</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">No hay pasos disponibles para este trabajo.</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">Insertar texto arriba</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Error: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">Insertar texto abajo</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">Contraer celda</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">Expandir celda</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">Crear celda de parámetro</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">Quitar celda de parámetro</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">Borrar resultado</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Error del Notebook: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">Error al iniciar la sesión del cuaderno</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">El servidor no se pudo iniciar por una razón desconocida</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">Dirección de correo electrónico</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">No se encontró el kernel {0}. En su lugar, se utilizará el kernel predeterminado.</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">Serie {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">Nombre de la cuenta</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Cerrar</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">Nombre de credencial</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="es">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated">N.º de parámetros insertados
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descripción</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">Seleccione una conexión para ejecutar celdas para este kernel</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">No se pudo eliminar la celda.</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">Error al cambiar de kernel. Se utilizará el kernel {0}. Error: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">No se pudo cambiar el kernel debido al error: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">Error en el cambio de contexto: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">No se pudo iniciar sesión: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">Se ha producido un error en la sesión del cliente al cerrar el cuaderno: {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">No puede encontrar el administrador de cuadernos para el proveedor {0}</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Error: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">Más</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Editar</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Cerrar</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">Convertir celda</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">Ejecutar celdas de arriba</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">Ejecutar celdas de abajo</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">Insertar código arriba</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">Insertar código abajo</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">Insertar texto arriba</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">Insertar texto abajo</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">Contraer celda</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">Expandir celda</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">Crear celda de parámetro</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">Quitar celda de parámetro</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">Borrar resultado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Agregar celda</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Celda de código</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Celda de texto</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">Bajar celda</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">Subir celda</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Eliminar</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Agregar celda</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Celda de código</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Celda de texto</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">Parámetros</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">Seleccione la celda activa y vuelva a intentarlo</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">Ejecutar celda</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">Cancelar ejecución</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">Error en la última ejecución. Haga clic para volver a ejecutar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">Expandir contenido de la celda de código</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">Contraer contenido de la celda de código</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">Negrita</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">Cursiva</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">Subrayado</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">Resaltar</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Código</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">Vínculo</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">Lista</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">Lista ordenada</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Imagen</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Alternancia de la vista previa de Markdown: desactivada</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">Encabezado</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">Encabezado 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">Encabezado 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">Encabezado 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">Párrafo</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">Inserción de un vínculo</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">Inserción de una imagen</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">Vista de texto enriquecido</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Vista En dos paneles</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Vista de Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">No se ha encontrado ningún representador {0} para la salida. Tiene los siguientes tipos MIME: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">seguro </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">No se encontró un componente para el selector {0}</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">Error al representar el componente: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">Haga clic en</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ Código</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">o</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ Texto</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">para agregar una celda de código o texto</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">Agregar una celda de código</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">Agregar una celda de texto</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">StdIn:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Haga doble clic para editar.&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Agregue contenido aquí...&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Buscar</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Buscar</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Coincidencia anterior</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Coincidencia siguiente</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Cerrar</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">La búsqueda ha devuelto un gran número de resultados, se resaltarán solo las primeras 999 coincidencias.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} de {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">No hay ningún resultado.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">Agregar código</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">Agregar texto</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">Crear archivo</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">No se pudo mostrar contenido: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Agregar celda</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Celda de código</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Celda de texto</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">Ejecutar todo</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">Celda</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Código</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Texto</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">Ejecutar celdas</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; Anterior</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">Siguiente &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">no se encontró la celda con URI {0} en este modelo</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Error al ejecutar las celdas. Para más información, vea el error en la salida de la celda seleccionada actualmente.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuevo Notebook</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuevo Notebook</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">Establecer área de trabajo y abrir</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">Kernel SQL: detenga la ejecución del Notebook cuando se produzca un error en una celda.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(Versión preliminar) Consulte todos los kernel del proveedor del cuaderno actual.</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">Permita a los cuadernos ejecutar comandos de Azure Data Studio.</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">Habilitar doble clic para editar las celdas de texto en los cuadernos</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">El texto se muestra como texto enriquecido (también conocido como WYSIWYG).</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">"Markdown" se muestra a la izquierda, con una vista previa del texto representado a la derecha.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">El texto se muestra como "Markdown".</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">Modo de edición predeterminado usado para las celdas de texto</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(Versión preliminar) Guarde el nombre de la conexión en los metadatos del cuaderno.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">Controla la altura de línea utilizada en la vista previa de Markdown del cuaderno. Este número es relativo al tamaño de la fuente.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(Vista preliminar) Mostrar el bloc de notas representado en el editor.</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">Número máximo de cambios almacenados en el historial de deshacer del editor de texto enriquecido del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">Búsqueda de cuadernos</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">Configure patrones globales para excluir archivos y carpetas en búsquedas de texto completo y abrir los patrones de uso rápido. Hereda todos los patrones globales de la configuración "#files.exclude". Lea más acerca de los patrones globales [aquí](https://code.visualstudio.com/docs/editor/codebasics-_advanced-search-options).</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">El patrón global con el que se harán coincidir las rutas de acceso de los archivos. Establézcalo en true o false para habilitarlo o deshabilitarlo.</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">Comprobación adicional de los elementos del mismo nivel de un archivo coincidente. Use $(nombreBase) como variable para el nombre de archivo que coincide.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">Esta opción están en desuso y ahora se utiliza "search.usePCRE2".</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">En desuso. Considere la utilización de "search.usePCRE2" para admitir la característica de expresiones regulares avanzadas.</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">Cuando está habilitado, el proceso de servicio de búsqueda se mantendrá habilitado en lugar de cerrarse después de una hora de inactividad. Esto mantendrá la caché de búsqueda de archivos en la memoria.</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Controla si se deben usar los archivos ".gitignore" e ".ignore" al buscar archivos.</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Controla si deben usarse archivos ".ignore" y ".gitignore" globables cuando se buscan archivos.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">Indica si se incluyen resultados de una búsqueda global de símbolos en los resultados de archivos de Quick Open.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">Indica si se incluyen resultados de archivos abiertos recientemente en los resultados de archivos de Quick Open.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">Las entradas de historial se ordenan por pertinencia en función del valor de filtro utilizado. Las entradas más pertinentes aparecen primero.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">Las entradas de historial se ordenan por uso reciente. Las entradas abiertas más recientemente aparecen primero.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">Controla el orden de clasificación del historial del editor en apertura rápida al filtrar.</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">Controla si debe seguir enlaces simbólicos durante la búsqueda.</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">Buscar sin distinción de mayúsculas y minúsculas si el patrón es todo en minúsculas; de lo contrario, buscar con distinción de mayúsculas y minúsculas.</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">Controla si la vista de búsqueda debe leer o modificar el portapapeles de búsqueda compartido en macOS.</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">Controla si la búsqueda se muestra como una vista en la barra lateral o como un panel en el área de paneles para disponer de más espacio horizontal.</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">Esta configuración está en desuso. Utilice el menú contextual de la vista de búsqueda en su lugar.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">Los archivos con menos de 10 resultados se expanden. El resto están colapsados.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">Controla si los resultados de la búsqueda estarán contraídos o expandidos.</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">Controla si debe abrirse la vista previa de reemplazo cuando se selecciona o reemplaza una coincidencia.</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">Controla si deben mostrarse los números de línea en los resultados de la búsqueda.</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">Si se utiliza el motor de expresión regular PCRE2 en la búsqueda de texto. Esto permite utilizar algunas características avanzadas de regex como la búsqueda anticipada y las referencias inversas. Sin embargo, no todas las características de PCRE2 son compatibles: solo las características que también admite JavaScript.</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">En desuso. Se usará PCRE2 automáticamente al utilizar características de regex que solo se admiten en PCRE2.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">Posicione el actionbar a la derecha cuando la vista de búsqueda es estrecha, e inmediatamente después del contenido cuando la vista de búsqueda es amplia.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">Posicionar siempre el actionbar a la derecha.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">Controla el posicionamiento de la actionbar en las filas en la vista de búsqueda.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">Busque todos los archivos a medida que escribe.</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">Habilite la búsqueda de propagación a partir de la palabra más cercana al cursor cuando el editor activo no tiene ninguna selección.</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">Actualiza la consulta de búsqueda del área de trabajo al texto seleccionado del editor al enfocar la vista de búsqueda. Esto ocurre al hacer clic o al desencadenar el comando "workbench.views.search.focus".</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">Cuando '#search.searchOnType' está habilitado, controla el tiempo de espera en milisegundos entre un carácter que se escribe y el inicio de la búsqueda. No tiene ningún efecto cuando 'search.searchOnType' está deshabilitado.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">Al hacer doble clic, se selecciona la palabra bajo el cursor.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">Al hacer doble clic, se abre el resultado en el grupo de editor activo.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">Al hacer doble clic se abre el resultado en el grupo del editor a un lado, creando uno si aún no existe.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">Configure el efecto de hacer doble clic en un resultado en un editor de búsqueda.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">Los resultados se ordenan por nombre de carpeta y archivo, en orden alfabético.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">Los resultados estan ordenados alfabéticamente por nombres de archivo, ignorando el orden de las carpetas.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">Los resultados se ordenan por extensiones de archivo, en orden alfabético.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">Los resultados se ordenan por la última fecha de modificación del archivo, en orden descendente.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">Los resultados se ordenan de forma descendente por conteo de archivos.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">Los resultados se ordenan por recuento por archivo, en orden ascendente.</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">Controla el orden de los resultados de búsqueda.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">Cargando kernels...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">Cambiando kernel...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">Adjuntar a </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">Kernel </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">Cargando contextos...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Cambiar conexión</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">Seleccionar conexión</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">Sin kernel</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Este cuaderno no se puede ejecutar con parámetros porque no se admite el kernel. Use los kernel y formato admitidos. [Más información](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Este bloc de notas no se puede ejecutar con parámetros hasta que se agregue una celda de parámetro. [Más información] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Este cuaderno no se puede ejecutar con los parámetros hasta que se agregue una celda de parámetro. [Más información](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">Borrar resultados</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">De confianza</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">No de confianza</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">Contraer celdas</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">Expandir celdas</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">Ejecutar con parámetros</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">Ninguno</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuevo Notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Buscar cadena siguiente</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Buscar cadena anterior</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">Resultados de la búsqueda</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">No se encuentra la ruta de búsqueda: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Cuadernos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">No ha abierto ninguna carpeta que contenga cuadernos o libros. </target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">Abrir cuaderno</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">El conjunto de resultados solo contiene un subconjunto de todas las coincidencias. Sea más específico en la búsqueda para acotar los resultados.</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">Búsqueda en curso... </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">No se encontraron resultados en '{0}' con exclusión de '{1}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">No se encontraron resultados en '{0}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">No se encontraron resultados con exclusión de '{0}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">No se encontraron resultados. Revise la configuración para configurar exclusiones y verificar sus archivos gitignore -</target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">Vuelva a realizar la búsqueda.</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">Buscar de nuevo en todos los archivos</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">Abrir configuración</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">La búsqueda devolvió {0} resultados en {1} archivos</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">Alternar Contraer y expandir</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">Cancelar búsqueda</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">Expandir todo</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Contraer todo</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">Borrar resultados de la búsqueda</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">Búsqueda: Escriba el término de búsqueda y presione Entrar para buscar o Esc para cancelar</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Buscar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">no se encontró la celda con URI {0} en este modelo</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Error al ejecutar las celdas. Para más información, vea el error en la salida de la celda seleccionada actualmente.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">Ejecute esta celda para ver las salidas.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">Esta vista está vacía. Agregue una celda a esta vista haciendo clic en el botón Insertar celdas.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Error de copia {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">Mostrar gráfico</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">Mostrar tabla</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">No se ha encontrado ningún representador de {0} para la salida. Tiene los siguientes tipos MIME: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(seguro) </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">Error al mostrar el gráfico de Plotly: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">No se ha encontrado una conexión.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">Agregar conexión</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">Paleta de colores del grupo de servidores utilizada en el viewlet del Explorador de objetos.</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">Expanda automáticamente los grupos de servidores en el viewlet del Explorador de Objetos.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(Versión preliminar) Use el nuevo árbol de servidores asincrónicos para la vista Servidores y el cuadro de diálogo Conexión, con compatibilidad con nuevas características como el filtrado de nodos dinámicos.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">Datos</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Conexión</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Editor de Power Query</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Panel</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Gráficos integrados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">Especifica plantillas de vista</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">Especifica plantillas de sesión</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Filtros de Profiler</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Conectar</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Inicio</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">Nueva sesión</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">Pausar</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">Reanudar</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Detener</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">Borrar los datos</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">¿Está seguro de que quiere borrar los datos?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">Desplazamiento automático: activado</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">Desplazamiento automático: desactivado</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">Alternar el panel contraído</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">Editar columnas</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Buscar la cadena siguiente</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Buscar la cadena anterior</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Iniciar Profiler</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">Filtrar...</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">Borrar filtro</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">¿Está seguro de que quiere borrar los filtros?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">Seleccionar vista</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">Seleccionar sesión</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">Seleccionar sesión:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">Seleccionar vista:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Texto</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">Etiqueta</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Detalles</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Buscar</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Buscar</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Coincidencia anterior</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Coincidencia siguiente</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Cerrar</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">La búsqueda ha devuelto un gran número de resultados, se resaltarán solo las primeras 999 coincidencias.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} de {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">No hay resultados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">Editor de Profiler para el texto del evento. Solo lectura</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">Eventos (filtrados): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">Eventos: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">Recuento de eventos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Guardar como CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Guardar como JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Guardar como Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Guardar como XML</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">La codificación de los resultados no se guardará al realizar la exportación en JSON. Recuerde guardarlos con la codificación deseada una vez que se cree el archivo.</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">El origen de datos de respaldo no admite la opción Guardar en archivo</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copiar con encabezados</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Seleccionar todo</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">Maximizar</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Gráfico</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">Visualizador</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">Elegir lenguaje SQL</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">Cambiar proveedor de lenguaje SQL</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">Tipo de lenguaje SQL</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">Cambiar el proveedor del motor SQL</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">Existe una conexión mediante el motor {0}. Para cambiar, por favor desconecte o cambie la conexión</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">Ningún editor de texto activo en este momento</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">Seleccionar proveedor de lenguaje</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">Plan de presentación XML</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">Cuadrícula de resultados</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">Se ha superado el número máximo de filas para el filtrado y la ordenación. Para actualizarla, puede ir a Configuración de usuario y cambiar la configuración: "queryEditor.results.inMemoryDataProcessingThreshold".</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">Centrarse en la consulta actual</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Ejecutar consulta</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">Ejecutar la consulta actual</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">Copiar consulta con resultados</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">La consulta y los resultados se han copiado correctamente.</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">Ejecutar la consulta actual con el plan real</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">Cancelar consulta</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">Actualizar caché de IntelliSense</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">Alternar resultados de la consulta</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">Alternar enfoque entre consulta y resultados</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">El parámetro de editor es necesario para la ejecución de un acceso directo</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">Analizar consulta</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">Comandos completados correctamente</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">Error del comando: </target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">Conéctese a un servidor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">Panel de mensajes</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">Copiar todo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">Resultados de consultas</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nueva consulta</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Editor de Power Query</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">Si es "true", los encabezados de columna se incluirán al guardar los resultados como CSV.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">Delimitador personalizado para usar entre los valores al guardar como CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">Caracteres que se usan para separar las filas al guardar los resultados como CSV.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">Carácter que se usa para delimitar los campos de texto al guardar los resultados como CSV.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">Codificación de archivo empleada al guardar los resultados como CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">Si es "true", se dará formato a la salida XML al guardar los resultados como XML.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">Codificación de archivo empleada al guardar los resultados como XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">Permitir streaming de resultados; contiene algunos defectos visuales menores</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">Opciones de configuración para copiar los resultados de la vista de resultados.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">Opciones de configuración para copiar los resultados de varias líneas de la vista de resultados.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(Experimental) Use una tabla optimizada en los resultados. Es posible que falten algunas funciones porque todavía estén en desarrollo.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">Controla el número máximo de filas permitidas para filtrar y ordenar en memoria. Si se supera el número, se deshabilitará la ordenación y el filtrado. Advertencia: El incremento de este número puede afectar al rendimiento.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">Indica si se debe abrir el archivo en Azure Data Studio después de guardar el resultado.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">Indica si debe mostrarse el tiempo de ejecución para los lotes individuales.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">Mensajes de ajuste automático de línea</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">Tipo de gráfico predeterminado para usar al abrir el visor de gráficos a partir de los resultados de una consulta</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">Se deshabilitará el coloreado de las pestañas</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">El borde superior de cada pestaña del editor se coloreará para que coincida con el grupo de servidores correspondiente</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">El color de fondo de la pestaña del editor coincidirá con el grupo de servidores pertinente</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">Controla cómo colorear las pestañas basadas en el grupo de servidores de la conexión activa</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">Controla si se muestra la información de conexión para una pestaña en el título.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">Solicitud para guardar los archivos SQL generados</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">Establezca keybinding workbench.action.query.shortcut{0} para ejecutar el texto del acceso directo como una llamada de procedimiento o en la ejecución de una consulta. Cualquier texto seleccionado en el editor de consultas se pasará como un parámetro al final de la consulta, o bien puede hacer referencia a él con {arg}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nueva consulta</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Ejecutar</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">Explicar</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">Real</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Cambiar conexión</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Conectar</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">Habilitar SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">Desactivar SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Seleccionar la base de datos</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">No se pudo cambiar la base de datos</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">No se ha podido cambiar de base de datos: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">Exportación como cuaderno</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">Resultados</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">Mensajes</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">Tiempo transcurrido</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">Recuento de filas</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} filas</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">Ejecutando consulta...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">Estado de ejecución</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">Resumen de la selección</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">Promedio: {0}; recuento: {1}; suma: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">Cuadrícula y mensajes de resultados</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">Controla la familia de fuentes.</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">Controla el grosor de la fuente.</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">Controla el tamaño de fuente en píxeles.</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">Controla el espacio entre letras en píxeles.</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">Controla la altura de la fila en píxeles</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">Controla el relleno de la celda en píxeles</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">Redimensione automáticamente el ancho de las columnas en los resultados iniciales. Podría tener problemas de rendimiento si hay muchas columnas o las celdas son grandes.</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">El máximo ancho en píxeles de las columnas de tamaño automático</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">Alternar el historial de consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Eliminar</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Borrar todo el historial</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">Abrir consulta</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Ejecutar consulta</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">Alternar la captura del historial de consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Pausar la captura del historial de consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Iniciar la captura del historial de consultas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">se realizó correctamente</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">error</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">No hay consultas que mostrar.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">Historial de consultas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">Historial de consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">Si la captura del historial de consultas está habilitada. De no ser así, las consultas ejecutadas no se capturarán.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Borrar todo el historial</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Pausar la captura del historial de consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Iniciar la captura del historial de consultas</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Vista</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Historial de consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">Historial de consultas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">Plan de consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">Operación</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">Objeto</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">Costo estimado</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">Coste del subárbol estimado</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">Filas reales</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">Filas estimadas</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">Ejecuciones reales</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">Costo de CPU estimado</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">Costo de E/S estimado</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">Paralelo</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">Reenlaces reales</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">Reenlaces estimados</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">Rebobinados reales</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">Rebobinados estimados</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">Particionado</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">Operaciones principales</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visor de recursos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">Error al abrir el vínculo: {0}.</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">Error al ejecutar el comando "{0}": {1}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">Árbol del visor de recursos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">Identificador del recurso.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Nombre de la vista en lenguaje natural. Se mostrará</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">Ruta de acceso al icono del recurso.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">Aporta recursos a la vista de recursos.</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">la propiedad "{0}" es obligatoria y debe ser de tipo "string"</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">la propiedad "{0}" se puede omitir o debe ser de tipo "string"</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">Debe habilitar las características en versión preliminar para utilizar la restauración</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">No se admite el comando de copia de seguridad en el contexto del servidor. Seleccione un servidor o base de datos y vuelva a intentarlo.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">No se admite el comando de restauración para bases de datos de Azure SQL.</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script como crear</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script como borrar</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Seleccionar el top 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script como ejecutar</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script como modificar</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Editar datos</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Seleccionar el top 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Take 10</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script como crear</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script como ejecutar</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script como modificar</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script como borrar</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">Error al actualizar el nodo "{0}"; {1}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} tareas en curso</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Vista</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">Tareas</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Tareas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">Alternar tareas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">se realizó correctamente</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">error</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">en curso</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">no iniciado</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">cancelado</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">cancelando</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">No hay un historial de tareas para mostrar.</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">Historial de tareas</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">Error de la tarea</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">No se ha podido ejecutar la tarea.</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">No hay ningún proveedor de datos registrado que pueda proporcionar datos de la vista.</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Contraer todo</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">Error al ejecutar el comando {1}: {0}. Probablemente esté provocado por la extensión que contribuye a {1}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Cerrar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">Las características en versión preliminar mejoran la experiencia en Azure Data Studio, ya que ofrecen acceso completo a nuevas funciones y mejoras. Puede obtener más información sobre las características en versión preliminar [aquí]({0}). ¿Quiere habilitar las características en versión preliminar?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">Sí (opción recomendada)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">No, no volver a mostrar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">Esta página de características está en versión preliminar. Las características en versión preliminar presentan nuevas funcionalidades que están en proceso de convertirse en parte permanente del producto. Son estables, pero necesitan mejoras de accesibilidad adicionales. Agradeceremos sus comentarios iniciales mientras están en desarrollo.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">Versión preliminar</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">Crear una conexión</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">Conéctese a una instancia de una base de datos por medio del cuadro de diálogo de conexión.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">Ejecutar una consulta</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">Interactúe con los datos por medio de un editor de consultas.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">Crear un cuaderno</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">Cree un nuevo cuaderno con un editor de cuadernos nativo.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Implementar un servidor</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">Cree una nueva instancia de un servicio de datos relacionales en la plataforma de su elección.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">Recursos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">Historial</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">Ubicación</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">Mostrar más</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Mostrar página principal al inicio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">Vínculos útiles</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">Introducción</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Descubra las funcionalidades que ofrece Azure Data Studio y aprenda a sacarles el máximo partido.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentación</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">Visite el centro de documentación para acceder a guías de inicio rápido y paso a paso, así como consultar referencias para PowerShell, API, etc.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">Vídeos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Información general de Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Introducción a los cuadernos de Azure Data Studio | Datos expuestos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensiones</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">Mostrar todo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">Más información </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Conexiones</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">Conéctese a SQL Server y Azure, realice consultas, administre las conexiones y mucho más.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Siguiente</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Cuadernos</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">Empiece a crear su propio cuaderno o colección de cuadernos en un solo lugar.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensiones</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Amplíe la funcionalidad de Azure Data Studio mediante la instalación de extensiones desarrolladas por nosotros y Microsoft, así como por la comunidad de terceros (es decir, ¡usted!).</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Configuración</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">Personalice Azure Data Studio según sus preferencias. Puede configurar opciones como el autoguardado y el tamaño de las pestañas, personalizar los métodos abreviados de teclado y cambiar a un tema de color de su gusto.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">Página de bienvenida</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">Descubra las principales características, los archivos abiertos recientemente y las extensiones recomendadas en la página de bienvenida. Para obtener más información sobre cómo empezar a trabajar con Azure Data Studio, consulte los vídeos y la documentación.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">Finalizar</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">Paseo de bienvenida para el usuario</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">Ocultar paseo de presentación</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">Más información</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Ayuda</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Bienvenida</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Paquete de administración de SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Paquete de administración de SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">El paquete de administración para SQL Server es una colección de populares extensiones de administración de bases de datos para ayudarle a administrar SQL Server.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">Agente SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">Importación de SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server dacpac</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Escriba y ejecute scripts de PowerShell con el editor de consultas enriquecidas de Azure Data Studio.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">Virtualización de datos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">Virtualice datos con SQL Server 2019 y cree tablas externas por medio de asistentes interactivos.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">Conéctese a bases de datos Postgre, adminístrelas y realice consultas en ellas con Azure Data Studio.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">El soporte para '{0}' ya está instalado.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">La ventana se volverá a cargar después de instalar compatibilidad adicional con {0}.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">Instalando compatibilidad adicional con {0}...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">No se pudo encontrar el soporte para {0} con id {1}.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nueva conexión</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nueva consulta</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Nuevo cuaderno</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Implementar un servidor</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Bienvenida</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">Nuevo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">Abrir...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">Abrir archivo...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">Abrir carpeta...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">Iniciar paseo</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">Cerrar barra del paseo introductorio</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">¿Le gustaría dar un paseo introductorio por Azure Data Studio?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">¡Le damos la bienvenida!</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">Abrir la carpeta {0} con la ruta de acceso {1}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Instalar</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">Instalar asignación de teclas de {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">Instalar compatibilidad adicional con {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">Instalado</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">El mapa de teclas de {0} ya está instalado</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">La compatibilidad con {0} ya está instalada</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Detalles</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">Color de fondo para la página de bienvenida.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Inicio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nueva conexión</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nueva consulta</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Nuevo cuaderno</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Abrir archivo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Abrir archivo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">Implementar</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">Nueva implementación...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Reciente</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">Más...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">No hay ninguna carpeta reciente.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Ayuda</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">Introducción</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentación</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">Notificar problema o solicitud de características</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">Repositorio de GitHub</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">Notas de la versión</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Mostrar página principal al inicio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">Personalizar</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensiones</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">Descargue las extensiones que necesite, incluido el paquete de administración de SQL Server y mucho más</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">Métodos abreviados de teclado</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">Encuentre sus comandos favoritos y personalícelos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">Tema de color</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">Modifique a su gusto la apariencia del editor y el código</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">Información</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">Encontrar y ejecutar todos los comandos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">Acceda rápidamente a los comandos y búsquelos desde la paleta de comandos ({0})</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">Descubra las novedades de esta última versión</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">Nuevas entradas del blog mensuales que muestran nuestras nuevas características</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Síganos en Twitter</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">Manténgase al día sobre cómo la comunidad usa Azure Data Studio y hable directamente con los ingenieros.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">Cuentas</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">Cuentas vinculadas</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Cerrar</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">No hay ninguna cuenta vinculada. Agregue una cuenta.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">Agregar una cuenta</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">No tiene ninguna nube habilitada. Vaya a la configuración, busque la configuración de la cuenta de Azure y habilite por lo menos una nube.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">No ha seleccionado ningún proveedor de autenticación. Vuelva a intentarlo.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Error al agregar la cuenta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">Debe actualizar las credenciales para esta cuenta.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Cerrar</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">Adición de cuenta en curso...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">El usuario canceló la actualización de la cuenta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Cuenta de Azure</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Inquilino de Azure</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">Copiar y abrir</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">Código de usuario</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">Sitio web</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">No se puede iniciar OAuth automático. Ya hay un OAuth automático en curso.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">Se necesita la conexión para interactuar con el servicio de administración</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Ningún controlador registrado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">Para interactuar con el servicio de evaluación, se necesita una conexión.</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">No hay ningún controlador registrado.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">Propiedades avanzadas</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Descartar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">Descripción del servidor (opcional)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">Borrar lista</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">Lista de conexiones recientes borrada</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">¿Está seguro que desea eliminar todas las conexiones de la lista?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Eliminar</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">Obtener la cadena de conexión actual</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">La cadena de conexión no está disponible</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">Ninguna conexión activa disponible</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Examinar</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">Escriba aquí para filtrar la lista</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">Filtrado de conexiones</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">Aplicación de filtro en curso</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">Eliminación del filtro en curso</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">Filtro aplicado</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">Filtro quitado</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Conexiones guardadas</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Conexiones guardadas</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">Árbol del explorador de conexiones</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">Error de conexión</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">Error en la conexión debido a un error de Kerberos.</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">La ayuda para configurar Kerberos está disponible en {0}</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">Si se ha conectado anteriormente puede que necesite volver a ejecutar kinit.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Conexión</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">Conexión en curso</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">Tipo de conexión</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Reciente</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">Detalles de conexión</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Conectar</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Conexiones recientes</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">Ninguna conexión reciente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">Error al obtener el token de cuenta de Azure para conexión</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">Conexión no aceptada</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">¿Seguro que desea cancelar esta conexión?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">Agregar una cuenta...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Predeterminado&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Cargando...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">Grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Predeterminado&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">Agregar nuevo grupo...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;No guardar&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} es necesario.</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0} se recortará.</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">Recordar contraseña</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">Cuenta</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">Actualizar credenciales de la cuenta</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Inquilino de Azure AD</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">Nombre (opcional)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">Avanzado...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">Debe seleccionar una cuenta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">Se ha conectado a</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">Desconectado</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">Conexiones sin guardar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">Abrir extensiones de panel</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">No hay extensiones de panel instaladas en este momento. Vaya al Administrador de extensiones para explorar las extensiones recomendadas.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">Paso {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Listo</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">Error al inicializar la sesión de edición de datos: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Cerrar</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Acción</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">Copiar detalles</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Error</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Advertencia</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">Información</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">Omitir</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">Ruta seleccionada</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">Archivos de tipo</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Descartar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">Seleccione un archivo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">Árbol explorador de archivos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">Se ha producido un error al cargar el explorador de archivos.</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">Error del explorador de archivos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">Todos los archivos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">Copiar celda</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">No se pasó ningún perfil de conexión al control flotante de información</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">Error de Insights</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">Error al leer el archivo de consulta: </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">Error al analizar la configuración de la conclusión; no se pudo encontrar la matriz/cadena de consulta o el archivo de consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">Artículo</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">Detalles de la conclusión</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">Propiedad</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">Conclusiones</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">Artículos</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">Detalles del artículo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">No se pudo encontrar el archivo de consulta en ninguna de las siguientes rutas:
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">Error</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">Correcto</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">Reintentar</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">Cancelado</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">En curso</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">Estado desconocido</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">En ejecución</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">A la espera de un subproceso</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">Entre reintentos</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">Inactivo</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">Suspendido</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[Obsoleto]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">No programado</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">No ejecutar nunca</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">Se necesita conexión para interactuar con JobManagementService</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">No hay ningún controlador registrado.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Error: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">Error al iniciar la sesión del cuaderno</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">El servidor no se pudo iniciar por una razón desconocida</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">No se encontró el kernel {0}. En su lugar, se utilizará el kernel predeterminado.</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="es">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Error: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="es">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="es">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">No se admite el cambio de tipos de editor en archivos no guardados</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated">N.º de parámetros insertados
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">Seleccione una conexión para ejecutar celdas para este kernel</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">No se pudo eliminar la celda.</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">Error al cambiar de kernel. Se utilizará el kernel {0}. Error: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">No se pudo cambiar el kernel debido al error: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">Error en el cambio de contexto: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">No se pudo iniciar sesión: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">Se ha producido un error en la sesión del cliente al cerrar el cuaderno: {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">No puede encontrar el administrador de cuadernos para el proveedor {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">No se pasó ninguna URI al crear el administrador de cuadernos</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">El proveedor de cuadernos no existe</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">Ya existe una vista con el nombre {0} en este cuaderno.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">Error del kernel SQL</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">Se debe elegir una conexión para ejecutar celdas de cuaderno</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">Mostrando las primeras {0} filas.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">Texto enriquecido</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Vista en dos paneles</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">nbformat v{0}. {1} no reconocido</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">Este archivo no tiene un formato válido de cuaderno</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">Celda de tipo {0} desconocido</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Tipo de salida {0} no reconocido</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">Se espera que los datos para {0} sean una cadena o una matriz de cadenas</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Tipo de salida {0} no reconocido</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">Identificador del proveedor del cuaderno.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">Extensiones de archivo que deben estar registradas en este proveedor de cuadernos</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">Núcleos que deben ser estándar con este proveedor de cuadernos</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">Aporta proveedores de cuadernos.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">Nombre del magic de celda, como "%%sql".</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">El lenguaje de celda que se usará si este magic de celda se incluye en la celda</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">Objetivo de ejecución opcional indicado por este magic, por ejemplo Spark vs SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">Conjunto opcional de kernels para los que esto es válido, por ejemplo python3, pyspark, sql</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">Aporta el lenguaje del cuaderno.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Carga en curso...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualizar</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">Editar conexión</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">Nueva conexión</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">Nuevo grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">Editar grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">Mostrar conexiones activas</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">Mostrar todas las conexiones</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">Eliminar conexión</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">Eliminar grupo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">Error al crear la sesión del Explorador de objetos</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">Varios errores:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">No se puede expandir porque no se encontró el proveedor de conexiones necesario "{0}"</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">Cancelado por el usuario</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">Diálogo de firewall cancelado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Carga en curso...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Conexiones recientes</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Servidores</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Servidores</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">Ordenar por evento</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">Ordenar por columna</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">Borrar todo</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Aplicar</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">Filtros</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">Quitar esta cláusula</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">Guardar filtro</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">Cargar filtro</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">Agregar una cláusula</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">Campo</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">Operador</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">Es NULL</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">No es NULL</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">Contiene</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">No contiene</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">Comienza por</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">No comienza por</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">Error al confirmar una fila: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">La consulta comenzó a ejecutarse a las </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">Comenzó a ejecutar la consulta "{0}"</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">Línea {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">Error al cancelar la consulta: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">Error en la actualización de la celda: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">La ejecución no se completó debido a un error inesperado: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">Tiempo total de ejecución: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">Comenzó a ejecutar la consulta en la línea {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">Se ha iniciado la ejecución del proceso por lotes ({0}).</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">Tiempo de ejecución por lotes: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Error de copia {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">Error al guardar los resultados. </target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">Selección del archivo de resultados</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (delimitado por comas)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Libro de Excel</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">Texto sin formato</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">Se está guardando el archivo...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">Los resultados se han guardado correctamente en {0}.</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Abrir archivo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">De</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">A</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">Crear nueva regla de firewall</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">La dirección IP del cliente no tiene acceso al servidor. Inicie sesión en una cuenta de Azure y cree una regla de firewall para habilitar el acceso.</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">Más información sobre configuración de firewall</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">Regla de firewall</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">Agregar mi IP de cliente </target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">Agregar mi rango IP de subred</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Error al agregar la cuenta</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">Error de la regla de firewall</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">Ruta del archivo de copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">Base de datos de destino</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Restauración de una base de datos</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de datos</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">Archivo de copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Restauración de una base de datos</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Origen</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">Restaurar de</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">Se requiere la ruta de acceso del archivo de copia de seguridad.</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">Especifique una o más rutas de archivo separadas por comas</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de datos</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">Destino</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">Restaurar en</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">Plan de restauración</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">Grupos de copias de seguridad para restaurar</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">Restaurar archivos de base de datos como</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">Restaurar detalles del archivo de base de datos</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">Nombre lógico del archivo</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">Tipo de archivo</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">Nombre del archivo original</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">Restaurar como</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">Opciones de restauración</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">Copia del final del registro</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">Conexiones del servidor</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">General</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Archivos</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Opciones</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">Archivos de copia de seguridad</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">Todos los archivos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">Grupos de servidores</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">Nombre del grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">Se requiere el nombre del grupo.</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">Descripción del grupo</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">Color del grupo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">Agregar grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">Editar grupo de servidores</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">1 o más tareas están en curso. ¿Seguro que desea salir?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sí</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="es">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">Introducción</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">Ver introducción</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">I&amp;&amp;ntroducción</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/admin-tool-ext-win.fr.xlf
+++ b/resources/xlf/fr/admin-tool-ext-win.fr.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/fr/agent.fr.xlf
+++ b/resources/xlf/fr/agent.fr.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">Nouvelle planification</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Annuler</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nom de la planification</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Planifications</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">Créer un proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">Modifier le proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Général</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">Nom du proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">Nom d'identification</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Description</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">Sous-système</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">Système d'exploitation (CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">Instantané de réplication</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">Lecteur du journal des transactions de réplication</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">Serveur de distribution de réplication</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">Fusion de réplication</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">Lecteur de file d'attente de réplication</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">Requête SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">Commande SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">Package SQL Server Integration Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">Actif pour les sous-systèmes suivants</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">Planifications de travail</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">Planifications disponibles :</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Description</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">Créer un opérateur</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">Modifier l'opérateur</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Général</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notifications</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Activé</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">Nom d'e-mail</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">Nom d'e-mail du récepteur de radiomessagerie</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">Lundi</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">Mardi</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">Mercredi</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">Jeudi</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">Vendredi  </target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">Samedi</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">Dimanche</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">Début de journée</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">Fin de journée</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">Planification de la radiomessagerie active</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">Liste d'alertes</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">Nom de l'alerte</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">E-mail</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">Récepteur de radiomessagerie</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">Général</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">Planifications de travail</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Étapes</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Planifications</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Alertes</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">Planifications disponibles :</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notifications</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">Le nom du travail ne peut pas être vide.</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">Nom</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Propriétaire</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">ID</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Catégorie</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">Description</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Activé</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">Liste des étapes de travail</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">Étape</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Type</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">En cas de succès</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">En cas d'échec</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">Nouvelle étape</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">Modifier l'étape</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">Supprimer l'étape</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">Monter l'étape</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">Descendre l'étape</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">Démarrer l'étape</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">Actions à effectuer à la fin du travail</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">E-mail</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">Page</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">Écrire dans le journal des événements d'application Windows</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">Supprimer le travail automatiquement</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">Liste des planifications</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">Choisir une planification</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nom de la planification</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">Liste des alertes</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">Nouvelle alerte</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">Nom de l'alerte</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Activé</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Type</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">Nouveau travail</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">Modifier le travail</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">Message de notification supplémentaire à envoyer</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">Délai entre les réponses</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">Minutes de retard</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">Créer un opérateur</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">Modifier l'opérateur</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Général</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notifications</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Activé</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">Nom d'e-mail</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">Nom d'e-mail du récepteur de radiomessagerie</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">Lundi</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">Mardi</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">Mercredi</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">Jeudi</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">Vendredi  </target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">Samedi</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">Dimanche</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">Début de journée</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">Fin de journée</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">Planification de la radiomessagerie active</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">Liste d'alertes</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">Nom de l'alerte</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">E-mail</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">Récepteur de radiomessagerie</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">La mise à jour du proxy a échoué '{0}'</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Général</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">Proxy '{0}' mis à jour</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Étapes</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">Proxy '{0}' créé</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">Planifications</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Alertes</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notifications</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">Le nom du travail ne peut pas être vide.</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Propriétaire</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Catégorie</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Description</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Activé</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">Liste des étapes de travail</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">Étape</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Type</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">En cas de succès</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">En cas d'échec</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">Nouvelle étape</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">Modifier l'étape</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">Supprimer l'étape</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">Monter l'étape</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">Descendre l'étape</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">Démarrer l'étape</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">Actions à effectuer à la fin du travail</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">E-mail</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">Page</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">Écrire dans le journal des événements d'application Windows</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">Supprimer le travail automatiquement</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Liste des planifications</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Choisir une planification</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Supprimer une planification</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">Liste des alertes</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">Nouvelle alerte</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">Nom de l'alerte</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Activé</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Type</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">Nouveau travail</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">Modifier le travail</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">La mise à jour de l'étape a échoué '{0}'</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">Le nom du travail doit être fourni</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">Le nom de l'étape doit être fourni</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">La mise à jour de l'étape a échoué '{0}'</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">Le nom du travail doit être fourni</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">Le nom de l'étape doit être fourni</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">Cette fonctionnalité est en cours de développement. Découvrez les dernières builds Insiders pour tester les changements les plus récents !</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">Modèle mis à jour</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">Échec de la mise à jour du modèle</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">Le bloc-notes doit être enregistré avant d’être planifié. Enregistrez, puis réessayez la planification.</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">Ajouter une nouvelle connexion</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">Sélectionnez une connexion</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">Sélectionnez une connexion valide.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">Cette fonctionnalité est en cours de développement. Découvrez les dernières builds Insiders pour tester les changements les plus récents !</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">Créer un proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">Modifier le proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Général</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">Nom du proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">Nom d'identification</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Description</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">Sous-système</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">Système d'exploitation (CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">Instantané de réplication</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">Lecteur du journal des transactions de réplication</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">Serveur de distribution de réplication</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">Fusion de réplication</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">Lecteur de file d'attente de réplication</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">Requête SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">Commande SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">Package SQL Server Integration Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">La mise à jour du proxy a échoué '{0}'</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">Proxy '{0}' mis à jour</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">Proxy '{0}' créé</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">Nouveau travail de notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">Modifier le travail du bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Général</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">Détails du notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">Chemin d’accès de bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">Base de données de stockage</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">Base de données d’exécution</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Sélectionner une base de données</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">Détails du travail</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Propriétaire</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Liste des planifications</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Choisir une planification</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Supprimer une planification</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Description</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">Sélectionnez un bloc-notes à planifier à partir du PC</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">Sélectionner une base de données pour stocker toutes les métadonnées et résultats du travail de bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">Sélectionnez une base de données pour laquelle les requêtes de bloc-notes vont s’exécuter</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">Une fois le bloc-notes terminé</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">En cas d’échec du bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">En cas de réussite du bloc-notes.</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">Le nom du bloc-notes doit être fourni</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">Le chemin du modèle doit être fourni</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">Chemin d'accès du bloc-notes non valide</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">Sélectionner une base de données de stockage</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">Sélectionner une base de données d’exécution</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">Le travail portant un nom similaire existe déjà</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">Échec de la mise à jour du bloc-notes « {0} »</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">Échec de la création du bloc-notes « {0} »</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">Le bloc-notes « {0} » a été mis à jour</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">Le bloc-notes « {0} » a été créé</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/azurecore.fr.xlf
+++ b/resources/xlf/fr/azurecore.fr.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">Erreur de récupération des groupes de ressources pour le compte {0} ({1}), abonnement {2} ({3}), locataire {4} : {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">Erreur de récupération des emplacements pour le compte {0} ({1}), abonnement {2} ({3}), locataire {4} : {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">Requête non valide</target>
@@ -379,7 +383,7 @@
         <target state="translated">SQL Server - Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
         <target state="translated">PostgreSQL Hyperscale avec Azure Arc</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
@@ -411,7 +415,7 @@
         <target state="translated">Erreur non identifiée avec l'authentification Azure</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">Le locataire spécifié avec l'ID « {0} » est introuvable.</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,7 +423,7 @@
         <target state="translated">Une erreur s'est produite pendant l'authentification ou vos jetons ont été supprimés du système. Essayez de rajouter votre compte à Azure Data Studio.</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">La récupération du jeton a échoué avec une erreur. Ouvrir les outils de développement pour voir l'erreur</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">L'obtention des informations d'identification a échoué pour le compte {0}. Accédez à la boîte de dialogue des comptes et actualisez le compte.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">Les demandes de ce compte ont été limitées. Pour réessayer, sélectionnez un nombre plus petit d’abonnements.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">Une erreur s’est produite lors du chargement des ressources Azure : {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Cluster Azure Data Explorer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/big-data-cluster.fr.xlf
+++ b/resources/xlf/fr/big-data-cluster.fr.xlf
@@ -12,15 +12,15 @@
       </trans-unit>
       <trans-unit id="command.connectController.title">
         <source xml:lang="en">Connect to Existing Controller</source>
-        <target state="new">Connect to Existing Controller</target>
+        <target state="translated">Se connecter au contrôleur existant</target>
       </trans-unit>
       <trans-unit id="command.createController.title">
         <source xml:lang="en">Create New Controller</source>
-        <target state="new">Create New Controller</target>
+        <target state="translated">Créer un contrôleur</target>
       </trans-unit>
       <trans-unit id="command.removeController.title">
         <source xml:lang="en">Remove Controller</source>
-        <target state="new">Remove Controller</target>
+        <target state="translated">Supprimer le contrôleur</target>
       </trans-unit>
       <trans-unit id="command.refreshController.title">
         <source xml:lang="en">Refresh</source>
@@ -49,16 +49,136 @@
       <trans-unit id="bdc.view.welcome.connect">
         <source xml:lang="en">No SQL Big Data Cluster controllers registered. [Learn More](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
 [Connect Controller](command:bigDataClusters.command.connectController)</source>
-        <target state="new">No SQL Big Data Cluster controllers registered. [Learn More](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
-[Connect Controller](command:bigDataClusters.command.connectController)</target>
+        <target state="translated">Aucun contrôleur de cluster Big Data SQL n'est inscrit. [En savoir plus](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
+[Connecter un contrôleur](command:bigDataClusters.command.connectController)</target>
       </trans-unit>
       <trans-unit id="bdc.view.welcome.loading">
         <source xml:lang="en">Loading controllers...</source>
-        <target state="new">Loading controllers...</target>
+        <target state="translated">Chargement des contrôleurs...</target>
       </trans-unit>
       <trans-unit id="bdc.ignoreSslVerification.desc">
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">Ignorer les erreurs de vérification SSL sur les points de terminaison de cluster Big Data SQL Server de type HDFS, Spark et Contrôleur si la valeur est true</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">Cluster Big Data SQL Server</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">Le cluster Big Data SQL Server vous permet de déployer des clusters scalables de conteneurs SQL Server, Spark et HDFS s'exécutant sur Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Version</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">Cible de déploiement</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">Nouveau cluster Azure Kubernetes Service</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">Cluster Azure Kubernetes Service existant</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">Cluster Kubernetes existant (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">Cluster Azure Red Hat OpenShift existant</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">Cluster OpenShift existant</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">Paramètres de cluster Big Data SQL Server</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">Nom de cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">Nom d'utilisateur du contrôleur</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">Mot de passe</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">Confirmer le mot de passe</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Paramètres Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">ID d'abonnement</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">Utiliser mon abonnement Azure par défaut</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">Nom de groupe de ressources</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">Région</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">Nom du cluster AKS</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">Taille de machine virtuelle</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">Nombre de machines virtuelles</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">Nom de la classe de stockage</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">Capacité de données (Go)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">Capacité des journaux (Go)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">J'accepte {0}, {1} et {2}.</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Déclaration de confidentialité Microsoft</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">Termes du contrat de licence azdata</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">Termes du contrat de licence SQL Server</target>
       </trans-unit>
     </body>
   </file>
@@ -254,299 +374,299 @@
     <body>
       <trans-unit id="bdc.dashboard.status">
         <source xml:lang="en">Status Icon</source>
-        <target state="new">Status Icon</target>
+        <target state="translated">Icône d'état</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.instance">
         <source xml:lang="en">Instance</source>
-        <target state="new">Instance</target>
+        <target state="translated">Instance</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.state">
         <source xml:lang="en">State</source>
-        <target state="new">State</target>
+        <target state="translated">État</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.view">
         <source xml:lang="en">View</source>
-        <target state="new">View</target>
+        <target state="translated">Voir</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.notAvailable">
         <source xml:lang="en">N/A</source>
-        <target state="new">N/A</target>
+        <target state="translated">N/A</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.healthStatusDetails">
         <source xml:lang="en">Health Status Details</source>
-        <target state="new">Health Status Details</target>
+        <target state="translated">Détails de l'état d'intégrité</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.metricsAndLogs">
         <source xml:lang="en">Metrics and Logs</source>
-        <target state="new">Metrics and Logs</target>
+        <target state="translated">Métriques et journaux</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.healthStatus">
         <source xml:lang="en">Health Status</source>
-        <target state="new">Health Status</target>
+        <target state="translated">État d'intégrité</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.nodeMetrics">
         <source xml:lang="en">Node Metrics</source>
-        <target state="new">Node Metrics</target>
+        <target state="translated">Métriques de nœud</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.sqlMetrics">
         <source xml:lang="en">SQL Metrics</source>
-        <target state="new">SQL Metrics</target>
+        <target state="translated">Métriques SQL</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.logs">
         <source xml:lang="en">Logs</source>
-        <target state="new">Logs</target>
+        <target state="translated">Journaux</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewNodeMetrics">
         <source xml:lang="en">View Node Metrics {0}</source>
-        <target state="new">View Node Metrics {0}</target>
+        <target state="translated">Voir les métriques de nœud {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewSqlMetrics">
         <source xml:lang="en">View SQL Metrics {0}</source>
-        <target state="new">View SQL Metrics {0}</target>
+        <target state="translated">Voir les métriques SQL {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewLogs">
         <source xml:lang="en">View Kibana Logs {0}</source>
-        <target state="new">View Kibana Logs {0}</target>
+        <target state="translated">Voir les journaux Kibana {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.lastUpdated">
         <source xml:lang="en">Last Updated : {0}</source>
-        <target state="new">Last Updated : {0}</target>
+        <target state="translated">Dernière mise à jour : {0}</target>
       </trans-unit>
       <trans-unit id="basicAuthName">
         <source xml:lang="en">Basic</source>
-        <target state="new">Basic</target>
+        <target state="translated">De base</target>
       </trans-unit>
       <trans-unit id="integratedAuthName">
         <source xml:lang="en">Windows Authentication</source>
-        <target state="new">Windows Authentication</target>
+        <target state="translated">Authentification Windows</target>
       </trans-unit>
       <trans-unit id="addNewController">
         <source xml:lang="en">Add New Controller</source>
-        <target state="new">Add New Controller</target>
+        <target state="translated">Ajouter un nouveau contrôleur</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
-        <target state="new">URL</target>
+        <target state="translated">URL</target>
       </trans-unit>
       <trans-unit id="username">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">Nom d'utilisateur</target>
       </trans-unit>
       <trans-unit id="password">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">Mot de passe</target>
       </trans-unit>
       <trans-unit id="rememberPassword">
         <source xml:lang="en">Remember Password</source>
-        <target state="new">Remember Password</target>
+        <target state="translated">Se souvenir du mot de passe</target>
       </trans-unit>
       <trans-unit id="clusterManagementUrl">
         <source xml:lang="en">Cluster Management URL</source>
-        <target state="new">Cluster Management URL</target>
+        <target state="translated">URL de gestion de cluster</target>
       </trans-unit>
       <trans-unit id="textAuthCapital">
         <source xml:lang="en">Authentication type</source>
-        <target state="new">Authentication type</target>
+        <target state="translated">Type d'authentification</target>
       </trans-unit>
       <trans-unit id="hdsf.dialog.connection.section">
         <source xml:lang="en">Cluster Connection</source>
-        <target state="new">Cluster Connection</target>
+        <target state="translated">Connexion du cluster</target>
       </trans-unit>
       <trans-unit id="add">
         <source xml:lang="en">Add</source>
-        <target state="new">Add</target>
+        <target state="translated">Ajouter</target>
       </trans-unit>
       <trans-unit id="cancel">
         <source xml:lang="en">Cancel</source>
-        <target state="new">Cancel</target>
+        <target state="translated">Annuler</target>
       </trans-unit>
       <trans-unit id="ok">
         <source xml:lang="en">OK</source>
-        <target state="new">OK</target>
+        <target state="translated">OK</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.refresh">
         <source xml:lang="en">Refresh</source>
-        <target state="new">Refresh</target>
+        <target state="translated">Actualiser</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.troubleshoot">
         <source xml:lang="en">Troubleshoot</source>
-        <target state="new">Troubleshoot</target>
+        <target state="translated">Résoudre les problèmes</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.bdcOverview">
         <source xml:lang="en">Big Data Cluster overview</source>
-        <target state="new">Big Data Cluster overview</target>
+        <target state="translated">Vue d'ensemble du cluster Big Data</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterDetails">
         <source xml:lang="en">Cluster Details</source>
-        <target state="new">Cluster Details</target>
+        <target state="translated">Détails du cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterOverview">
         <source xml:lang="en">Cluster Overview</source>
-        <target state="new">Cluster Overview</target>
+        <target state="translated">Vue d'ensemble du cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.serviceEndpoints">
         <source xml:lang="en">Service Endpoints</source>
-        <target state="new">Service Endpoints</target>
+        <target state="translated">Points de terminaison de service</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterProperties">
         <source xml:lang="en">Cluster Properties</source>
-        <target state="new">Cluster Properties</target>
+        <target state="translated">Propriétés du cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterState">
         <source xml:lang="en">Cluster State</source>
-        <target state="new">Cluster State</target>
+        <target state="translated">État du cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.serviceName">
         <source xml:lang="en">Service Name</source>
-        <target state="new">Service Name</target>
+        <target state="translated">Nom du service</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.service">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">Service</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.endpoint">
         <source xml:lang="en">Endpoint</source>
-        <target state="new">Endpoint</target>
+        <target state="translated">Point de terminaison</target>
       </trans-unit>
       <trans-unit id="copiedEndpoint">
         <source xml:lang="en">Endpoint '{0}' copied to clipboard</source>
-        <target state="new">Endpoint '{0}' copied to clipboard</target>
+        <target state="translated">Point de terminaison '{0}' copié dans le Presse-papiers</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.copy">
         <source xml:lang="en">Copy</source>
-        <target state="new">Copy</target>
+        <target state="translated">Copier</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewDetails">
         <source xml:lang="en">View Details</source>
-        <target state="new">View Details</target>
+        <target state="translated">Voir les détails</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewErrorDetails">
         <source xml:lang="en">View Error Details</source>
-        <target state="new">View Error Details</target>
+        <target state="translated">Voir les détails de l'erreur</target>
       </trans-unit>
       <trans-unit id="connectController.dialog.title">
         <source xml:lang="en">Connect to Controller</source>
-        <target state="new">Connect to Controller</target>
+        <target state="translated">Se connecter au contrôleur</target>
       </trans-unit>
       <trans-unit id="mount.main.section">
         <source xml:lang="en">Mount Configuration</source>
-        <target state="new">Mount Configuration</target>
+        <target state="translated">Configuration du montage</target>
       </trans-unit>
       <trans-unit id="mount.task.name">
         <source xml:lang="en">Mounting HDFS folder on path {0}</source>
-        <target state="new">Mounting HDFS folder on path {0}</target>
+        <target state="translated">Montage du dossier HDFS sur le chemin {0}</target>
       </trans-unit>
       <trans-unit id="refreshmount.task.name">
         <source xml:lang="en">Refreshing HDFS Mount on path {0}</source>
-        <target state="new">Refreshing HDFS Mount on path {0}</target>
+        <target state="translated">Actualisation du montage HDFS sur le chemin {0}</target>
       </trans-unit>
       <trans-unit id="deletemount.task.name">
         <source xml:lang="en">Deleting HDFS Mount on path {0}</source>
-        <target state="new">Deleting HDFS Mount on path {0}</target>
+        <target state="translated">Suppression du montage HDFS sur le chemin {0}</target>
       </trans-unit>
       <trans-unit id="mount.task.submitted">
         <source xml:lang="en">Mount creation has started</source>
-        <target state="new">Mount creation has started</target>
+        <target state="translated">La création du montage a commencé</target>
       </trans-unit>
       <trans-unit id="refreshmount.task.submitted">
         <source xml:lang="en">Refresh mount request submitted</source>
-        <target state="new">Refresh mount request submitted</target>
+        <target state="translated">Demande d'actualisation du montage envoyée</target>
       </trans-unit>
       <trans-unit id="deletemount.task.submitted">
         <source xml:lang="en">Delete mount request submitted</source>
-        <target state="new">Delete mount request submitted</target>
+        <target state="translated">Supprimer la demande de montage envoyée</target>
       </trans-unit>
       <trans-unit id="mount.task.complete">
         <source xml:lang="en">Mounting HDFS folder is complete</source>
-        <target state="new">Mounting HDFS folder is complete</target>
+        <target state="translated">Le montage du dossier HDFS est terminé</target>
       </trans-unit>
       <trans-unit id="mount.task.inprogress">
         <source xml:lang="en">Mounting is likely to complete, check back later to verify</source>
-        <target state="new">Mounting is likely to complete, check back later to verify</target>
+        <target state="translated">Le montage va probablement être effectué, revenez vérifier plus tard</target>
       </trans-unit>
       <trans-unit id="mount.dialog.title">
         <source xml:lang="en">Mount HDFS Folder</source>
-        <target state="new">Mount HDFS Folder</target>
+        <target state="translated">Monter le dossier HDFS</target>
       </trans-unit>
       <trans-unit id="mount.hdfsPath.title">
         <source xml:lang="en">HDFS Path</source>
-        <target state="new">HDFS Path</target>
+        <target state="translated">Chemin HDFS</target>
       </trans-unit>
       <trans-unit id="mount.hdfsPath.info">
         <source xml:lang="en">Path to a new (non-existing) directory which you want to associate with the mount</source>
-        <target state="new">Path to a new (non-existing) directory which you want to associate with the mount</target>
+        <target state="translated">Chemin d'un nouveau répertoire (non existant) à associer au montage</target>
       </trans-unit>
       <trans-unit id="mount.remoteUri.title">
         <source xml:lang="en">Remote URI</source>
-        <target state="new">Remote URI</target>
+        <target state="translated">URI distant</target>
       </trans-unit>
       <trans-unit id="mount.remoteUri.info">
         <source xml:lang="en">The URI to the remote data source. Example for ADLS: abfs://fs@saccount.dfs.core.windows.net/</source>
-        <target state="new">The URI to the remote data source. Example for ADLS: abfs://fs@saccount.dfs.core.windows.net/</target>
+        <target state="translated">URI de la source de données distante. Exemple pour ADLS : abfs://fs@saccount.dfs.core.windows.net/</target>
       </trans-unit>
       <trans-unit id="mount.credentials.title">
         <source xml:lang="en">Credentials</source>
-        <target state="new">Credentials</target>
+        <target state="translated">Informations d'identification</target>
       </trans-unit>
       <trans-unit id="mount.credentials.info">
         <source xml:lang="en">Mount credentials for authentication to remote data source for reads</source>
-        <target state="new">Mount credentials for authentication to remote data source for reads</target>
+        <target state="translated">Informations d'identification de montage pour l'authentification auprès de la source de données distante pour les lectures</target>
       </trans-unit>
       <trans-unit id="refreshmount.dialog.title">
         <source xml:lang="en">Refresh Mount</source>
-        <target state="new">Refresh Mount</target>
+        <target state="translated">Actualiser le montage</target>
       </trans-unit>
       <trans-unit id="deleteMount.dialog.title">
         <source xml:lang="en">Delete Mount</source>
-        <target state="new">Delete Mount</target>
+        <target state="translated">Supprimer le montage</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.loadingClusterStateCompleted">
         <source xml:lang="en">Loading cluster state completed</source>
-        <target state="new">Loading cluster state completed</target>
+        <target state="translated">L'état de cluster a été chargé</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.loadingHealthStatusCompleted">
         <source xml:lang="en">Loading health status completed</source>
-        <target state="new">Loading health status completed</target>
+        <target state="translated">L'état d'intégrité a été chargé</target>
       </trans-unit>
       <trans-unit id="err.controller.username.required">
         <source xml:lang="en">Username is required</source>
-        <target state="new">Username is required</target>
+        <target state="translated">Nom d'utilisateur obligatoire</target>
       </trans-unit>
       <trans-unit id="err.controller.password.required">
         <source xml:lang="en">Password is required</source>
-        <target state="new">Password is required</target>
+        <target state="translated">Mot de passe obligatoire</target>
       </trans-unit>
       <trans-unit id="endpointsError">
         <source xml:lang="en">Unexpected error retrieving BDC Endpoints: {0}</source>
-        <target state="new">Unexpected error retrieving BDC Endpoints: {0}</target>
+        <target state="translated">Erreur inattendue pendant la récupération des points de terminaison BDC : {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.noConnection">
         <source xml:lang="en">The dashboard requires a connection. Please click retry to enter your credentials.</source>
-        <target state="new">The dashboard requires a connection. Please click retry to enter your credentials.</target>
+        <target state="translated">Le tableau de bord nécessite une connexion. Cliquez sur Réessayer pour entrer vos informations d'identification.</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.unexpectedError">
         <source xml:lang="en">Unexpected error occurred: {0}</source>
-        <target state="new">Unexpected error occurred: {0}</target>
+        <target state="translated">Erreur inattendue : {0}</target>
       </trans-unit>
       <trans-unit id="mount.hdfs.loginerror1">
         <source xml:lang="en">Login to controller failed</source>
-        <target state="new">Login to controller failed</target>
+        <target state="translated">La connexion au contrôleur a échoué</target>
       </trans-unit>
       <trans-unit id="mount.hdfs.loginerror2">
         <source xml:lang="en">Login to controller failed: {0}</source>
-        <target state="new">Login to controller failed: {0}</target>
+        <target state="translated">La connexion au contrôleur a échoué : {0}</target>
       </trans-unit>
       <trans-unit id="mount.err.formatting">
         <source xml:lang="en">Bad formatting of credentials at {0}</source>
-        <target state="new">Bad formatting of credentials at {0}</target>
+        <target state="translated">Mise en forme incorrecte des informations d'identification sur {0}</target>
       </trans-unit>
       <trans-unit id="mount.task.error">
         <source xml:lang="en">Error mounting folder: {0}</source>
-        <target state="new">Error mounting folder: {0}</target>
+        <target state="translated">Erreur de montage du dossier {0}</target>
       </trans-unit>
       <trans-unit id="mount.error.unknown">
         <source xml:lang="en">Unknown error occurred during the mount process</source>
-        <target state="new">Unknown error occurred during the mount process</target>
+        <target state="translated">Une erreur inconnue s'est produite pendant le processus de montage</target>
       </trans-unit>
     </body>
   </file>
@@ -566,7 +686,7 @@
       </trans-unit>
       <trans-unit id="bdc.error.getClusterConfig">
         <source xml:lang="en">Error retrieving cluster config from {0}</source>
-        <target state="new">Error retrieving cluster config from {0}</target>
+        <target state="translated">Erreur de récupération de la configuration de cluster à partir de {0}</target>
       </trans-unit>
       <trans-unit id="bdc.error.getEndPoints">
         <source xml:lang="en">Error retrieving endpoints from {0}</source>
@@ -582,7 +702,7 @@
       </trans-unit>
       <trans-unit id="bdc.error.statusHdfs">
         <source xml:lang="en">Error getting mount status</source>
-        <target state="new">Error getting mount status</target>
+        <target state="translated">Erreur d'obtention de l'état de montage</target>
       </trans-unit>
       <trans-unit id="bdc.error.refreshHdfs">
         <source xml:lang="en">Error refreshing mount</source>
@@ -602,7 +722,7 @@
       </trans-unit>
       <trans-unit id="bdc.dashboard.title">
         <source xml:lang="en">Big Data Cluster Dashboard -</source>
-        <target state="new">Big Data Cluster Dashboard -</target>
+        <target state="translated">Tableau de bord de cluster Big Data -</target>
       </trans-unit>
       <trans-unit id="textYes">
         <source xml:lang="en">Yes</source>
@@ -614,7 +734,7 @@
       </trans-unit>
       <trans-unit id="textConfirmRemoveController">
         <source xml:lang="en">Are you sure you want to remove '{0}'?</source>
-        <target state="new">Are you sure you want to remove '{0}'?</target>
+        <target state="translated">Voulez-vous vraiment supprimer '{0}' ?</target>
       </trans-unit>
     </body>
   </file>
@@ -622,7 +742,7 @@
     <body>
       <trans-unit id="bdc.controllerTreeDataProvider.error">
         <source xml:lang="en">Unexpected error loading saved controllers: {0}</source>
-        <target state="new">Unexpected error loading saved controllers: {0}</target>
+        <target state="translated">Erreur inattendue pendant chargement des contrôleurs enregistrés : {0}</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/cms.fr.xlf
+++ b/resources/xlf/fr/cms.fr.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">Chargement...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">Une erreur inattendue s'est produite durant le chargement des serveurs enregistrés {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">Chargement...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">Le groupe de serveurs de gestion centralisée a déjà un serveur inscrit nommé {0}</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Vous ne pouvez pas utiliser les serveurs Azure SQL Database comme serveurs de gestion centralisée</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Vous ne pouvez pas utiliser les serveurs Azure SQL comme serveurs de gestion centralisée</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/fr/dacpac.fr.xlf
+++ b/resources/xlf/fr/dacpac.fr.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="fr">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Espacement</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">Chemin d’accès complet du dossier dans lequel . DACPAC et . Les fichiers BACPAC sont enregistrés par défaut</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Serveur cible</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Serveur source</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Base de données source</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Base de données cible</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">Emplacement de fichier</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">Sélectionner un fichier</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">Résumé des paramètres</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Version</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">Paramètre</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valeur</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">Nom de la base de données</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Ouvrir</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">Mettre à niveau la base de données existante</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">Nouvelle base de données</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">{0} des actions de déploiement listées peuvent entraîner une perte de données. Vérifiez que vous avez une sauvegarde ou un instantané disponible en cas de problème avec le déploiement.</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">Poursuivre malgré le risque de perte de données</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">Aucune perte de données suite aux actions de déploiement listées.</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">Enregistrer</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">Emplacement de fichier</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">Version (utiliser x.x.x.x où x est un nombre)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Ouvrir</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">Déployer un fichier .dacpac d'application de couche Données sur une instance de SQL Server [Déployer Dacpac]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">Exporter le schéma et les données d'une base de données au format de fichier logique .bacpac [Exporter Bacpac]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">Nom de la base de données</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">Mettre à niveau la base de données existante</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">Nouvelle base de données</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Base de données cible</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">Serveur cible</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">Serveur source</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">Base de données source</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Version</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">Paramètre</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valeur</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">par défaut</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">Assistant de l'application de la couche Données</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">Générer le script</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">Vous pouvez voir l'état de la génération de script dans la vue Tâches une fois l'Assistant fermé. Le script s'ouvre dès qu'il est généré.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">par défaut</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">Déployer des opérations de plan</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">Une base de données portant le même nom existe déjà sur l'instance de SQL Server</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">Nom non indéfini</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">Le nom ne peut pas se terminer par un point</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">Un nom de fichier ne peut pas être un espace blanc</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">Caractères de fichier non valides</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">Ce nom de fichier est réservé à l’utilisation par Windows. Choisissez un autre nom et essayez à nouveau</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">Nom de fichier réservé. Choisissez un autre nom et réessayez</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">Le nom ne peut pas se terminer par un espace</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">Le nom de fichier est supérieur à 255 caractères</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">La génération du plan de déploiement a échoué '{0}'</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">Échec de génération du script de déploiement « {0} »</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">Échec de l'opération {0} « {1} »</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">Vous pouvez voir l'état de la génération de script dans la vue Tâches une fois l'Assistant fermé. Le script s'ouvre dès qu'il est généré.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/import.fr.xlf
+++ b/resources/xlf/fr/import.fr.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="fr">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">Configuration de l’importation de fichiers plats</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[Facultatif] Journaliser la sortie de débogage dans la console (Voir -&gt; Sortie) et sélectionner le canal de sortie approprié dans la liste déroulante</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">{0} démarré</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">Démarrage de {0}</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">Échec du démarrage de {0} : {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">Installation de {0} sur {1}</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">Installation du service {0}</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">{0} installé</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Téléchargement de {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} Ko)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Téléchargement de {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">Téléchargement terminé {0}</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">{0} extrait ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">Envoyer des commentaires</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">le composant de service n'a pas pu démarrer</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">Serveur contenant la base de données</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">Base de données dans laquelle la table est créée</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">Emplacement de fichier non valide. Essayez un autre fichier d’entrée</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Parcourir</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Ouvrir</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">Emplacement du fichier à importer</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">Nouveau nom de table</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">Schéma de table</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">Importer des données</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Suivant</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">Nom de la colonne</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">Type de données</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">Clé primaire</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">Autoriser les valeurs Null</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">Cette opération a analysé la structure du fichier d'entrée pour générer l'aperçu ci-dessous des 50 premières lignes.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">Cette opération a échoué. Essayez un autre fichier d'entrée.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualiser</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">Importer les informations</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ Vous avez inséré les données dans une table.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">Cette opération a analysé la structure du fichier d'entrée pour générer l'aperçu ci-dessous des 50 premières lignes.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">Cette opération a échoué. Essayez un autre fichier d'entrée.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualiser</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">Importer des données</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Suivant</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">Nom de la colonne</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">Type de données</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">Clé primaire</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">Autoriser les valeurs Null</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">Serveur contenant la base de données</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">Base de données dans laquelle la table est créée</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">Parcourir</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Ouvrir</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">Emplacement du fichier à importer</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">Nouveau nom de table</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">Schéma de table</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">Connectez-vous à un serveur avant d'utiliser cet Assistant.</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">L’extension d’importation de SQL Server ne prend pas en charge ce type de connexion</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">Importer un nouveau fichier</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">Envoyer des commentaires</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">le composant de service n'a pas pu démarrer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">Service démarré</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">Démarrage du service</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">Le démarrage du service d'importation {0} a échoué</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">Installation du service {0} sur {1}</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">Installation du service</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Installé</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">Téléchargement de {0}</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} Ko)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">Service de téléchargement</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">Terminé !</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/notebook.fr.xlf
+++ b/resources/xlf/fr/notebook.fr.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Chemin local d'une installation précédente de Python utilisée par Notebooks.</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">Ne pas afficher d’invite pour mettre à jour Python.</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">Durée d’attente (en minutes) avant l’arrêt d’un serveur une fois tous les blocs-notes fermés. (Entrez 0 pour ne pas arrêter)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Remplacez les paramètres d'éditeur par défaut dans l'éditeur de notebook. Les paramètres comprennent la couleur d'arrière-plan, la couleur de la ligne actuelle et la bordure</target>
@@ -32,7 +40,7 @@
       </trans-unit>
       <trans-unit id="notebook.trustedBooks.description">
         <source xml:lang="en">Notebooks contained in these books will automatically be trusted.</source>
-        <target state="new">Notebooks contained in these books will automatically be trusted.</target>
+        <target state="translated">Les notebooks contenus dans ces books sont automatiquement approuvés.</target>
       </trans-unit>
       <trans-unit id="notebook.maxBookSearchDepth.description">
         <source xml:lang="en">Maximum depth of subdirectories to search for Books (Enter 0 for infinite)</source>
@@ -40,15 +48,19 @@
       </trans-unit>
       <trans-unit id="notebook.collapseBookItems.description">
         <source xml:lang="en">Collapse Book items at root level in the Notebooks Viewlet</source>
-        <target state="new">Collapse Book items at root level in the Notebooks Viewlet</target>
+        <target state="translated">Réduire les éléments Book au niveau racine dans la viewlet Notebooks</target>
       </trans-unit>
       <trans-unit id="notebook.remoteBookDownloadTimeout.description">
         <source xml:lang="en">Download timeout in milliseconds for GitHub books</source>
-        <target state="new">Download timeout in milliseconds for GitHub books</target>
+        <target state="translated">Délai d'expiration en millisecondes du téléchargement des books GitHub</target>
       </trans-unit>
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
-        <target state="new">Notebooks that are pinned by the user for the current workspace</target>
+        <target state="translated">Notebooks épinglés par l'utilisateur pour l'espace de travail actuel</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,72 +151,84 @@
         <target state="translated">Notebooks Jupyter</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">Enregistrer le notebook</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Enregistrer Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="new">Trust Book</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Jupyter Book de confiance</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">Rechercher dans le notebook</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Rechercher dans Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
-        <target state="new">Notebooks</target>
+        <target state="translated">Notebooks</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="new">Provided Books</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">Jupyter Books fournis</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
-        <target state="new">Pinned notebooks</target>
+        <target state="translated">Notebooks épinglés</target>
       </trans-unit>
       <trans-unit id="title.PreviewLocalizedBook">
         <source xml:lang="en">Get localized SQL Server 2019 guide</source>
-        <target state="new">Get localized SQL Server 2019 guide</target>
+        <target state="translated">Localiser le Guide SQL Server 2019</target>
       </trans-unit>
       <trans-unit id="title.openJupyterBook">
         <source xml:lang="en">Open Jupyter Book</source>
-        <target state="new">Open Jupyter Book</target>
+        <target state="translated">Ouvrir Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.closeJupyterBook">
         <source xml:lang="en">Close Jupyter Book</source>
-        <target state="new">Close Jupyter Book</target>
+        <target state="translated">Fermer Jupyter Book</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="new">Close Jupyter Notebook</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">Fermeture du bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">Voulez-vous supprimer le bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">Ajouter un bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">Ajouter un fichier de marques</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
-        <target state="new">Reveal in Books</target>
+        <target state="translated">Afficher dans Books</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="new">Create Book (Preview)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Créer un Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
-        <target state="new">Open Notebooks in Folder</target>
+        <target state="translated">Ouvrir les notebooks dans le dossier</target>
       </trans-unit>
       <trans-unit id="title.openRemoteJupyterBook">
         <source xml:lang="en">Add Remote Jupyter Book</source>
-        <target state="new">Add Remote Jupyter Book</target>
+        <target state="translated">Ajouter un book Jupyter distant</target>
       </trans-unit>
       <trans-unit id="title.pinNotebook">
         <source xml:lang="en">Pin Notebook</source>
-        <target state="new">Pin Notebook</target>
+        <target state="translated">Épingler le notebook</target>
       </trans-unit>
       <trans-unit id="title.unpinNotebook">
         <source xml:lang="en">Unpin Notebook</source>
-        <target state="new">Unpin Notebook</target>
+        <target state="translated">Détacher le notebook</target>
       </trans-unit>
       <trans-unit id="title.moveTo">
         <source xml:lang="en">Move to ...</source>
-        <target state="new">Move to ...</target>
+        <target state="translated">Déplacer vers...</target>
       </trans-unit>
     </body>
   </file>
@@ -212,11 +236,11 @@
     <body>
       <trans-unit id="ensureDirOutputMsg">
         <source xml:lang="en">... Ensuring {0} exists</source>
-        <target state="new">... Ensuring {0} exists</target>
+        <target state="translated">...Vérification de l'existence de {0}</target>
       </trans-unit>
       <trans-unit id="executeCommandProcessExited">
         <source xml:lang="en">Process exited with error code: {0}. StdErr Output: {1}</source>
-        <target state="new">Process exited with error code: {0}. StdErr Output: {1}</target>
+        <target state="translated">Le processus s'est terminé avec le code d'erreur : {0}, sortie StdErr : {1}</target>
       </trans-unit>
     </body>
   </file>
@@ -224,11 +248,11 @@
     <body>
       <trans-unit id="managePackages.localhost">
         <source xml:lang="en">localhost</source>
-        <target state="new">localhost</target>
+        <target state="translated">localhost</target>
       </trans-unit>
       <trans-unit id="managePackages.packageNotFound">
         <source xml:lang="en">Could not find the specified package</source>
-        <target state="new">Could not find the specified package</target>
+        <target state="translated">Package spécifié introuvable</target>
       </trans-unit>
     </body>
   </file>
@@ -248,293 +272,333 @@
       </trans-unit>
       <trans-unit id="noBDCConnectionError">
         <source xml:lang="en">Spark kernels require a connection to a SQL Server Big Data Cluster master instance.</source>
-        <target state="new">Spark kernels require a connection to a SQL Server Big Data Cluster master instance.</target>
+        <target state="translated">Les noyaux Spark nécessitent une connexion a une instance maître de cluster Big Data SQL Server.</target>
       </trans-unit>
       <trans-unit id="providerNotValidError">
         <source xml:lang="en">Non-MSSQL providers are not supported for spark kernels.</source>
-        <target state="new">Non-MSSQL providers are not supported for spark kernels.</target>
+        <target state="translated">Les fournisseurs non-MSSQL ne sont pas pris en charge pour les noyaux Spark.</target>
       </trans-unit>
       <trans-unit id="allFiles">
         <source xml:lang="en">All Files</source>
-        <target state="new">All Files</target>
+        <target state="translated">Tous les fichiers</target>
       </trans-unit>
       <trans-unit id="labelSelectFolder">
         <source xml:lang="en">Select Folder</source>
-        <target state="new">Select Folder</target>
+        <target state="translated">Sélectionner un dossier</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="new">Select Book</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Sélectionnez un Jupyter Book</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
-        <target state="new">Folder already exists. Are you sure you want to delete and replace this folder?</target>
+        <target state="translated">Le dossier existe déjà. Voulez-vous vraiment supprimer et remplacer ce dossier ?</target>
       </trans-unit>
       <trans-unit id="openNotebookCommand">
         <source xml:lang="en">Open Notebook</source>
-        <target state="new">Open Notebook</target>
+        <target state="translated">Ouvrir le notebook</target>
       </trans-unit>
       <trans-unit id="openMarkdownCommand">
         <source xml:lang="en">Open Markdown</source>
-        <target state="new">Open Markdown</target>
+        <target state="translated">Ouvrir le fichier Markdown</target>
       </trans-unit>
       <trans-unit id="openExternalLinkCommand">
         <source xml:lang="en">Open External Link</source>
-        <target state="new">Open External Link</target>
+        <target state="translated">Ouvrir le lien externe</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="new">Book is now trusted in the workspace.</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">Jupyter Book est maintenant approuvé dans l'espace de travail.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="new">Book is already trusted in this workspace.</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">Jupyter Book est déjà approuvé dans cet espace de travail.</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="new">Book is no longer trusted in this workspace</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">Jupyter Book n'est plus approuvé dans cet espace de travail</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="new">Book is already untrusted in this workspace.</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">Jupyter Book est déjà non approuvé dans cet espace de travail.</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="new">Book {0} is now pinned in the workspace.</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">Jupyter Book {0} est maintenant épinglé dans l'espace de travail.</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="new">Book {0} is no longer pinned in this workspace</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Jupyter Book {0} n'est plus épinglé dans cet espace de travail</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="new">Failed to find a Table of Contents file in the specified book.</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">Aucun fichier de table des matières dans le Jupyter Book spécifié.</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="new">No books are currently selected in the viewlet.</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">Aucun Jupyter Book n'est actuellement sélectionné dans la viewlet.</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="new">Select Book Section</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Sélectionnez la section Jupyter Book</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
-        <target state="new">Add to this level</target>
+        <target state="translated">Ajouter à ce niveau</target>
       </trans-unit>
       <trans-unit id="missingFileError">
         <source xml:lang="en">Missing file : {0} from {1}</source>
-        <target state="new">Missing file : {0} from {1}</target>
+        <target state="translated">Fichier manquant : {0} dans {1}</target>
       </trans-unit>
       <trans-unit id="InvalidError.tocFile">
         <source xml:lang="en">Invalid toc file</source>
-        <target state="new">Invalid toc file</target>
+        <target state="translated">Fichier TOC non valide</target>
       </trans-unit>
       <trans-unit id="Invalid toc.yml">
         <source xml:lang="en">Error: {0} has an incorrect toc.yml file</source>
-        <target state="new">Error: {0} has an incorrect toc.yml file</target>
+        <target state="translated">Erreur : {0} a un fichier toc.yml incorrect</target>
       </trans-unit>
       <trans-unit id="configFileError">
         <source xml:lang="en">Configuration file missing</source>
-        <target state="new">Configuration file missing</target>
+        <target state="translated">Fichier de configuration manquant</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="new">Open book {0} failed: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Échec de l’ouverture du Jupyter Book {0} : {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="new">Failed to read book {0}: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">Échec de la lecture du Jupyter Book {0} : {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
-        <target state="new">Open notebook {0} failed: {1}</target>
+        <target state="translated">L'ouverture du notebook {0} a échoué : {1}</target>
       </trans-unit>
       <trans-unit id="openMarkdownError">
         <source xml:lang="en">Open markdown {0} failed: {1}</source>
-        <target state="new">Open markdown {0} failed: {1}</target>
+        <target state="translated">L'ouverture du fichier Markdown {0} a échoué : {1}</target>
       </trans-unit>
       <trans-unit id="openUntitledNotebookError">
         <source xml:lang="en">Open untitled notebook {0} as untitled failed: {1}</source>
-        <target state="new">Open untitled notebook {0} as untitled failed: {1}</target>
+        <target state="translated">Ouvrez un notebook {0} sans titre, car le {1} sans titre a échoué</target>
       </trans-unit>
       <trans-unit id="openExternalLinkError">
         <source xml:lang="en">Open link {0} failed: {1}</source>
-        <target state="new">Open link {0} failed: {1}</target>
+        <target state="translated">L'ouverture du lien {0} a échoué : {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="new">Close book {0} failed: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Échec de la fermerture de Jupyter Book {0} : {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
  The file has been renamed to {2} to prevent data loss.</source>
-        <target state="new">File {0} already exists in the destination folder {1} 
- The file has been renamed to {2} to prevent data loss.</target>
+        <target state="translated">Le fichier {0} existe déjà dans le dossier de destination {1} 
+ Le fichier a été renommé en {2} pour éviter toute perte de données.</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="new">Error while editing book {0}: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Erreur pendant la modification du Jupyter Book {0} : {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="new">Error while selecting a book or a section to edit: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">Erreur pendant la sélection d'un Jupyter Book ou d'une section à modifier : {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">Échec de la recherche des sections {0} dans {1}.</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
-        <target state="new">URL</target>
+        <target state="translated">URL</target>
       </trans-unit>
       <trans-unit id="repoUrl">
         <source xml:lang="en">Repository URL</source>
-        <target state="new">Repository URL</target>
+        <target state="translated">URL du dépôt</target>
       </trans-unit>
       <trans-unit id="location">
         <source xml:lang="en">Location</source>
-        <target state="new">Location</target>
+        <target state="translated">Emplacement</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="new">Add Remote Book</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">Ajouter un book Jupyter distant</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
-        <target state="new">GitHub</target>
+        <target state="translated">GitHub</target>
       </trans-unit>
       <trans-unit id="onsharedFile">
         <source xml:lang="en">Shared File</source>
-        <target state="new">Shared File</target>
+        <target state="translated">Fichier partagé</target>
       </trans-unit>
       <trans-unit id="releases">
         <source xml:lang="en">Releases</source>
-        <target state="new">Releases</target>
+        <target state="translated">Mises en production</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="new">Book</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter Book</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Version</target>
       </trans-unit>
       <trans-unit id="language">
         <source xml:lang="en">Language</source>
-        <target state="new">Language</target>
+        <target state="translated">Langue</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="new">No books are currently available on the provided link</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">Aucun Jupyter Book n'est disponible actuellement sur le lien fourni</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
-        <target state="new">The url provided is not a Github release url</target>
+        <target state="translated">L'URL fournie n'est pas une URL de mise en production GitHub</target>
       </trans-unit>
       <trans-unit id="search">
         <source xml:lang="en">Search</source>
-        <target state="new">Search</target>
+        <target state="translated">Recherche</target>
       </trans-unit>
       <trans-unit id="add">
         <source xml:lang="en">Add</source>
-        <target state="new">Add</target>
+        <target state="translated">Ajouter</target>
       </trans-unit>
       <trans-unit id="close">
         <source xml:lang="en">Close</source>
-        <target state="new">Close</target>
+        <target state="translated">Fermer</target>
       </trans-unit>
       <trans-unit id="invalidTextPlaceholder">
         <source xml:lang="en">-</source>
-        <target state="new">-</target>
+        <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="new">Remote Book download is in progress</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">Le téléchargement du Jupyter Book distant est en cours</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="new">Remote Book download is complete</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">Jupyter Book distant est téléchargé</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="new">Error while downloading remote Book</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">Erreur lors du téléchargement du Jupyter Book distant</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="new">Error while decompressing remote Book</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">Erreur de décompression du Jupyter Book distant</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="new">Error while creating remote Book directory</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">Erreur pendant la création du répertoire du Jupyter Book distant</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="new">Downloading Remote Book</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">Téléchargement du Jupyter Book distant</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
-        <target state="new">Resource not Found</target>
+        <target state="translated">Ressource introuvable</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="new">Books not Found</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">Jupyter Books introuvables</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
-        <target state="new">Releases not Found</target>
+        <target state="translated">Versions introuvables</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="new">The selected book is not valid</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">Le Jupyter Book sélectionné n'est pas valide</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
-        <target state="new">Http Request failed with error: {0} {1}</target>
+        <target state="translated">La requête HTTP a échoué avec l'erreur : {0} {1}</target>
       </trans-unit>
       <trans-unit id="msgDownloadLocation">
         <source xml:lang="en">Downloading to {0}</source>
-        <target state="new">Downloading to {0}</target>
+        <target state="translated">Téléchargement dans {0}</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="new">New Group</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">Nouveau livre de jupyter (Preview)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="new">Groups are used to organize Notebooks.</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Les livres de la bibliothèque sont utilisés pour organiser les blocs-notes.</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="new">Browse locations...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">En savoir plus.</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="new">Select content folder</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">Dossier de contenu</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">Parcourir</target>
       </trans-unit>
       <trans-unit id="create">
         <source xml:lang="en">Create</source>
-        <target state="new">Create</target>
+        <target state="translated">Créer</target>
       </trans-unit>
       <trans-unit id="name">
         <source xml:lang="en">Name</source>
-        <target state="new">Name</target>
+        <target state="translated">Nom</target>
       </trans-unit>
       <trans-unit id="saveLocation">
         <source xml:lang="en">Save location</source>
-        <target state="new">Save location</target>
+        <target state="translated">Emplacement d'enregistrement</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
-        <target state="new">Content folder (Optional)</target>
+        <target state="translated">Dossier de contenu (facultatif)</target>
       </trans-unit>
       <trans-unit id="msgContentFolderError">
         <source xml:lang="en">Content folder path does not exist</source>
-        <target state="new">Content folder path does not exist</target>
+        <target state="translated">Le chemin du dossier de contenu n'existe pas</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="new">Save location path does not exist</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">Le chemin de l'emplacement d'enregistrement n'existe pas.</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">Erreur lors de la tentative d’accès : {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">Nouveau bloc-notes (Aperçu)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">Nouvel Aperçu Markdown (Aperçu)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">Extension de fichier</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">Le fichier existe déjà. Voulez-vous vraiment remplacer ce fichier?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Titre</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">Nom de fichier</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">Le chemin d’accès de l’emplacement d’enregistrer n’est pas valide.</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">Un fichier nommé {0} existe déjà dans le dossier de destination</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">Une autre installation de Python est actuellement en cours. En attente de la fin de l'installation.</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">Les sessions de bloc-notes python actives seront arrêtées pour permettre la mise à jour. Voulez-vous continuer maintenant ?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">Python {0} est désormais disponible dans Azure Data Studio. La version actuelle de Python (3.6.6) n’est plus prise en charge en décembre 2021. Voulez-vous effectuer une mise à jour vers python {0} maintenant ?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">Python {0} sera installé et va remplacer python 3.6.6. Certains packages ne sont peut-être plus compatibles avec la nouvelle version ou doivent peut-être être réinstallés. Un bloc-notes va être créé pour vous aider à réinstaller tous les packages PIP. Voulez-vous continuer la mise à jour maintenant ?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">L'installation des dépendances de notebook a échoué avec l'erreur : {0}</target>
@@ -598,11 +674,23 @@
       </trans-unit>
       <trans-unit id="msgPackageRetrievalFailed">
         <source xml:lang="en">Encountered an error when trying to retrieve list of installed packages: {0}</source>
-        <target state="new">Encountered an error when trying to retrieve list of installed packages: {0}</target>
+        <target state="translated">Erreur pendant la tentative de récupération de la liste des packages installés : {0}</target>
       </trans-unit>
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
-        <target state="new">Encountered an error when getting Python user path: {0}</target>
+        <target state="translated">Erreur pendant l'obtention du chemin de l'utilisateur Python : {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">Ne plus me poser la question</target>
       </trans-unit>
     </body>
   </file>
@@ -610,35 +698,35 @@
     <body>
       <trans-unit id="configurePython.okButtonText">
         <source xml:lang="en">Install</source>
-        <target state="new">Install</target>
+        <target state="translated">Installer</target>
       </trans-unit>
       <trans-unit id="configurePython.invalidLocationMsg">
         <source xml:lang="en">The specified install location is invalid.</source>
-        <target state="new">The specified install location is invalid.</target>
+        <target state="translated">L'emplacement d'installation spécifié n'est pas valide.</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonNotFoundMsg">
         <source xml:lang="en">No Python installation was found at the specified location.</source>
-        <target state="new">No Python installation was found at the specified location.</target>
+        <target state="translated">Aucune installation de Python à l'emplacement spécifié.</target>
       </trans-unit>
       <trans-unit id="configurePython.wizardNameWithKernel">
         <source xml:lang="en">Configure Python to run {0} kernel</source>
-        <target state="new">Configure Python to run {0} kernel</target>
+        <target state="translated">Configurer Python pour exécuter le noyau {0}</target>
       </trans-unit>
       <trans-unit id="configurePython.wizardNameWithoutKernel">
         <source xml:lang="en">Configure Python to run kernels</source>
-        <target state="new">Configure Python to run kernels</target>
+        <target state="translated">Configurer Python pour exécuter les noyaux</target>
       </trans-unit>
       <trans-unit id="configurePython.page0Name">
         <source xml:lang="en">Configure Python Runtime</source>
-        <target state="new">Configure Python Runtime</target>
+        <target state="translated">Configurer le runtime Python</target>
       </trans-unit>
       <trans-unit id="configurePython.page1Name">
         <source xml:lang="en">Install Dependencies</source>
-        <target state="new">Install Dependencies</target>
+        <target state="translated">Installer les dépendances</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonInstallDeclined">
         <source xml:lang="en">Python installation was declined.</source>
-        <target state="new">Python installation was declined.</target>
+        <target state="translated">L'installation de Python a été refusée.</target>
       </trans-unit>
     </body>
   </file>
@@ -678,55 +766,55 @@
     <body>
       <trans-unit id="configurePython.browseButtonText">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">Parcourir</target>
       </trans-unit>
       <trans-unit id="configurePython.selectFileLabel">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">Sélectionner</target>
       </trans-unit>
       <trans-unit id="configurePython.descriptionWithKernel">
         <source xml:lang="en">The {0} kernel requires a Python runtime to be configured and dependencies to be installed.</source>
-        <target state="new">The {0} kernel requires a Python runtime to be configured and dependencies to be installed.</target>
+        <target state="translated">Le noyau {0} nécessite la configuration d'un runtime Python et l'installation de dépendances.</target>
       </trans-unit>
       <trans-unit id="configurePython.descriptionWithoutKernel">
         <source xml:lang="en">Notebook kernels require a Python runtime to be configured and dependencies to be installed.</source>
-        <target state="new">Notebook kernels require a Python runtime to be configured and dependencies to be installed.</target>
+        <target state="translated">Les noyaux de notebook nécessitent la configuration d'un runtime Python et l'installation de dépendances.</target>
       </trans-unit>
       <trans-unit id="configurePython.installationType">
         <source xml:lang="en">Installation Type</source>
-        <target state="new">Installation Type</target>
+        <target state="translated">Type d'installation</target>
       </trans-unit>
       <trans-unit id="configurePython.locationTextBoxText">
         <source xml:lang="en">Python Install Location</source>
-        <target state="new">Python Install Location</target>
+        <target state="translated">Emplacement d'installation de Python</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonConfigured">
         <source xml:lang="en">Python runtime configured!</source>
-        <target state="new">Python runtime configured!</target>
+        <target state="translated">Runtime python configuré !</target>
       </trans-unit>
       <trans-unit id="configurePythyon.dropdownPathLabel">
         <source xml:lang="en">{0} (Python {1})</source>
-        <target state="new">{0} (Python {1})</target>
+        <target state="translated">{0} (Python {1})</target>
       </trans-unit>
       <trans-unit id="configurePythyon.noVersionsFound">
         <source xml:lang="en">No supported Python versions found.</source>
-        <target state="new">No supported Python versions found.</target>
+        <target state="translated">Aucune version de Python prise en charge.</target>
       </trans-unit>
       <trans-unit id="configurePythyon.defaultPathLabel">
         <source xml:lang="en">{0} (Default)</source>
-        <target state="new">{0} (Default)</target>
+        <target state="translated">{0} (Par défaut)</target>
       </trans-unit>
       <trans-unit id="configurePython.newInstall">
         <source xml:lang="en">New Python installation</source>
-        <target state="new">New Python installation</target>
+        <target state="translated">Nouvelle installation de Python</target>
       </trans-unit>
       <trans-unit id="configurePython.existingInstall">
         <source xml:lang="en">Use existing Python installation</source>
-        <target state="new">Use existing Python installation</target>
+        <target state="translated">Utiliser l'installation existante de Python</target>
       </trans-unit>
       <trans-unit id="configurePythyon.customPathLabel">
         <source xml:lang="en">{0} (Custom)</source>
-        <target state="new">{0} (Custom)</target>
+        <target state="translated">{0} (Personnalisé)</target>
       </trans-unit>
     </body>
   </file>
@@ -734,27 +822,27 @@
     <body>
       <trans-unit id="configurePython.pkgNameColumn">
         <source xml:lang="en">Name</source>
-        <target state="new">Name</target>
+        <target state="translated">Nom</target>
       </trans-unit>
       <trans-unit id="configurePython.existingVersionColumn">
         <source xml:lang="en">Existing Version</source>
-        <target state="new">Existing Version</target>
+        <target state="translated">Version existante</target>
       </trans-unit>
       <trans-unit id="configurePython.requiredVersionColumn">
         <source xml:lang="en">Required Version</source>
-        <target state="new">Required Version</target>
+        <target state="translated">Version obligatoire</target>
       </trans-unit>
       <trans-unit id="configurePython.kernelLabel">
         <source xml:lang="en">Kernel</source>
-        <target state="new">Kernel</target>
+        <target state="translated">Noyau</target>
       </trans-unit>
       <trans-unit id="configurePython.requiredDependencies">
         <source xml:lang="en">Install required kernel dependencies</source>
-        <target state="new">Install required kernel dependencies</target>
+        <target state="translated">Installer les dépendances de noyau nécessaires</target>
       </trans-unit>
       <trans-unit id="msgUnsupportedKernel">
         <source xml:lang="en">Could not retrieve packages for kernel {0}</source>
-        <target state="new">Could not retrieve packages for kernel {0}</target>
+        <target state="translated">Impossible de récupérer les packages du noyau {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -774,7 +862,7 @@
       </trans-unit>
       <trans-unit id="notebookStartProcessExitPremature">
         <source xml:lang="en">Notebook process exited prematurely with error code: {0}. StdErr Output: {1}</source>
-        <target state="new">Notebook process exited prematurely with error code: {0}. StdErr Output: {1}</target>
+        <target state="translated">Le processus du notebook a quitté prématurément avec le code d'erreur : {0}, sortie StdErr : {1}</target>
       </trans-unit>
       <trans-unit id="jupyterError">
         <source xml:lang="en">Error sent from Jupyter: {0}</source>
@@ -806,23 +894,23 @@
       </trans-unit>
       <trans-unit id="notebook.couldNotFindKnoxGateway">
         <source xml:lang="en">Could not find Knox gateway endpoint</source>
-        <target state="new">Could not find Knox gateway endpoint</target>
+        <target state="translated">Point de terminaison de passerelle Knox introuvable</target>
       </trans-unit>
       <trans-unit id="promptBDCUsername">
         <source xml:lang="en">{0}Please provide the username to connect to the BDC Controller:</source>
-        <target state="new">{0}Please provide the username to connect to the BDC Controller:</target>
+        <target state="translated">{0}Fournissez le nom d'utilisateur pour se connecter au contrôleur BDC :</target>
       </trans-unit>
       <trans-unit id="promptBDCPassword">
         <source xml:lang="en">Please provide the password to connect to the BDC Controller</source>
-        <target state="new">Please provide the password to connect to the BDC Controller</target>
+        <target state="translated">Fournissez le mot de passe pour se connecter au contrôleur BDC</target>
       </trans-unit>
       <trans-unit id="bdcConnectError">
         <source xml:lang="en">Error: {0}. </source>
-        <target state="new">Error: {0}. </target>
+        <target state="translated">Erreur : {0}. </target>
       </trans-unit>
       <trans-unit id="clusterControllerConnectionRequired">
         <source xml:lang="en">A connection to the cluster controller is required to run Spark jobs</source>
-        <target state="new">A connection to the cluster controller is required to run Spark jobs</target>
+        <target state="translated">Une connexion au contrôleur de cluster est nécessaire pour exécuter les travaux Spark</target>
       </trans-unit>
     </body>
   </file>
@@ -854,7 +942,7 @@
       </trans-unit>
       <trans-unit id="managePackages.deleteColumn">
         <source xml:lang="en">Delete</source>
-        <target state="new">Delete</target>
+        <target state="translated">Supprimer</target>
       </trans-unit>
       <trans-unit id="managePackages.uninstallButtonText">
         <source xml:lang="en">Uninstall selected packages</source>
@@ -866,7 +954,7 @@
       </trans-unit>
       <trans-unit id="managePackages.location">
         <source xml:lang="en">Location</source>
-        <target state="new">Location</target>
+        <target state="translated">Emplacement</target>
       </trans-unit>
       <trans-unit id="managePackages.packageCount">
         <source xml:lang="en">{0} {1} packages found</source>
@@ -946,7 +1034,7 @@
     <body>
       <trans-unit id="managePackages.packageRequestError">
         <source xml:lang="en">Package info request failed with error: {0} {1}</source>
-        <target state="new">Package info request failed with error: {0} {1}</target>
+        <target state="translated">La demande d'informations de package a échoué avec l'erreur : {0} {1}</target>
       </trans-unit>
     </body>
   </file>
@@ -954,15 +1042,15 @@
     <body>
       <trans-unit id="msgSampleCodeDataFrame">
         <source xml:lang="en">This sample code loads the file into a data frame and shows the first 10 results.</source>
-        <target state="new">This sample code loads the file into a data frame and shows the first 10 results.</target>
+        <target state="translated">Cet exemple de code charge le fichier dans un cadre de données et affiche les 10 premiers résultats.</target>
       </trans-unit>
       <trans-unit id="noNotebookVisible">
         <source xml:lang="en">No notebook editor is active</source>
-        <target state="new">No notebook editor is active</target>
+        <target state="translated">Aucun éditeur de notebook actif</target>
       </trans-unit>
       <trans-unit id="notebookFiles">
         <source xml:lang="en">Notebooks</source>
-        <target state="new">Notebooks</target>
+        <target state="translated">Notebooks</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">L'action {0} n'est pas prise en charge pour ce gestionnaire</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">Impossible d'ouvrir le lien {0}, car seuls les liens HTTP et HTTPS sont pris en charge</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">Impossible d'ouvrir le lien {0}, car seuls les liens HTTP, HTTPS et Fichier sont pris en charge</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/fr/profiler.fr.xlf
+++ b/resources/xlf/fr/profiler.fr.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/fr/resource-deployment.fr.xlf
+++ b/resources/xlf/fr/resource-deployment.fr.xlf
@@ -12,7 +12,7 @@
       </trans-unit>
       <trans-unit id="deploy-resource-command-name">
         <source xml:lang="en">New Deployment…</source>
-        <target state="new">New Deployment…</target>
+        <target state="translated">Nouveau déploiement...</target>
       </trans-unit>
       <trans-unit id="deploy-resource-command-category">
         <source xml:lang="en">Deployment</source>
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">Exécuter l'image conteneur SQL Server avec Docker</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">Cluster Big Data SQL Server</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">Le cluster Big Data SQL Server vous permet de déployer des clusters scalables de conteneurs SQL Server, Spark et HDFS s'exécutant sur Kubernetes</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">Version</target>
@@ -44,43 +36,15 @@
       </trans-unit>
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
-        <target state="new">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="new">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">Cible de déploiement</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">Nouveau cluster Azure Kubernetes Service</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">Cluster Azure Kubernetes Service existant</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">Cluster Kubernetes existant (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="new">Existing Azure Red Hat OpenShift cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="new">Existing OpenShift cluster</target>
+        <target state="translated">SQL Server 2019</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
-        <target state="new">Deploy SQL Server 2017 container images</target>
+        <target state="translated">Déployer des images conteneur SQL Server 2017</target>
       </trans-unit>
       <trans-unit id="docker-sql-2019-title">
         <source xml:lang="en">Deploy SQL Server 2019 container images</source>
-        <target state="new">Deploy SQL Server 2019 container images</target>
+        <target state="translated">Déployer des images conteneur SQL Server 2019</target>
       </trans-unit>
       <trans-unit id="docker-container-name-field">
         <source xml:lang="en">Container name</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">Port</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">Paramètres de cluster Big Data SQL Server</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">Nom de cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">Nom d'utilisateur du contrôleur</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">Mot de passe</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">Confirmer le mot de passe</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Paramètres Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">ID d'abonnement</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">Utiliser mon abonnement Azure par défaut</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">Nom de groupe de ressources</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">Région</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">Nom du cluster AKS</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">Taille de machine virtuelle</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">Nombre de machines virtuelles</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">Nom de la classe de stockage</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">Capacité de données (Go)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">Capacité des journaux (Go)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">SQL Server sur Windows</target>
@@ -170,197 +70,185 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">Exécutez SQL Server sur Windows, sélectionnez une version pour commencer.</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">J'accepte {0}, {1} et {2}.</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
-        <target state="new">Microsoft Privacy Statement</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">Termes du contrat de licence azdata</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">Termes du contrat de licence SQL Server</target>
+        <target state="translated">Déclaration de confidentialité Microsoft</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
-        <target state="new">Deployment configuration</target>
+        <target state="translated">Configuration du déploiement</target>
       </trans-unit>
       <trans-unit id="azdata-install-location-description">
         <source xml:lang="en">Location of the azdata package used for the install command</source>
-        <target state="new">Location of the azdata package used for the install command</target>
+        <target state="translated">Emplacement du package azdata utilisé pour la commande d'installation</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-display-name">
         <source xml:lang="en">SQL Server on Azure Virtual Machine</source>
-        <target state="new">SQL Server on Azure Virtual Machine</target>
+        <target state="translated">SQL Server dans une machine virtuelle Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-description">
         <source xml:lang="en">Create SQL virtual machines on Azure. Best for migrations and applications requiring OS-level access.</source>
-        <target state="new">Create SQL virtual machines on Azure. Best for migrations and applications requiring OS-level access.</target>
+        <target state="translated">Créez des machines virtuelles SQL sur Azure. Idéal pour les migrations et les applications nécessitant un accès au niveau du système d'exploitation.</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-deploy-dialog-title">
         <source xml:lang="en">Deploy Azure SQL virtual machine</source>
-        <target state="new">Deploy Azure SQL virtual machine</target>
+        <target state="translated">Déployer une machine virtuelle Azure SQL</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-deploy-dialog-action-text">
         <source xml:lang="en">Script to notebook</source>
-        <target state="new">Script to notebook</target>
+        <target state="translated">Exécuter un script sur un notebook</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement">
         <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="new">I accept {0}, {1} and {2}.</target>
+        <target state="translated">J'accepte {0}, {1} et {2}.</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement-sqlvm-eula">
         <source xml:lang="en">Azure SQL VM License Terms</source>
-        <target state="new">Azure SQL VM License Terms</target>
+        <target state="translated">Termes du contrat de licence Azure SQL VM</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement-azdata-eula">
         <source xml:lang="en">azdata License Terms</source>
-        <target state="new">azdata License Terms</target>
+        <target state="translated">Termes du contrat de licence azdata</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-azure-account-page-label">
         <source xml:lang="en">Azure information</source>
-        <target state="new">Azure information</target>
+        <target state="translated">Informations Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-azure-location-label">
         <source xml:lang="en">Azure locations</source>
-        <target state="new">Azure locations</target>
+        <target state="translated">Localisations Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-information-page-label">
         <source xml:lang="en">VM information</source>
-        <target state="new">VM information</target>
+        <target state="translated">Informations VM</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-image-label">
         <source xml:lang="en">Image</source>
-        <target state="new">Image</target>
+        <target state="translated">Image</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-image-sku-label">
         <source xml:lang="en">VM image SKU</source>
-        <target state="new">VM image SKU</target>
+        <target state="translated">Référence SKU d'image VM</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-publisher-label">
         <source xml:lang="en">Publisher</source>
-        <target state="new">Publisher</target>
+        <target state="translated">Serveur de publication</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vmname-label">
         <source xml:lang="en">Virtual machine name</source>
-        <target state="new">Virtual machine name</target>
+        <target state="translated">Nom de la machine virtuelle</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vmsize-label">
         <source xml:lang="en">Size</source>
-        <target state="new">Size</target>
+        <target state="translated">Taille</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-page-lable">
         <source xml:lang="en">Storage account</source>
-        <target state="new">Storage account</target>
+        <target state="translated">Compte de stockage</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-accountname-label">
         <source xml:lang="en">Storage account name</source>
-        <target state="new">Storage account name</target>
+        <target state="translated">Nom du compte de stockage</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-sku-label">
         <source xml:lang="en">Storage account SKU type</source>
-        <target state="new">Storage account SKU type</target>
+        <target state="translated">Type de référence SKU du compte de stockage</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-administrator-account-page-label">
         <source xml:lang="en">Administrator account</source>
-        <target state="new">Administrator account</target>
+        <target state="translated">Compte Administrateur</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-username-label">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">Nom d'utilisateur</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-password-label">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">Mot de passe</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-password-confirm-label">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">Confirmer le mot de passe</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-summary-page-label">
         <source xml:lang="en">Summary</source>
-        <target state="new">Summary</target>
+        <target state="translated">Récapitulatif</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-display-name">
         <source xml:lang="en">Azure SQL Database</source>
-        <target state="new">Azure SQL Database</target>
+        <target state="translated">Azure SQL Database</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-description">
         <source xml:lang="en">Create a SQL database, database server, or elastic pool in Azure.</source>
-        <target state="new">Create a SQL database, database server, or elastic pool in Azure.</target>
+        <target state="translated">Créez une base de données SQL, un serveur de base de données ou un pool élastique dans Azure.</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-portal-ok-button-text">
         <source xml:lang="en">Create in Azure portal</source>
-        <target state="new">Create in Azure portal</target>
+        <target state="translated">Créer dans le portail Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-notebook-ok-button-text">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">Sélectionner</target>
       </trans-unit>
       <trans-unit id="resource-type-display-name">
         <source xml:lang="en">Resource Type</source>
-        <target state="new">Resource Type</target>
+        <target state="translated">Type de ressource</target>
       </trans-unit>
       <trans-unit id="sql-azure-single-database-display-name">
         <source xml:lang="en">Single Database</source>
-        <target state="new">Single Database</target>
+        <target state="translated">Base de données unique</target>
       </trans-unit>
       <trans-unit id="sql-azure-elastic-pool-display-name">
         <source xml:lang="en">Elastic Pool</source>
-        <target state="new">Elastic Pool</target>
+        <target state="translated">Pool élastique</target>
       </trans-unit>
       <trans-unit id="sql-azure-database-server-display-name">
         <source xml:lang="en">Database Server</source>
-        <target state="new">Database Server</target>
+        <target state="translated">Serveur de base de données</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement">
         <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="new">I accept {0}, {1} and {2}.</target>
+        <target state="translated">J'accepte {0}, {1} et {2}.</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement-sqldb-eula">
         <source xml:lang="en">Azure SQL DB License Terms</source>
-        <target state="new">Azure SQL DB License Terms</target>
+        <target state="translated">Termes du contrat de licence Azure SQL DB</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement-azdata-eula">
         <source xml:lang="en">azdata License Terms</source>
-        <target state="new">azdata License Terms</target>
+        <target state="translated">Termes du contrat de licence azdata</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-display-name">
         <source xml:lang="en">Azure SQL managed instance</source>
-        <target state="new">Azure SQL managed instance</target>
+        <target state="translated">Instance managée Azure SQL</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-display-description">
         <source xml:lang="en">Create a SQL Managed Instance in either Azure or a customer-managed environment</source>
-        <target state="new">Create a SQL Managed Instance in either Azure or a customer-managed environment</target>
+        <target state="translated">Créer une instance managée SQL dans Azure ou dans un environnement géré par le client</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-okButton-text">
         <source xml:lang="en">Open in Portal</source>
-        <target state="new">Open in Portal</target>
+        <target state="translated">Ouvrir dans le portail</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-resource-type-option-label">
         <source xml:lang="en">Resource Type</source>
-        <target state="new">Resource Type</target>
+        <target state="translated">Type de ressource</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-agreement">
         <source xml:lang="en">I accept {0} and {1}.</source>
-        <target state="new">I accept {0} and {1}.</target>
+        <target state="translated">J'accepte {0} et {1}.</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-agreement-eula">
         <source xml:lang="en">Azure SQL MI License Terms</source>
-        <target state="new">Azure SQL MI License Terms</target>
+        <target state="translated">Termes du contrat de licence Azure SQL MI</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-help-text">
         <source xml:lang="en">Azure SQL Managed Instance provides full SQL Server access and feature compatibility for migrating SQL Servers to Azure, or developing new applications. {0}.</source>
-        <target state="new">Azure SQL Managed Instance provides full SQL Server access and feature compatibility for migrating SQL Servers to Azure, or developing new applications. {0}.</target>
+        <target state="translated">Azure SQL Managed Instance offre un accès total à SQL Server ainsi que la compatibilité des fonctionnalités afin de migrer les serveurs SQL vers Azure ou développer de nouvelles applications. {0}.</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-help-text-learn-more">
         <source xml:lang="en">Learn More</source>
-        <target state="new">Learn More</target>
+        <target state="translated">En savoir plus</target>
       </trans-unit>
     </body>
   </file>
@@ -368,227 +256,243 @@
     <body>
       <trans-unit id="azure.account">
         <source xml:lang="en">Azure Account</source>
-        <target state="new">Azure Account</target>
+        <target state="translated">Compte Azure</target>
       </trans-unit>
       <trans-unit id="azure.account.subscription">
         <source xml:lang="en">Subscription (selected subset)</source>
-        <target state="new">Subscription (selected subset)</target>
+        <target state="translated">Abonnement (sous-ensemble sélectionné)</target>
       </trans-unit>
       <trans-unit id="azure.account.subscriptionDescription">
         <source xml:lang="en">Change the currently selected subscriptions through the 'Select Subscriptions' action on an account listed in the 'Azure' tree view of the 'Connections' viewlet</source>
-        <target state="new">Change the currently selected subscriptions through the 'Select Subscriptions' action on an account listed in the 'Azure' tree view of the 'Connections' viewlet</target>
+        <target state="translated">Changer les abonnements actuellement sélectionnés par le biais de l'action « Sélectionner des abonnements » dans un compte listé dans l'arborescence « Azure » de la viewlet « Connexions »</target>
       </trans-unit>
       <trans-unit id="azure.account.resourceGroup">
         <source xml:lang="en">Resource Group</source>
-        <target state="new">Resource Group</target>
+        <target state="translated">Groupe de ressources</target>
       </trans-unit>
       <trans-unit id="azure.account.location">
         <source xml:lang="en">Azure Location</source>
-        <target state="new">Azure Location</target>
+        <target state="translated">Localisation Azure</target>
       </trans-unit>
       <trans-unit id="filePicker.browse">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">Parcourir</target>
       </trans-unit>
       <trans-unit id="button.label">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">Sélectionner</target>
       </trans-unit>
       <trans-unit id="kubeConfigClusterPicker.kubeConfigFilePath">
         <source xml:lang="en">Kube config file path</source>
-        <target state="new">Kube config file path</target>
+        <target state="translated">Chemin du fichier de configuration Kube</target>
       </trans-unit>
       <trans-unit id="kubeConfigClusterPicker.clusterContextNotFound">
         <source xml:lang="en">No cluster context information found</source>
-        <target state="new">No cluster context information found</target>
+        <target state="translated">Aucune information de contexte de cluster</target>
       </trans-unit>
       <trans-unit id="azure.signin">
         <source xml:lang="en">Sign in…</source>
-        <target state="new">Sign in…</target>
+        <target state="translated">Connexion…</target>
       </trans-unit>
       <trans-unit id="azure.refresh">
         <source xml:lang="en">Refresh</source>
-        <target state="new">Refresh</target>
+        <target state="translated">Actualiser</target>
       </trans-unit>
       <trans-unit id="azure.yes">
         <source xml:lang="en">Yes</source>
-        <target state="new">Yes</target>
+        <target state="translated">Oui</target>
       </trans-unit>
       <trans-unit id="azure.no">
         <source xml:lang="en">No</source>
-        <target state="new">No</target>
+        <target state="translated">Non</target>
       </trans-unit>
       <trans-unit id="azure.resourceGroup.createNewResourceGroup">
         <source xml:lang="en">Create a new resource group</source>
-        <target state="new">Create a new resource group</target>
+        <target state="translated">Créer un groupe de ressources</target>
       </trans-unit>
       <trans-unit id="azure.resourceGroup.NewResourceGroupAriaLabel">
         <source xml:lang="en">New resource group name</source>
-        <target state="new">New resource group name</target>
+        <target state="translated">Nom du nouveau groupe de ressources</target>
       </trans-unit>
       <trans-unit id="deployCluster.Realm">
         <source xml:lang="en">Realm</source>
-        <target state="new">Realm</target>
+        <target state="translated">Domaine</target>
       </trans-unit>
       <trans-unit id="UnknownFieldTypeError">
         <source xml:lang="en">Unknown field type: "{0}"</source>
-        <target state="new">Unknown field type: "{0}"</target>
+        <target state="translated">Type de champ inconnu : "{0}"</target>
       </trans-unit>
       <trans-unit id="optionsSource.alreadyDefined">
         <source xml:lang="en">Options Source with id:{0} is already defined</source>
-        <target state="new">Options Source with id:{0} is already defined</target>
+        <target state="translated">La source d'options avec l'ID : {0} est déjà définie</target>
       </trans-unit>
       <trans-unit id="valueProvider.alreadyDefined">
         <source xml:lang="en">Value Provider with id:{0} is already defined</source>
-        <target state="new">Value Provider with id:{0} is already defined</target>
+        <target state="translated">Le fournisseur de valeur avec l'ID : {0} est déjà défini</target>
       </trans-unit>
       <trans-unit id="optionsSource.notDefined">
         <source xml:lang="en">No Options Source defined for id: {0}</source>
-        <target state="new">No Options Source defined for id: {0}</target>
+        <target state="translated">Aucune source d'options définie pour l'ID : {0}</target>
       </trans-unit>
       <trans-unit id="valueProvider.notDefined">
         <source xml:lang="en">No Value Provider defined for id: {0}</source>
-        <target state="new">No Value Provider defined for id: {0}</target>
+        <target state="translated">Aucun fournisseur de valeur défini pour l'ID : {0}</target>
       </trans-unit>
       <trans-unit id="getVariableValue.unknownVariableName">
         <source xml:lang="en">Attempt to get variable value for unknown variable:{0}</source>
-        <target state="new">Attempt to get variable value for unknown variable:{0}</target>
+        <target state="translated">Tentative d'obtention de la valeur de variable pour une variable inconnue : {0}</target>
       </trans-unit>
       <trans-unit id="getIsPassword.unknownVariableName">
         <source xml:lang="en">Attempt to get isPassword for unknown variable:{0}</source>
-        <target state="new">Attempt to get isPassword for unknown variable:{0}</target>
+        <target state="translated">Tentative d'obtention de isPassword pour une variable inconnue : {0}</target>
       </trans-unit>
       <trans-unit id="optionsNotDefined">
         <source xml:lang="en">FieldInfo.options was not defined for field type: {0}</source>
-        <target state="new">FieldInfo.options was not defined for field type: {0}</target>
+        <target state="translated">FieldInfo.options n'a pas été défini pour le type de champ : {0}</target>
       </trans-unit>
       <trans-unit id="optionsNotObjectOrArray">
         <source xml:lang="en">FieldInfo.options must be an object if it is not an array</source>
-        <target state="new">FieldInfo.options must be an object if it is not an array</target>
+        <target state="translated">FieldInfo.options doit être un objet s'il ne s'agit pas d'un tableau</target>
       </trans-unit>
       <trans-unit id="optionsTypeNotFound">
         <source xml:lang="en">When FieldInfo.options is an object it must have 'optionsType' property</source>
-        <target state="new">When FieldInfo.options is an object it must have 'optionsType' property</target>
+        <target state="translated">Quand FieldInfo.options est un objet, il doit avoir la propriété « optionsType »</target>
       </trans-unit>
       <trans-unit id="optionsTypeRadioOrDropdown">
         <source xml:lang="en">When optionsType is not {0} then it must be {1}</source>
-        <target state="new">When optionsType is not {0} then it must be {1}</target>
+        <target state="translated">Quand optionsType n'est pas {0}, il doit être {1}</target>
       </trans-unit>
       <trans-unit id="azdataEulaNotAccepted">
         <source xml:lang="en">Deployment cannot continue. Azure Data CLI license terms have not yet been accepted. Please accept the EULA to enable the features that requires Azure Data CLI.</source>
-        <target state="new">Deployment cannot continue. Azure Data CLI license terms have not yet been accepted. Please accept the EULA to enable the features that requires Azure Data CLI.</target>
+        <target state="translated">Le déploiement ne peut pas continuer. Les termes du contrat de licence Azure Data CLI n'ont pas encore été acceptés. Acceptez le CLUF pour activer les fonctionnalités nécessitant Azure Data CLI.</target>
       </trans-unit>
       <trans-unit id="azdataEulaDeclined">
         <source xml:lang="en">Deployment cannot continue. Azure Data CLI license terms were declined.You can either Accept EULA to continue or Cancel this operation</source>
-        <target state="new">Deployment cannot continue. Azure Data CLI license terms were declined.You can either Accept EULA to continue or Cancel this operation</target>
+        <target state="translated">Le déploiement ne peut pas continuer. Les termes du contrat de licence d'Azure Data CLI ont été refusés. Vous pouvez accepter le CLUF pour continuer ou annuler cette opération</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
-        <target state="new">Accept EULA &amp; Select</target>
+        <target state="translated">Accepter le CLUF et sélectionner</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">L’extension «{0}» est nécessaire pour déployer cette ressource. Voulez-vous l’installer maintenant ?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Installer</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">Installation de l'extension '{0}'...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">Extension inconnue '{0}'</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
-        <target state="new">Select the deployment options</target>
+        <target state="translated">Sélectionner les options de déploiement</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceSearchPlaceholder">
         <source xml:lang="en">Filter resources...</source>
-        <target state="new">Filter resources...</target>
+        <target state="translated">Filtrer les ressources...</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.tagsListViewTitle">
         <source xml:lang="en">Categories</source>
-        <target state="new">Categories</target>
+        <target state="translated">Catégories</target>
       </trans-unit>
       <trans-unit id="validation.multipleValidationErrors">
         <source xml:lang="en">There are some errors on this page, click 'Show Details' to view the errors.</source>
-        <target state="new">There are some errors on this page, click 'Show Details' to view the errors.</target>
+        <target state="translated">Cette page a des erreurs, cliquez sur 'Afficher les détails' pour les voir.</target>
       </trans-unit>
       <trans-unit id="ui.ScriptToNotebookButton">
         <source xml:lang="en">Script</source>
-        <target state="new">Script</target>
+        <target state="translated">Exécuter le script</target>
       </trans-unit>
       <trans-unit id="ui.DeployButton">
         <source xml:lang="en">Run</source>
-        <target state="new">Run</target>
+        <target state="translated">Exécuter</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.ViewErrorDetail">
         <source xml:lang="en">View error detail</source>
-        <target state="new">View error detail</target>
+        <target state="translated">Voir le détail de l'erreur</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.FailedToOpenNotebook">
         <source xml:lang="en">An error occurred opening the output notebook. {1}{2}.</source>
-        <target state="new">An error occurred opening the output notebook. {1}{2}.</target>
+        <target state="translated">Erreur pendant l'ouverture du notebook de sortie. {1}{2}.</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.BackgroundExecutionFailed">
         <source xml:lang="en">The task "{0}" has failed.</source>
-        <target state="new">The task "{0}" has failed.</target>
+        <target state="translated">La tâche « {0} » a échoué.</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.TaskFailedWithNoOutputNotebook">
         <source xml:lang="en">The task "{0}" failed and no output Notebook was generated.</source>
-        <target state="new">The task "{0}" failed and no output Notebook was generated.</target>
+        <target state="translated">La tâche « {0} » a échoué et aucun notebook de sortie n'a été généré.</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryAll">
         <source xml:lang="en">All</source>
-        <target state="new">All</target>
+        <target state="translated">Tout</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnPrem">
         <source xml:lang="en">On-premises</source>
-        <target state="new">On-premises</target>
+        <target state="translated">Local</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoriesSqlServer">
         <source xml:lang="en">SQL Server</source>
-        <target state="new">SQL Server</target>
+        <target state="translated">SQL Server</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnHybrid">
         <source xml:lang="en">Hybrid</source>
-        <target state="new">Hybrid</target>
+        <target state="translated">Hybride</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnPostgreSql">
         <source xml:lang="en">PostgreSQL</source>
-        <target state="new">PostgreSQL</target>
+        <target state="translated">PostgreSQL</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnCloud">
         <source xml:lang="en">Cloud</source>
-        <target state="new">Cloud</target>
+        <target state="translated">Cloud</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Description">
         <source xml:lang="en">Description</source>
-        <target state="new">Description</target>
+        <target state="translated">Description</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Tool">
         <source xml:lang="en">Tool</source>
-        <target state="new">Tool</target>
+        <target state="translated">Outil</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Status">
         <source xml:lang="en">Status</source>
-        <target state="new">Status</target>
+        <target state="translated">État</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Version">
         <source xml:lang="en">Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Version</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.RequiredVersion">
         <source xml:lang="en">Required Version</source>
-        <target state="new">Required Version</target>
+        <target state="translated">Version obligatoire</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.discoverPathOrAdditionalInformation">
         <source xml:lang="en">Discovered Path or Additional Information</source>
-        <target state="new">Discovered Path or Additional Information</target>
+        <target state="translated">Chemin découvert ou informations supplémentaires</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.requiredTools">
         <source xml:lang="en">Required tools</source>
-        <target state="new">Required tools</target>
+        <target state="translated">Outils obligatoires</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.InstallTools">
         <source xml:lang="en">Install tools</source>
-        <target state="new">Install tools</target>
+        <target state="translated">Installer les outils</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Options">
         <source xml:lang="en">Options</source>
-        <target state="new">Options</target>
+        <target state="translated">Options</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallingTool">
         <source xml:lang="en">Required tool '{0}' [ {1} ] is being installed now.</source>
-        <target state="new">Required tool '{0}' [ {1} ] is being installed now.</target>
+        <target state="translated">L'outil nécessaire « {0} » [ {1} ] est en cours d'installation.</target>
       </trans-unit>
     </body>
   </file>
@@ -596,45 +500,45 @@
     <body>
       <trans-unit id="getClusterContexts.errorFetchingClusters">
         <source xml:lang="en">An error ocurred while loading or parsing the config file:{0}, error is:{1}</source>
-        <target state="new">An error ocurred while loading or parsing the config file:{0}, error is:{1}</target>
+        <target state="translated">Erreur pendant le chargement ou l'analyse du fichier de configuration : {0}, erreur : {1}</target>
       </trans-unit>
       <trans-unit id="fileChecker.NotFile">
         <source xml:lang="en">Path: {0} is not a file, please select a valid kube config file.</source>
-        <target state="new">Path: {0} is not a file, please select a valid kube config file.</target>
+        <target state="translated">Le chemin {0} n'est pas un fichier, sélectionnez un fichier de configuration Kube valide.</target>
       </trans-unit>
       <trans-unit id="fileChecker.FileNotFound">
         <source xml:lang="en">File: {0} not found. Please select a kube config file.</source>
-        <target state="new">File: {0} not found. Please select a kube config file.</target>
+        <target state="translated">Fichier {0} introuvable. Sélectionnez un fichier de configuration Kube.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedAccountsError">
         <source xml:lang="en">Unexpected error fetching accounts: {0}</source>
-        <target state="new">Unexpected error fetching accounts: {0}</target>
+        <target state="translated">Erreur inattendue pendant la récupération des comptes : {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.errorFetchingStorageClasses">
         <source xml:lang="en">Unexpected error fetching available kubectl storage classes : {0}</source>
-        <target state="new">Unexpected error fetching available kubectl storage classes : {0}</target>
+        <target state="translated">Erreur inattendue pendant la récupération des classes de stockage kubectl disponibles : {0}</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedSubscriptionsError">
         <source xml:lang="en">Unexpected error fetching subscriptions for account {0}: {1}</source>
-        <target state="new">Unexpected error fetching subscriptions for account {0}: {1}</target>
+        <target state="translated">Erreur inattendue pendant la récupération des abonnements pour le compte {0} : {1}</target>
       </trans-unit>
       <trans-unit id="azure.accounts.accountNotFoundError">
         <source xml:lang="en">The selected account '{0}' is no longer available. Click sign in to add it again or select a different account.</source>
-        <target state="new">The selected account '{0}' is no longer available. Click sign in to add it again or select a different account.</target>
+        <target state="translated">Le compte sélectionné « {0} » n'est plus disponible. Cliquez sur Se connecter pour le rajouter ou sélectionnez un autre compte.</target>
       </trans-unit>
       <trans-unit id="azure.accessError">
         <source xml:lang="en">
  Error Details: {0}.</source>
-        <target state="new">
- Error Details: {0}.</target>
+        <target state="translated">
+ Détails de l'erreur : {0}.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.accountStaleError">
         <source xml:lang="en">The access token for selected account '{0}' is no longer valid. Please click the sign in button and refresh the account or select a different account.</source>
-        <target state="new">The access token for selected account '{0}' is no longer valid. Please click the sign in button and refresh the account or select a different account.</target>
+        <target state="translated">Le jeton d'accès pour le compte sélectionné « {0} » n'est plus valide. Cliquez sur le bouton Se connecter, actualisez le compte ou sélectionnez un autre compte.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedResourceGroupsError">
         <source xml:lang="en">Unexpected error fetching resource groups for subscription {0}: {1}</source>
-        <target state="new">Unexpected error fetching resource groups for subscription {0}: {1}</target>
+        <target state="translated">Erreur inattendue pendant la récupération des groupes de ressources pour l'abonnement {0} : {1}</target>
       </trans-unit>
       <trans-unit id="invalidSQLPassword">
         <source xml:lang="en">{0} doesn't meet the password complexity requirement. For more information: https://docs.microsoft.com/sql/relational-databases/security/password-policy</source>
@@ -650,139 +554,139 @@
     <body>
       <trans-unit id="deployAzureSQLVM.NewSQLVMTitle">
         <source xml:lang="en">Deploy Azure SQL VM</source>
-        <target state="new">Deploy Azure SQL VM</target>
+        <target state="translated">Déployer Azure SQL VM</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Exécuter un script sur un notebook</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">Remplissez les champs obligatoires marqués d'un astérisque rouge.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureSettingsPageTitle">
         <source xml:lang="en">Azure settings</source>
-        <target state="new">Azure settings</target>
+        <target state="translated">Paramètres Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureAccountDropdownLabel">
         <source xml:lang="en">Azure Account</source>
-        <target state="new">Azure Account</target>
+        <target state="translated">Compte Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureSubscriptionDropdownLabel">
         <source xml:lang="en">Subscription</source>
-        <target state="new">Subscription</target>
+        <target state="translated">Abonnement</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.ResourceGroup">
         <source xml:lang="en">Resource Group</source>
-        <target state="new">Resource Group</target>
+        <target state="translated">Groupe de ressources</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureRegionDropdownLabel">
         <source xml:lang="en">Region</source>
-        <target state="new">Region</target>
+        <target state="translated">Région</target>
       </trans-unit>
       <trans-unit id="deployeAzureSQLVM.VmSettingsPageTitle">
         <source xml:lang="en">Virtual machine settings</source>
-        <target state="new">Virtual machine settings</target>
+        <target state="translated">Paramètres de la machine virtuelle</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmNameTextBoxLabel">
         <source xml:lang="en">Virtual machine name</source>
-        <target state="new">Virtual machine name</target>
+        <target state="translated">Nom de la machine virtuelle</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminUsernameTextBoxLabel">
         <source xml:lang="en">Administrator account username</source>
-        <target state="new">Administrator account username</target>
+        <target state="translated">Nom d'utilisateur du compte Administrateur</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminPasswordTextBoxLabel">
         <source xml:lang="en">Administrator account password</source>
-        <target state="new">Administrator account password</target>
+        <target state="translated">Mot de passe du compte Administrateur</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminConfirmPasswordTextBoxLabel">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">Confirmer le mot de passe</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmImageDropdownLabel">
         <source xml:lang="en">Image</source>
-        <target state="new">Image</target>
+        <target state="translated">Image</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmSkuDropdownLabel">
         <source xml:lang="en">Image SKU</source>
-        <target state="new">Image SKU</target>
+        <target state="translated">Référence SKU de l'image</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmImageVersionDropdownLabel">
         <source xml:lang="en">Image Version</source>
-        <target state="new">Image Version</target>
+        <target state="translated">Version de l'image</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmSizeDropdownLabel">
         <source xml:lang="en">Size</source>
-        <target state="new">Size</target>
+        <target state="translated">Taille</target>
       </trans-unit>
       <trans-unit id="deployeAzureSQLVM.VmSizeLearnMoreLabel">
         <source xml:lang="en">Click here to learn more about pricing and supported VM sizes</source>
-        <target state="new">Click here to learn more about pricing and supported VM sizes</target>
+        <target state="translated">Cliquer ici pour en savoir plus sur les prix et les tailles de VM prises en charge</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsPageTitle">
         <source xml:lang="en">Networking</source>
-        <target state="new">Networking</target>
+        <target state="translated">Réseau</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsPageDescription">
         <source xml:lang="en">Configure network settings</source>
-        <target state="new">Configure network settings</target>
+        <target state="translated">Configurer les paramètres réseau</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsNewVirtualNetwork">
         <source xml:lang="en">New virtual network</source>
-        <target state="new">New virtual network</target>
+        <target state="translated">Nouveau réseau virtuel</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VirtualNetworkDropdownLabel">
         <source xml:lang="en">Virtual Network</source>
-        <target state="new">Virtual Network</target>
+        <target state="translated">Réseau virtuel</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsNewSubnet">
         <source xml:lang="en">New subnet</source>
-        <target state="new">New subnet</target>
+        <target state="translated">Nouveau sous-réseau</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SubnetDropdownLabel">
         <source xml:lang="en">Subnet</source>
-        <target state="new">Subnet</target>
+        <target state="translated">Sous-réseau</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PublicIPDropdownLabel">
         <source xml:lang="en">Public IP</source>
-        <target state="new">Public IP</target>
+        <target state="translated">IP publique</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsUseExistingPublicIp">
         <source xml:lang="en">New public ip</source>
-        <target state="new">New public ip</target>
+        <target state="translated">Nouvelle IP publique</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmRDPAllowCheckboxLabel">
         <source xml:lang="en">Enable Remote Desktop (RDP) inbound port (3389)</source>
-        <target state="new">Enable Remote Desktop (RDP) inbound port (3389)</target>
+        <target state="translated">Activer le port d'entrée Bureau à distance (RDP) (3389)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlServerSettingsPageTitle">
         <source xml:lang="en">SQL Servers settings</source>
-        <target state="new">SQL Servers settings</target>
+        <target state="translated">Paramètres des serveurs SQL</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlConnectivityTypeDropdownLabel">
         <source xml:lang="en">SQL connectivity</source>
-        <target state="new">SQL connectivity</target>
+        <target state="translated">Connectivité SQL</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlPortLabel">
         <source xml:lang="en">Port</source>
-        <target state="new">Port</target>
+        <target state="translated">Port</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlEnableSQLAuthenticationLabel">
         <source xml:lang="en">Enable SQL authentication</source>
-        <target state="new">Enable SQL authentication</target>
+        <target state="translated">Activer l'authentification SQL</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationUsernameLabel">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">Nom d'utilisateur</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationPasswordLabel">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">Mot de passe</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationConfirmPasswordLabel">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">Confirmer le mot de passe</target>
       </trans-unit>
     </body>
   </file>
@@ -790,39 +694,39 @@
     <body>
       <trans-unit id="deployCluster.SaveConfigFiles">
         <source xml:lang="en">Save config files</source>
-        <target state="new">Save config files</target>
+        <target state="translated">Enregistrer les fichiers config</target>
       </trans-unit>
       <trans-unit id="deployCluster.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Exécuter un script sur un notebook</target>
       </trans-unit>
       <trans-unit id="deployCluster.SelectConfigFileFolder">
         <source xml:lang="en">Save config files</source>
-        <target state="new">Save config files</target>
+        <target state="translated">Enregistrer les fichiers config</target>
       </trans-unit>
       <trans-unit id="deployCluster.SaveConfigFileSucceeded">
         <source xml:lang="en">Config files saved to {0}</source>
-        <target state="new">Config files saved to {0}</target>
+        <target state="translated">Fichiers config enregistrés dans {0}</target>
       </trans-unit>
       <trans-unit id="deployCluster.NewAKSWizardTitle">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on a new AKS cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on a new AKS cluster</target>
+        <target state="translated">Déployer le cluster Big Data SQL Server 2019 sur un nouveau cluster AKS</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingAKSWizardTitle">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing AKS cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing AKS cluster</target>
+        <target state="translated">Déployer le cluster Big Data SQL Server 2019 sur un cluster AKS existant</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingKubeAdm">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing kubeadm cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing kubeadm cluster</target>
+        <target state="translated">Déployer le cluster Big Data SQL Server 2019 sur un cluster kubeadm existant</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingARO">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing Azure Red Hat OpenShift cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing Azure Red Hat OpenShift cluster</target>
+        <target state="translated">Déployer le cluster Big Data SQL Server 2019 sur un cluster Azure Red Hat OpenShift existant</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingOpenShift">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing OpenShift cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing OpenShift cluster</target>
+        <target state="translated">Déployer le cluster Big Data SQL Server 2019 sur un cluster OpenShift existant</target>
       </trans-unit>
     </body>
   </file>
@@ -830,79 +734,79 @@
     <body>
       <trans-unit id="deploymentDialog.ToolStatus.NotInstalled">
         <source xml:lang="en">Not Installed</source>
-        <target state="new">Not Installed</target>
+        <target state="translated">Non installé</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Installed">
         <source xml:lang="en">Installed</source>
-        <target state="new">Installed</target>
+        <target state="translated">Installé</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Installing">
         <source xml:lang="en">Installing…</source>
-        <target state="new">Installing…</target>
+        <target state="translated">Installation…</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Error">
         <source xml:lang="en">Error</source>
-        <target state="new">Error</target>
+        <target state="translated">Erreur</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Failed">
         <source xml:lang="en">Failed</source>
-        <target state="new">Failed</target>
+        <target state="translated">Échec</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformationalMessage.Brew">
         <source xml:lang="en">•	brew is needed for deployment of the tools and needs to be pre-installed before necessary tools can be deployed</source>
-        <target state="new">•	brew is needed for deployment of the tools and needs to be pre-installed before necessary tools can be deployed</target>
+        <target state="translated">•	brew est nécessaire pour le déploiement des outils et doit être préinstallé pour pouvoir déployer les outils nécessaires</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformationalMessage.Curl">
         <source xml:lang="en">•	curl is needed for installation and needs to be pre-installed before necessary tools can be deployed</source>
-        <target state="new">•	curl is needed for installation and needs to be pre-installed before necessary tools can be deployed</target>
+        <target state="translated">•	curl est nécessaire pour l'installation et doit être préinstallé pour pouvoir déployer les outils nécessaires</target>
       </trans-unit>
       <trans-unit id="toolBase.getPip3InstallationLocation.LocationNotFound">
         <source xml:lang="en">   Could not find 'Location' in the output:</source>
-        <target state="new">   Could not find 'Location' in the output:</target>
+        <target state="translated">   « Location » est introuvable dans la sortie :</target>
       </trans-unit>
       <trans-unit id="toolBase.getPip3InstallationLocation.Output">
         <source xml:lang="en">   output:</source>
-        <target state="new">   output:</target>
+        <target state="translated">   sortie :</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallError">
         <source xml:lang="en">Error installing tool '{0}' [ {1} ].{2}Error: {3}{2}See output channel '{4}' for more details</source>
-        <target state="new">Error installing tool '{0}' [ {1} ].{2}Error: {3}{2}See output channel '{4}' for more details</target>
+        <target state="translated">Erreur d'installation de l'outil « {0} » [ {1} ].{2}Erreur : {3}{2}Voir le canal de sortie « {4} » pour plus de détails</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallErrorInformation">
         <source xml:lang="en">Error installing tool. See output channel '{0}' for more details</source>
-        <target state="new">Error installing tool. See output channel '{0}' for more details</target>
+        <target state="translated">Erreur d'installation de l'outil. Voir le canal de sortie « {0} » pour plus de détails</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallFailed">
         <source xml:lang="en">Installation commands completed but version of tool '{0}' could not be detected so our installation attempt has failed. Detection Error: {1}{2}Cleaning up previous installations would help.</source>
-        <target state="new">Installation commands completed but version of tool '{0}' could not be detected so our installation attempt has failed. Detection Error: {1}{2}Cleaning up previous installations would help.</target>
+        <target state="translated">Commandes d'installation exécutées, mais impossible de détecter la version de l'outil « {0} ». La tentative d'installation a donc échoué. Erreur de détection : {1}{2}Essayez de nettoyer les installations précédentes.</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallFailInformation">
         <source xml:lang="en">Failed to detect version post installation. See output channel '{0}' for more details</source>
-        <target state="new">Failed to detect version post installation. See output channel '{0}' for more details</target>
+        <target state="translated">La détection de la version après l'installation a échoué. Voir le canal de sortie « {0} » pour plus de détails</target>
       </trans-unit>
       <trans-unit id="toolBase.ManualUninstallCommand">
         <source xml:lang="en"> A possibly way to uninstall is using this command:{0}   &gt;{1}</source>
-        <target state="new"> A possibly way to uninstall is using this command:{0}   &gt;{1}</target>
+        <target state="translated"> Vous pouvez effectuer la désinstallation à l'aide de cette commande : {0}   &gt;{1}</target>
       </trans-unit>
       <trans-unit id="toolBase.SeeOutputChannel">
         <source xml:lang="en">{0}See output channel '{1}' for more details</source>
-        <target state="new">{0}See output channel '{1}' for more details</target>
+        <target state="translated">{0}Voir le canal de sortie « {1} » pour plus de détails</target>
       </trans-unit>
       <trans-unit id="toolBase.installCore.CannotInstallTool">
         <source xml:lang="en">Cannot install tool:{0}::{1} as installation commands are unknown for your OS distribution, Please install {0} manually before proceeding</source>
-        <target state="new">Cannot install tool:{0}::{1} as installation commands are unknown for your OS distribution, Please install {0} manually before proceeding</target>
+        <target state="translated">Impossible d'installer l'outil : {0}::{1}, car les commandes d'installation sont inconnues pour la distribution de votre système d'exploitation. Installez {0} manuellement avant de continuer</target>
       </trans-unit>
       <trans-unit id="toolBase.addInstallationSearchPathsToSystemPath.SearchPaths">
         <source xml:lang="en">Search Paths for tool '{0}': {1}</source>
-        <target state="new">Search Paths for tool '{0}': {1}</target>
+        <target state="translated">Chemins de recherche de l'outil « {0} » : {1}</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
-        <target state="new">Error retrieving version information. See output channel '{0}' for more details</target>
+        <target state="translated">Erreur de récupération des informations de version. Voir le canal de sortie « {0} » pour plus de détails</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
-        <target state="new">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </target>
+        <target state="translated">Erreur de récupération des informations de version.{0}Sortie non valide reçue, sortie de la commande get version : « {1} » </target>
       </trans-unit>
     </body>
   </file>
@@ -910,87 +814,87 @@
     <body>
       <trans-unit id="deployAzureSQLDB.NewSQLDBTitle">
         <source xml:lang="en">Deploy Azure SQL DB</source>
-        <target state="new">Deploy Azure SQL DB</target>
+        <target state="translated">Déployer Azure SQL DB</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Exécuter un script sur un notebook</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">Remplissez les champs obligatoires marqués d'un astérisque rouge.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSettingsPageTitle">
         <source xml:lang="en">Azure SQL Database - Azure account settings</source>
-        <target state="new">Azure SQL Database - Azure account settings</target>
+        <target state="translated">Azure SQL Database - Paramètres de compte Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSettingsSummaryPageTitle">
         <source xml:lang="en">Azure account settings</source>
-        <target state="new">Azure account settings</target>
+        <target state="translated">Paramètres de compte Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureAccountDropdownLabel">
         <source xml:lang="en">Azure account</source>
-        <target state="new">Azure account</target>
+        <target state="translated">Compte Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSubscriptionDropdownLabel">
         <source xml:lang="en">Subscription</source>
-        <target state="new">Subscription</target>
+        <target state="translated">Abonnement</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureDatabaseServersDropdownLabel">
         <source xml:lang="en">Server</source>
-        <target state="new">Server</target>
+        <target state="translated">Serveur</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.ResourceGroup">
         <source xml:lang="en">Resource group</source>
-        <target state="new">Resource group</target>
+        <target state="translated">Groupe de ressources</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DatabaseSettingsPageTitle">
         <source xml:lang="en">Database settings</source>
-        <target state="new">Database settings</target>
+        <target state="translated">Paramètres de base de données</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallRuleNameLabel">
         <source xml:lang="en">Firewall rule name</source>
-        <target state="new">Firewall rule name</target>
+        <target state="translated">Nom de la règle de pare-feu</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DatabaseNameLabel">
         <source xml:lang="en">SQL database name</source>
-        <target state="new">SQL database name</target>
+        <target state="translated">Nom de la base de données SQL</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.CollationNameLabel">
         <source xml:lang="en">Database collation</source>
-        <target state="new">Database collation</target>
+        <target state="translated">Classement de base de données</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.CollationNameSummaryLabel">
         <source xml:lang="en">Collation for database</source>
-        <target state="new">Collation for database</target>
+        <target state="translated">Classement de la base de données</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.IpAddressInfoLabel">
         <source xml:lang="en">Enter IP addresses in IPv4 format.</source>
-        <target state="new">Enter IP addresses in IPv4 format.</target>
+        <target state="translated">Entrez les adresses IP au format IPv4.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.StartIpAddressLabel">
         <source xml:lang="en">Min IP address in firewall IP range</source>
-        <target state="new">Min IP address in firewall IP range</target>
+        <target state="translated">Adresse IP min. dans la plage IP du pare-feu</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.EndIpAddressLabel">
         <source xml:lang="en">Max IP address in firewall IP range</source>
-        <target state="new">Max IP address in firewall IP range</target>
+        <target state="translated">Adresse IP max. dans la plage IP du pare-feu</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.StartIpAddressShortLabel">
         <source xml:lang="en">Min IP address</source>
-        <target state="new">Min IP address</target>
+        <target state="translated">Adresse IP min.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.EndIpAddressShortLabel">
         <source xml:lang="en">Max IP address</source>
-        <target state="new">Max IP address</target>
+        <target state="translated">Adresse IP max.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallRuleDescription">
         <source xml:lang="en">Create a firewall rule for your local client IP in order to connect to your database through Azure Data Studio after creation is completed.</source>
-        <target state="new">Create a firewall rule for your local client IP in order to connect to your database through Azure Data Studio after creation is completed.</target>
+        <target state="translated">Créez une règle de pare-feu pour votre IP de client local afin de vous connecter à votre base de données via Azure Data Studio une fois la création effectuée.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallToggleLabel">
         <source xml:lang="en">Create a firewall rule</source>
-        <target state="new">Create a firewall rule</target>
+        <target state="translated">Créer une règle de pare-feu</target>
       </trans-unit>
     </body>
   </file>
@@ -998,7 +902,7 @@
     <body>
       <trans-unit id="resourceDeployment.KubeCtlDescription">
         <source xml:lang="en">Runs commands against Kubernetes clusters</source>
-        <target state="new">Runs commands against Kubernetes clusters</target>
+        <target state="translated">Exécute des commandes sur des clusters Kubernetes</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.KubeCtlDisplayName">
         <source xml:lang="en">kubectl</source>
@@ -1006,67 +910,67 @@
       </trans-unit>
       <trans-unit id="resourceDeployment.invalidKubectlVersionOutput">
         <source xml:lang="en">Unable to parse the kubectl version command output: "{0}"</source>
-        <target state="new">Unable to parse the kubectl version command output: "{0}"</target>
+        <target state="translated">Impossible d'analyser la sortie de la commande de version kubectl : « {0} »</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.UpdatingBrewRepository">
         <source xml:lang="en">updating your brew repository for kubectl installation …</source>
-        <target state="new">updating your brew repository for kubectl installation …</target>
+        <target state="translated">mise à jour de votre dépôt brew pour l'installation de kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.InstallingKubeCtl">
         <source xml:lang="en">installing kubectl …</source>
-        <target state="new">installing kubectl …</target>
+        <target state="translated">installation de kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AptGetUpdate">
         <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
+        <target state="translated">mise à jour des informations de dépôt...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AptGetPackages">
         <source xml:lang="en">getting packages needed for kubectl installation …</source>
-        <target state="new">getting packages needed for kubectl installation …</target>
+        <target state="translated">obtention des packages nécessaires à l'installation de kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for kubectl …</source>
-        <target state="new">downloading and installing the signing key for kubectl …</target>
+        <target state="translated">téléchargement et installation de la clé de signature pour kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AddingKubectlRepositoryInformation">
         <source xml:lang="en">adding the kubectl repository information …</source>
-        <target state="new">adding the kubectl repository information …</target>
+        <target state="translated">ajout des informations du dépôt kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.InstallingKubectl">
         <source xml:lang="en">installing kubectl …</source>
-        <target state="new">installing kubectl …</target>
+        <target state="translated">installation de kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DeletePreviousDownloadedKubectl.exe">
         <source xml:lang="en">deleting previously downloaded kubectl.exe if one exists …</source>
-        <target state="new">deleting previously downloaded kubectl.exe if one exists …</target>
+        <target state="translated">suppression du fichier kubectl.exe précédemment téléchargé, le cas échéant...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadingAndInstallingKubectl">
         <source xml:lang="en">downloading and installing the latest kubectl.exe …</source>
-        <target state="new">downloading and installing the latest kubectl.exe …</target>
+        <target state="translated">téléchargement et installation du dernier fichier kubectl.exe...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DeletePreviousDownloadedKubectl">
         <source xml:lang="en">deleting previously downloaded kubectl if one exists …</source>
-        <target state="new">deleting previously downloaded kubectl if one exists …</target>
+        <target state="translated">suppression du kubectl précédemment téléchargé, le cas échéant...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadingKubectl">
         <source xml:lang="en">downloading the latest kubectl release …</source>
-        <target state="new">downloading the latest kubectl release …</target>
+        <target state="translated">téléchargement de la dernière mise en production de kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.MakingExecutable">
         <source xml:lang="en">making kubectl executable …</source>
-        <target state="new">making kubectl executable …</target>
+        <target state="translated">création de l'exécutable kubectl...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.CleaningUpOldBackups">
         <source xml:lang="en">cleaning up any previously backed up version in the install location if they exist …</source>
-        <target state="new">cleaning up any previously backed up version in the install location if they exist …</target>
+        <target state="translated">nettoyage des versions précédemment sauvegardées dans l'emplacement d'installation, le cas échéant...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.BackupCurrentBinary">
         <source xml:lang="en">backing up any existing kubectl in the install location …</source>
-        <target state="new">backing up any existing kubectl in the install location …</target>
+        <target state="translated">sauvegarde de tout kubectl existant dans l'emplacement d'installation...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.MoveToSystemPath">
         <source xml:lang="en">moving kubectl into the install location in the PATH …</source>
-        <target state="new">moving kubectl into the install location in the PATH …</target>
+        <target state="translated">déplacement de kubectl dans l'emplacement d'installation dans PATH...</target>
       </trans-unit>
     </body>
   </file>
@@ -1074,7 +978,7 @@
     <body>
       <trans-unit id="wizardPage.ValidationError">
         <source xml:lang="en">There are some errors on this page, click 'Show Details' to view the errors.</source>
-        <target state="new">There are some errors on this page, click 'Show Details' to view the errors.</target>
+        <target state="translated">Cette page a des erreurs, cliquez sur 'Afficher les détails' pour les voir.</target>
       </trans-unit>
     </body>
   </file>
@@ -1082,24 +986,20 @@
     <body>
       <trans-unit id="deploymentDialog.OpenNotebook">
         <source xml:lang="en">Open Notebook</source>
-        <target state="new">Open Notebook</target>
+        <target state="translated">Ouvrir le notebook</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.OkButtonText">
         <source xml:lang="en">OK</source>
-        <target state="new">OK</target>
+        <target state="translated">OK</target>
       </trans-unit>
       <trans-unit id="notebookType">
         <source xml:lang="en">Notebook type</source>
-        <target state="new">Notebook type</target>
+        <target state="translated">Type de notebook</target>
       </trans-unit>
     </body>
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">Le chargement de l'extension {0} a échoué. Erreur détectée dans la définition du type de ressource dans package.json, consultez la console de débogage pour plus d'informations.</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">Le type de ressource {0} n'est pas défini</target>
@@ -1118,31 +1018,31 @@
     <body>
       <trans-unit id="resourceDeployment.outputChannel">
         <source xml:lang="en">Deployments</source>
-        <target state="new">Deployments</target>
+        <target state="translated">Déploiements</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.ErroredOut">
         <source xml:lang="en">	&gt;&gt;&gt; {0}   … errored out: {1}</source>
-        <target state="new">	&gt;&gt;&gt; {0}   … errored out: {1}</target>
+        <target state="translated">	&gt;&gt;&gt; {0}   … a donné une erreur : {1}</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.IgnoringError">
         <source xml:lang="en">	&gt;&gt;&gt; Ignoring error in execution and continuing tool deployment</source>
-        <target state="new">	&gt;&gt;&gt; Ignoring error in execution and continuing tool deployment</target>
+        <target state="translated">	&gt;&gt;&gt; Omission de l'erreur dans l'exécution et poursuite du déploiement de l'outil</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.stdout">
         <source xml:lang="en">    stdout: </source>
-        <target state="new">    stdout: </target>
+        <target state="translated">    stdout : </target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.stderr">
         <source xml:lang="en">    stderr: </source>
-        <target state="new">    stderr: </target>
+        <target state="translated">    stderr : </target>
       </trans-unit>
       <trans-unit id="platformService.RunStreamedCommand.ExitedWithCode">
         <source xml:lang="en">    &gt;&gt;&gt; {0}    … exited with code: {1}</source>
-        <target state="new">    &gt;&gt;&gt; {0}    … exited with code: {1}</target>
+        <target state="translated">    &gt;&gt;&gt; {0}    … a quitté avec le code : {1}</target>
       </trans-unit>
       <trans-unit id="platformService.RunStreamedCommand.ExitedWithSignal">
         <source xml:lang="en">    &gt;&gt;&gt; {0}   … exited with signal: {1}</source>
-        <target state="new">    &gt;&gt;&gt; {0}   … exited with signal: {1}</target>
+        <target state="translated">    &gt;&gt;&gt; {0}   … a quitté avec le signal : {1}</target>
       </trans-unit>
     </body>
   </file>
@@ -1158,31 +1058,31 @@
     <body>
       <trans-unit id="deployCluster.serviceScaleTableTitle">
         <source xml:lang="en">Service scale settings (Instances)</source>
-        <target state="new">Service scale settings (Instances)</target>
+        <target state="translated">Paramètres de mise à l'échelle du service (instances)</target>
       </trans-unit>
       <trans-unit id="deployCluster.storageTableTitle">
         <source xml:lang="en">Service storage settings (GB per Instance)</source>
-        <target state="new">Service storage settings (GB per Instance)</target>
+        <target state="translated">Paramètres de stockage du service (Go par instance)</target>
       </trans-unit>
       <trans-unit id="deployCluster.featureTableTitle">
         <source xml:lang="en">Features</source>
-        <target state="new">Features</target>
+        <target state="translated">Fonctionnalités</target>
       </trans-unit>
       <trans-unit id="deployCluster.yesText">
         <source xml:lang="en">Yes</source>
-        <target state="new">Yes</target>
+        <target state="translated">Oui</target>
       </trans-unit>
       <trans-unit id="deployCluster.noText">
         <source xml:lang="en">No</source>
-        <target state="new">No</target>
+        <target state="translated">Non</target>
       </trans-unit>
       <trans-unit id="deployCluster.summaryPageTitle">
         <source xml:lang="en">Deployment configuration profile</source>
-        <target state="new">Deployment configuration profile</target>
+        <target state="translated">Profil de configuration de déploiement</target>
       </trans-unit>
       <trans-unit id="deployCluster.summaryPageDescription">
         <source xml:lang="en">Select the target configuration profile</source>
-        <target state="new">Select the target configuration profile</target>
+        <target state="translated">Sélectionner le profil de configuration cible</target>
       </trans-unit>
       <trans-unit id="deployCluster.ProfileHintText">
         <source xml:lang="en">Note: The settings of the deployment profile can be customized in later steps.</source>
@@ -1190,15 +1090,15 @@
       </trans-unit>
       <trans-unit id="deployCluster.loadingProfiles">
         <source xml:lang="en">Loading profiles</source>
-        <target state="new">Loading profiles</target>
+        <target state="translated">Chargement des profils</target>
       </trans-unit>
       <trans-unit id="deployCluster.loadingProfilesCompleted">
         <source xml:lang="en">Loading profiles completed</source>
-        <target state="new">Loading profiles completed</target>
+        <target state="translated">Profils chargés</target>
       </trans-unit>
       <trans-unit id="deployCluster.profileRadioGroupLabel">
         <source xml:lang="en">Deployment configuration profile</source>
-        <target state="new">Deployment configuration profile</target>
+        <target state="translated">Profil de configuration de déploiement</target>
       </trans-unit>
       <trans-unit id="deployCluster.loadProfileFailed">
         <source xml:lang="en">Failed to load the deployment profiles: {0}</source>
@@ -1222,19 +1122,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">Service</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataStorageType">
         <source xml:lang="en">Data</source>
-        <target state="new">Data</target>
+        <target state="translated">Données</target>
       </trans-unit>
       <trans-unit id="deployCluster.logsStorageType">
         <source xml:lang="en">Logs</source>
-        <target state="new">Logs</target>
+        <target state="translated">Journaux</target>
       </trans-unit>
       <trans-unit id="deployCluster.StorageType">
         <source xml:lang="en">Storage type</source>
-        <target state="new">Storage type</target>
+        <target state="translated">Type de stockage</target>
       </trans-unit>
       <trans-unit id="deployCluster.basicAuthentication">
         <source xml:lang="en">Basic authentication</source>
@@ -1250,7 +1150,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.featureText">
         <source xml:lang="en">Feature</source>
-        <target state="new">Feature</target>
+        <target state="translated">Composant</target>
       </trans-unit>
       <trans-unit id="deployCluster.ProfileNotSelectedError">
         <source xml:lang="en">Please select a deployment profile.</source>
@@ -1262,7 +1162,7 @@
     <body>
       <trans-unit id="deployCluster.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">Remplissez les champs obligatoires marqués d'un astérisque rouge.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AzureSettingsPageTitle">
         <source xml:lang="en">Azure settings</source>
@@ -1322,7 +1222,7 @@
     <body>
       <trans-unit id="deployCluster.ClusterNameDescription">
         <source xml:lang="en">The cluster name must consist only of alphanumeric lowercase characters or '-' and must start and end with an alphanumeric character.</source>
-        <target state="new">The cluster name must consist only of alphanumeric lowercase characters or '-' and must start and end with an alphanumeric character.</target>
+        <target state="translated">Le nom de cluster doit contenir seulement des caractères alphanumériques en minuscules ou « - », et doit commencer et se terminer par un caractère alphanumérique.</target>
       </trans-unit>
       <trans-unit id="deployCluster.ClusterSettingsPageTitle">
         <source xml:lang="en">Cluster settings</source>
@@ -1434,7 +1334,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.RealmDescription">
         <source xml:lang="en">If not provided, the domain DNS name will be used as the default value.</source>
-        <target state="new">If not provided, the domain DNS name will be used as the default value.</target>
+        <target state="translated">S'il n'est pas fourni, le nom DNS du domaine est utilisé comme valeur par défaut.</target>
       </trans-unit>
       <trans-unit id="deployCluster.ClusterAdmins">
         <source xml:lang="en">Cluster admin group</source>
@@ -1470,7 +1370,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.AppOwners">
         <source xml:lang="en">App owners</source>
-        <target state="new">App owners</target>
+        <target state="translated">Propriétaires d'application</target>
       </trans-unit>
       <trans-unit id="deployCluster.AppOwnersPlaceHolder">
         <source xml:lang="en">Use comma to separate the values.</source>
@@ -1494,19 +1394,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.Subdomain">
         <source xml:lang="en">Subdomain</source>
-        <target state="new">Subdomain</target>
+        <target state="translated">Sous-domaine</target>
       </trans-unit>
       <trans-unit id="deployCluster.SubdomainDescription">
         <source xml:lang="en">A unique DNS subdomain to use for this SQL Server Big Data Cluster. If not provided, the cluster name will be used as the default value.</source>
-        <target state="new">A unique DNS subdomain to use for this SQL Server Big Data Cluster. If not provided, the cluster name will be used as the default value.</target>
+        <target state="translated">Sous-domaine DNS unique à utiliser pour ce cluster Big Data SQL Server. S'il n'est pas fourni, le nom de cluster est utilisé comme valeur par défaut.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefix">
         <source xml:lang="en">Account prefix</source>
-        <target state="new">Account prefix</target>
+        <target state="translated">Préfixe du compte</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefixDescription">
         <source xml:lang="en">A unique prefix for AD accounts SQL Server Big Data Cluster will generate. If not provided, the subdomain name will be used as the default value. If a subdomain is not provided, the cluster name will be used as the default value.</source>
-        <target state="new">A unique prefix for AD accounts SQL Server Big Data Cluster will generate. If not provided, the subdomain name will be used as the default value. If a subdomain is not provided, the cluster name will be used as the default value.</target>
+        <target state="translated">Préfixe unique pour les comptes AD que le cluster Big Data SQL Server génère. S'il n'est pas fourni, le nom du sous-domaine est utilisé comme valeur par défaut. Si aucun sous-domaine n'est fourni, le nom du cluster est utilisé comme valeur par défaut.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AdminPasswordField">
         <source xml:lang="en">Password</source>
@@ -1646,19 +1546,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.controllerDataStorageClass">
         <source xml:lang="en">Controller's data storage class</source>
-        <target state="new">Controller's data storage class</target>
+        <target state="translated">Classe de stockage de données du contrôleur</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerDataStorageClaimSize">
         <source xml:lang="en">Controller's data storage claim size</source>
-        <target state="new">Controller's data storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage de données du contrôleur</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerLogsStorageClass">
         <source xml:lang="en">Controller's logs storage class</source>
-        <target state="new">Controller's logs storage class</target>
+        <target state="translated">Classe de stockage des journaux du contrôleur</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerLogsStorageClaimSize">
         <source xml:lang="en">Controller's logs storage claim size</source>
-        <target state="new">Controller's logs storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage des journaux du contrôleur</target>
       </trans-unit>
       <trans-unit id="deployCluster.StoragePool">
         <source xml:lang="en">Storage pool (HDFS)</source>
@@ -1666,19 +1566,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolDataStorageClass">
         <source xml:lang="en">Storage pool's data storage class</source>
-        <target state="new">Storage pool's data storage class</target>
+        <target state="translated">Classe de stockage de données du pool de stockage</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolDataStorageClaimSize">
         <source xml:lang="en">Storage pool's data storage claim size</source>
-        <target state="new">Storage pool's data storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage de données du pool de stockage</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolLogsStorageClass">
         <source xml:lang="en">Storage pool's logs storage class</source>
-        <target state="new">Storage pool's logs storage class</target>
+        <target state="translated">Classe de stockage des journaux du pool de stockage</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolLogsStorageClaimSize">
         <source xml:lang="en">Storage pool's logs storage claim size</source>
-        <target state="new">Storage pool's logs storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage des journaux du pool de stockage</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataPool">
         <source xml:lang="en">Data pool</source>
@@ -1686,39 +1586,39 @@
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolDataStorageClass">
         <source xml:lang="en">Data pool's data storage class</source>
-        <target state="new">Data pool's data storage class</target>
+        <target state="translated">Classe de stockage de données du pool de données</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolDataStorageClaimSize">
         <source xml:lang="en">Data pool's data storage claim size</source>
-        <target state="new">Data pool's data storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage de données du pool de données</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolLogsStorageClass">
         <source xml:lang="en">Data pool's logs storage class</source>
-        <target state="new">Data pool's logs storage class</target>
+        <target state="translated">Classe de stockage des journaux du pool de données</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolLogsStorageClaimSize">
         <source xml:lang="en">Data pool's logs storage claim size</source>
-        <target state="new">Data pool's logs storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage des journaux du pool de données</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterDataStorageClass">
         <source xml:lang="en">SQL Server master's data storage class</source>
-        <target state="new">SQL Server master's data storage class</target>
+        <target state="translated">Classe de stockage de données de l'instance maître SQL Server</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterDataStorageClaimSize">
         <source xml:lang="en">SQL Server master's data storage claim size</source>
-        <target state="new">SQL Server master's data storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage de données de l'instance maître SQL Server</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterLogsStorageClass">
         <source xml:lang="en">SQL Server master's logs storage class</source>
-        <target state="new">SQL Server master's logs storage class</target>
+        <target state="translated">Classe de stockage des journaux de l'instance maître SQL Server</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterLogsStorageClaimSize">
         <source xml:lang="en">SQL Server master's logs storage claim size</source>
-        <target state="new">SQL Server master's logs storage claim size</target>
+        <target state="translated">Taille de la revendication de stockage des journaux de l'instance maître SQL Server</target>
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service name</source>
-        <target state="new">Service name</target>
+        <target state="translated">Nom du service</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataStorageClassName">
         <source xml:lang="en">Storage class for data</source>
@@ -1738,7 +1638,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.StorageSettings">
         <source xml:lang="en">Storage settings</source>
-        <target state="new">Storage settings</target>
+        <target state="translated">Paramètres de stockage</target>
       </trans-unit>
       <trans-unit id="deployCluster.StorageSectionTitle">
         <source xml:lang="en">Storage settings</source>
@@ -1822,7 +1722,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.AppOwners">
         <source xml:lang="en">App owners</source>
-        <target state="new">App owners</target>
+        <target state="translated">Propriétaires d'application</target>
       </trans-unit>
       <trans-unit id="deployCluster.AppReaders">
         <source xml:lang="en">App readers</source>
@@ -1830,11 +1730,11 @@
       </trans-unit>
       <trans-unit id="deployCluster.Subdomain">
         <source xml:lang="en">Subdomain</source>
-        <target state="new">Subdomain</target>
+        <target state="translated">Sous-domaine</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefix">
         <source xml:lang="en">Account prefix</source>
-        <target state="new">Account prefix</target>
+        <target state="translated">Préfixe du compte</target>
       </trans-unit>
       <trans-unit id="deployCluster.DomainServiceAccountUserName">
         <source xml:lang="en">Service account username</source>
@@ -1902,7 +1802,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">Service</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataStorageClassName">
         <source xml:lang="en">Storage class for data</source>
@@ -2010,11 +1910,11 @@
     <body>
       <trans-unit id="sqlVMDeploymentWizard.PasswordLengthError">
         <source xml:lang="en">Password must be between 12 and 123 characters long.</source>
-        <target state="new">Password must be between 12 and 123 characters long.</target>
+        <target state="translated">Le mot de passe doit avoir entre 12 et 123 caractères.</target>
       </trans-unit>
       <trans-unit id="sqlVMDeploymentWizard.PasswordSpecialCharRequirementError">
         <source xml:lang="en">Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character.</source>
-        <target state="new">Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character.</target>
+        <target state="translated">Le mot de passe doit comporter trois des éléments suivants : une minuscule, une majuscule, un chiffre et un caractère spécial.</target>
       </trans-unit>
     </body>
   </file>
@@ -2022,47 +1922,47 @@
     <body>
       <trans-unit id="deployAzureSQLVM.VnameLengthError">
         <source xml:lang="en">Virtual machine name must be between 1 and 15 characters long.</source>
-        <target state="new">Virtual machine name must be between 1 and 15 characters long.</target>
+        <target state="translated">Le nom de machine virtuelle doit avoir entre 1 et 15 caractères.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameOnlyNumericNameError">
         <source xml:lang="en">Virtual machine name cannot contain only numbers.</source>
-        <target state="new">Virtual machine name cannot contain only numbers.</target>
+        <target state="translated">Le nom de la machine virtuelle ne peut pas contenir uniquement des chiffres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNamePrefixSuffixError">
         <source xml:lang="en">Virtual machine name Can't start with underscore. Can't end with period or hyphen</source>
-        <target state="new">Virtual machine name Can't start with underscore. Can't end with period or hyphen</target>
+        <target state="translated">Le nom de machine virtuelle ne peut pas commencer par un trait de soulignement, et ne peut pas se terminer par un point ou un trait d'union</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameSpecialCharError">
         <source xml:lang="en">Virtual machine name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Virtual machine name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">Le nom de machine virtuelle ne peut pas contenir les caractères spéciaux \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameExistsError">
         <source xml:lang="en">Virtual machine name must be unique in the current resource group.</source>
-        <target state="new">Virtual machine name must be unique in the current resource group.</target>
+        <target state="translated">Le nom de la machine virtuelle doit être unique dans le groupe de ressources actuel.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameLengthError">
         <source xml:lang="en">Username must be between 1 and 20 characters long.</source>
-        <target state="new">Username must be between 1 and 20 characters long.</target>
+        <target state="translated">Le nom d'utilisateur doit avoir entre 1 et 20 caractères.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameSuffixError">
         <source xml:lang="en">Username cannot end with period</source>
-        <target state="new">Username cannot end with period</target>
+        <target state="translated">Le nom d'utilisateur ne peut pas se terminer par un point</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameSpecialCharError">
         <source xml:lang="en">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp; .</source>
-        <target state="new">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp; .</target>
+        <target state="translated">Le nom d'utilisateur ne peut pas contenir les caractères spéciaux \/""[]:|&lt;&gt;+=;,?*@&amp; .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameReservedWordsError">
         <source xml:lang="en">Username must not include reserved words.</source>
-        <target state="new">Username must not include reserved words.</target>
+        <target state="translated">Les noms d'utilisateur ne doivent pas comprendre de mots réservés.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMConfirmPasswordError">
         <source xml:lang="en">Password and confirm password must match.</source>
-        <target state="new">Password and confirm password must match.</target>
+        <target state="translated">Les champs de mot de passe et de confirmation du mot de passe doivent correspondre.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.vmDropdownSizeError">
         <source xml:lang="en">Select a valid virtual machine size.</source>
-        <target state="new">Select a valid virtual machine size.</target>
+        <target state="translated">Sélectionnez une taille de machine virtuelle valide.</target>
       </trans-unit>
     </body>
   </file>
@@ -2070,39 +1970,39 @@
     <body>
       <trans-unit id="deployAzureSQLVM.NewVnetPlaceholder">
         <source xml:lang="en">Enter name for new virtual network</source>
-        <target state="new">Enter name for new virtual network</target>
+        <target state="translated">Entrer un nom pour le nouveau réseau virtuel</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewSubnetPlaceholder">
         <source xml:lang="en">Enter name for new subnet</source>
-        <target state="new">Enter name for new subnet</target>
+        <target state="translated">Entrer un nom pour le nouveau sous-réseau</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewPipPlaceholder">
         <source xml:lang="en">Enter name for new public IP</source>
-        <target state="new">Enter name for new public IP</target>
+        <target state="translated">Entrer un nom pour la nouvelle IP publique</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VnetNameLengthError">
         <source xml:lang="en">Virtual Network name must be between 2 and 64 characters long</source>
-        <target state="new">Virtual Network name must be between 2 and 64 characters long</target>
+        <target state="translated">Le nom de réseau virtuel doit avoir entre 2 et 64 caractères</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewVnetError">
         <source xml:lang="en">Create a new virtual network</source>
-        <target state="new">Create a new virtual network</target>
+        <target state="translated">Créer un réseau virtuel</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SubnetNameLengthError">
         <source xml:lang="en">Subnet name must be between 1 and 80 characters long</source>
-        <target state="new">Subnet name must be between 1 and 80 characters long</target>
+        <target state="translated">Le nom de sous-réseau doit avoir entre 1 et 80 caractères</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewSubnetError">
         <source xml:lang="en">Create a new sub network</source>
-        <target state="new">Create a new sub network</target>
+        <target state="translated">Créer un sous-réseau</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PipNameError">
         <source xml:lang="en">Public IP name must be between 1 and 80 characters long</source>
-        <target state="new">Public IP name must be between 1 and 80 characters long</target>
+        <target state="translated">Le nom d'IP publique doit avoir entre 1 et 80 caractères</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewPipError">
         <source xml:lang="en">Create a new new public Ip</source>
-        <target state="new">Create a new new public Ip</target>
+        <target state="translated">Créer une IP publique</target>
       </trans-unit>
     </body>
   </file>
@@ -2110,27 +2010,27 @@
     <body>
       <trans-unit id="deployAzureSQLVM.PrivateConnectivityDropdownOptionDefault">
         <source xml:lang="en">Private (within Virtual Network)</source>
-        <target state="new">Private (within Virtual Network)</target>
+        <target state="translated">Privé (dans un réseau virtuel)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.LocalConnectivityDropdownOption">
         <source xml:lang="en">Local (inside VM only)</source>
-        <target state="new">Local (inside VM only)</target>
+        <target state="translated">Local (sur la machine virtuelle uniquement)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PublicConnectivityDropdownOption">
         <source xml:lang="en">Public (Internet)</source>
-        <target state="new">Public (Internet)</target>
+        <target state="translated">Public (Internet)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlUsernameLengthError">
         <source xml:lang="en">Username must be between 2 and 128 characters long.</source>
-        <target state="new">Username must be between 2 and 128 characters long.</target>
+        <target state="translated">Le nom d'utilisateur doit avoir entre 2 et 128 caractères.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlUsernameSpecialCharError">
         <source xml:lang="en">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?* .</source>
-        <target state="new">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?* .</target>
+        <target state="translated">Le nom d'utilisateur ne peut pas contenir les caractères spéciaux \/""[]:|&lt;&gt;+=;,?* .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlConfirmPasswordError">
         <source xml:lang="en">Password and confirm password must match.</source>
-        <target state="new">Password and confirm password must match.</target>
+        <target state="translated">Les champs de mot de passe et de confirmation du mot de passe doivent correspondre.</target>
       </trans-unit>
     </body>
   </file>
@@ -2138,7 +2038,7 @@
     <body>
       <trans-unit id="notebookWizard.autoSummaryPageTitle">
         <source xml:lang="en">Review your configuration</source>
-        <target state="new">Review your configuration</target>
+        <target state="translated">Vérifier votre configuration</target>
       </trans-unit>
     </body>
   </file>
@@ -2146,55 +2046,55 @@
     <body>
       <trans-unit id="deployAzureSQLDB.DBMinIpInvalidError">
         <source xml:lang="en">Min Ip address is invalid</source>
-        <target state="new">Min Ip address is invalid</target>
+        <target state="translated">L'adresse IP min. n'est pas valide</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBMaxIpInvalidError">
         <source xml:lang="en">Max Ip address is invalid</source>
-        <target state="new">Max Ip address is invalid</target>
+        <target state="translated">L'adresse IP max. n'est pas valide</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallOnlyNumericNameError">
         <source xml:lang="en">Firewall name cannot contain only numbers.</source>
-        <target state="new">Firewall name cannot contain only numbers.</target>
+        <target state="translated">Le nom de pare-feu ne peut pas contenir seulement des nombres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallLengthError">
         <source xml:lang="en">Firewall name must be between 1 and 100 characters long.</source>
-        <target state="new">Firewall name must be between 1 and 100 characters long.</target>
+        <target state="translated">Le nom de pare-feu doit avoir entre 1 et 100 caractères.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallSpecialCharError">
         <source xml:lang="en">Firewall name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Firewall name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">Le nom de pare-feu ne peut pas contenir les caractères spéciaux \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallUpperCaseError">
         <source xml:lang="en">Upper case letters are not allowed for firewall name</source>
-        <target state="new">Upper case letters are not allowed for firewall name</target>
+        <target state="translated">Les lettres majuscules ne sont pas autorisées dans le nom de pare-feu</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameOnlyNumericNameError">
         <source xml:lang="en">Database name cannot contain only numbers.</source>
-        <target state="new">Database name cannot contain only numbers.</target>
+        <target state="translated">Le nom de base de données ne peut pas contenir seulement des nombres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameLengthError">
         <source xml:lang="en">Database name must be between 1 and 100 characters long.</source>
-        <target state="new">Database name must be between 1 and 100 characters long.</target>
+        <target state="translated">Le nom de base de données doit avoir entre 1 et 100 caractères.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameSpecialCharError">
         <source xml:lang="en">Database name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Database name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">Le nom de base de données ne peut pas contenir les caractères spéciaux \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameExistsError">
         <source xml:lang="en">Database name must be unique in the current server.</source>
-        <target state="new">Database name must be unique in the current server.</target>
+        <target state="translated">Le nom de base de données doit être unique dans le serveur actuel.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationOnlyNumericNameError">
         <source xml:lang="en">Collation name cannot contain only numbers.</source>
-        <target state="new">Collation name cannot contain only numbers.</target>
+        <target state="translated">Le nom de classement ne peut pas contenir seulement des nombres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationLengthError">
         <source xml:lang="en">Collation name must be between 1 and 100 characters long.</source>
-        <target state="new">Collation name must be between 1 and 100 characters long.</target>
+        <target state="translated">Le nom de classement doit avoir entre 1 et 100 caractères.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationSpecialCharError">
         <source xml:lang="en">Collation name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Collation name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">Le nom de classement ne peut pas contenir les caractères spéciaux \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
     </body>
   </file>
@@ -2202,17 +2102,17 @@
     <body>
       <trans-unit id="deployAzureSQLDB.azureSignInError">
         <source xml:lang="en">Sign in to an Azure account first</source>
-        <target state="new">Sign in to an Azure account first</target>
+        <target state="translated">Se connecter d'abord à un compte Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.NoServerLabel">
         <source xml:lang="en">No servers found</source>
-        <target state="new">No servers found</target>
+        <target state="translated">Aucun serveur</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.NoServerError">
         <source xml:lang="en">No servers found in current subscription.
 Select a different subscription containing at least one server</source>
-        <target state="new">No servers found in current subscription.
-Select a different subscription containing at least one server</target>
+        <target state="translated">Aucun serveur dans l'abonnement actuel.
+Sélectionnez un autre abonnement contenant au moins un serveur</target>
       </trans-unit>
     </body>
   </file>
@@ -2220,59 +2120,59 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="notebookWizard.toolsAndEulaPageTitle">
         <source xml:lang="en">Deployment pre-requisites</source>
-        <target state="new">Deployment pre-requisites</target>
-      </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="new">To proceed, you must accept the terms of the End User License Agreement(EULA)</target>
+        <target state="translated">Prérequis de déploiement</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
-        <target state="new">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</target>
+        <target state="translated">Certains outils n'ont toujours pas été découverts. Vérifiez qu'ils sont installés, en cours d'exécution et découvrables</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">Pour continuer, vous devez accepter les conditions du contrat de licence utilisateur final (CLUF).</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
-        <target state="new">Loading required tools information completed</target>
+        <target state="translated">Les informations d'outils nécessaires ont été téléchargées</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredTools">
         <source xml:lang="en">Loading required tools information</source>
-        <target state="new">Loading required tools information</target>
+        <target state="translated">Chargement des informations d'outils nécessaires</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AgreementTitle">
         <source xml:lang="en">Accept terms of use</source>
-        <target state="new">Accept terms of use</target>
+        <target state="translated">Accepter les conditions d'utilisation</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolDoesNotMeetVersionRequirement">
         <source xml:lang="en">'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.</source>
-        <target state="new">'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.</target>
+        <target state="translated">« {0} » [ {1} ] ne respecte pas la version minimale requise, désinstallez-le et redémarrez Azure Data Studio.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstalledTools">
         <source xml:lang="en">All required tools are installed now.</source>
-        <target state="new">All required tools are installed now.</target>
+        <target state="translated">Tous les outils nécessaires sont maintenant installés.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.PendingInstallation">
         <source xml:lang="en">Following tools: {0} were still not discovered. Please make sure that they are installed, running and discoverable</source>
-        <target state="new">Following tools: {0} were still not discovered. Please make sure that they are installed, running and discoverable</target>
+        <target state="translated">Les outils suivants {0} n'ont toujours pas été découverts. Vérifiez qu'ils sont installés, en cours d'exécution et découvrables</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformation">
         <source xml:lang="en">'{0}' was not discovered and automated installation is not currently supported. Install '{0}' manually or ensure it is started and discoverable. Once done please restart Azure Data Studio. See [{1}] .</source>
-        <target state="new">'{0}' was not discovered and automated installation is not currently supported. Install '{0}' manually or ensure it is started and discoverable. Once done please restart Azure Data Studio. See [{1}] .</target>
+        <target state="translated">« {0} » n'a pas été découvert et l'installation automatique n'est pas prise en charge actuellement. Installez manuellement « {0} », ou vérifiez qu'il est démarré et découvrable. Ensuite, redémarrez Azure Data Studio. Consultez [{1}].</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.VersionInformationDebugHint">
         <source xml:lang="en">You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'Azure Data CLI' output channels</source>
-        <target state="new">You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'Azure Data CLI' output channels</target>
+        <target state="translated">Si les outils sont installés manuellement, vous devez redémarrer Azure Data Studio pour appliquer le changement. Des détails supplémentaires sont disponibles dans les canaux de sortie « Déploiements » et « Azure Data CLI »</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallToolsHintOne">
         <source xml:lang="en">Tool: {0} is not installed, you can click the "{1}" button to install it.</source>
-        <target state="new">Tool: {0} is not installed, you can click the "{1}" button to install it.</target>
+        <target state="translated">L'outil {0} n'est pas installé, vous pouvez cliquer sur le bouton « {1} » pour l'installer.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallToolsHintMany">
         <source xml:lang="en">Tools: {0} are not installed, you can click the "{1}" button to install them.</source>
-        <target state="new">Tools: {0} are not installed, you can click the "{1}" button to install them.</target>
+        <target state="translated">Les outils {0} ne sont pas installés, vous pouvez cliquer sur le bouton « {1} » pour les installer.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.NoRequiredTool">
         <source xml:lang="en">No tools required</source>
-        <target state="new">No tools required</target>
+        <target state="translated">Aucun outil nécessaire</target>
       </trans-unit>
     </body>
   </file>
@@ -2280,23 +2180,23 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.DownloadAndLaunchTaskName">
         <source xml:lang="en">Download and launch installer, URL: {0}</source>
-        <target state="new">Download and launch installer, URL: {0}</target>
+        <target state="translated">Télécharger et lancer le programme d'installation, URL : {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DownloadingText">
         <source xml:lang="en">Downloading from: {0}</source>
-        <target state="new">Downloading from: {0}</target>
+        <target state="translated">Téléchargement à partir de : {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DownloadCompleteText">
         <source xml:lang="en">Successfully downloaded: {0}</source>
-        <target state="new">Successfully downloaded: {0}</target>
+        <target state="translated">{0} a été téléchargé</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.LaunchingProgramText">
         <source xml:lang="en">Launching: {0}</source>
-        <target state="new">Launching: {0}</target>
+        <target state="translated">Lancement de {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.ProgramLaunchedText">
         <source xml:lang="en">Successfully launched: {0}</source>
-        <target state="new">Successfully launched: {0}</target>
+        <target state="translated">{0} a été lancé</target>
       </trans-unit>
     </body>
   </file>
@@ -2304,7 +2204,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.DockerDescription">
         <source xml:lang="en">Packages and runs applications in isolated containers</source>
-        <target state="new">Packages and runs applications in isolated containers</target>
+        <target state="translated">Insère dans un package et exécute des applications dans des conteneurs isolés</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DockerDisplayName">
         <source xml:lang="en">docker</source>
@@ -2316,7 +2216,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzCLIDescription">
         <source xml:lang="en">Manages Azure resources</source>
-        <target state="new">Manages Azure resources</target>
+        <target state="translated">Gère les ressources Azure</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzCLIDisplayName">
         <source xml:lang="en">Azure CLI</source>
@@ -2324,47 +2224,47 @@ Select a different subscription containing at least one server</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DeletingPreviousAzureCli.msi">
         <source xml:lang="en">deleting previously downloaded azurecli.msi if one exists …</source>
-        <target state="new">deleting previously downloaded azurecli.msi if one exists …</target>
+        <target state="translated">suppression du fichier azurecli.msi précédemment téléchargé, le cas échéant...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DownloadingAndInstallingAzureCli">
         <source xml:lang="en">downloading azurecli.msi and installing azure-cli …</source>
-        <target state="new">downloading azurecli.msi and installing azure-cli …</target>
+        <target state="translated">téléchargement d'azurecli.msi et installation d'azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DisplayingInstallationLog">
         <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
+        <target state="translated">affichage du journal d'installation...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.UpdatingBrewRepository">
         <source xml:lang="en">updating your brew repository for azure-cli installation …</source>
-        <target state="new">updating your brew repository for azure-cli installation …</target>
+        <target state="translated">mise à jour de votre dépôt brew pour l'installation d'azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.InstallingAzureCli">
         <source xml:lang="en">installing azure-cli …</source>
-        <target state="new">installing azure-cli …</target>
+        <target state="translated">installation d'azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetUpdate">
         <source xml:lang="en">updating repository information before installing azure-cli …</source>
-        <target state="new">updating repository information before installing azure-cli …</target>
+        <target state="translated">mise à jour des informations de dépôt avant l'installation d'azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetPackages">
         <source xml:lang="en">getting packages needed for azure-cli installation …</source>
-        <target state="new">getting packages needed for azure-cli installation …</target>
+        <target state="translated">obtention des packages nécessaires à l'installation d'azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for azure-cli …</source>
-        <target state="new">downloading and installing the signing key for azure-cli …</target>
+        <target state="translated">téléchargement et installation de la clé de signature pour azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AddingAzureCliRepositoryInformation">
         <source xml:lang="en">adding the azure-cli repository information …</source>
-        <target state="new">adding the azure-cli repository information …</target>
+        <target state="translated">ajout des informations du dépôt azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetUpdateAgain">
         <source xml:lang="en">updating repository information again for azure-cli …</source>
-        <target state="new">updating repository information again for azure-cli …</target>
+        <target state="translated">remise à jour des informations de dépôt pour azure-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.ScriptedInstall">
         <source xml:lang="en">download and invoking script to install azure-cli …</source>
-        <target state="new">download and invoking script to install azure-cli …</target>
+        <target state="translated">télécharger et appeler un script pour installer azure-cli...</target>
       </trans-unit>
     </body>
   </file>
@@ -2372,59 +2272,23 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzdataDescription">
         <source xml:lang="en">Azure Data command line interface</source>
-        <target state="new">Azure Data command line interface</target>
+        <target state="translated">Interface de ligne de commande Azure Data</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzdataDisplayName">
         <source xml:lang="en">Azure Data CLI</source>
-        <target state="new">Azure Data CLI</target>
+        <target state="translated">Azure Data CLI</target>
+      </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">L’extension CLI de données Azure doit être installée pour déployer cette ressource. Veuillez l’installer via la galerie d’extensions et essayer à nouveau.</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
-        <target state="new">Error retrieving version information. See output channel '{0}' for more details</target>
+        <target state="translated">Erreur de récupération des informations de version. Voir le canal de sortie « {0} » pour plus de détails</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
-        <target state="new">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="new">deleting previously downloaded Azdata.msi if one exists …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="new">downloading Azdata.msi and installing azdata-cli …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="new">tapping into the brew repository for azdata-cli …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="new">updating the brew repository for azdata-cli installation …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="new">installing azdata …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="new">getting packages needed for azdata installation …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="new">downloading and installing the signing key for azdata …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="new">adding the azdata repository information …</target>
+        <target state="translated">Erreur de récupération des informations de version.{0}Sortie non valide reçue, sortie de la commande get version : « {1} » </target>
       </trans-unit>
     </body>
   </file>
@@ -2432,51 +2296,51 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzdataDescription">
         <source xml:lang="en">Azure Data command line interface</source>
-        <target state="new">Azure Data command line interface</target>
+        <target state="translated">Interface de ligne de commande Azure Data</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzdataDisplayName">
         <source xml:lang="en">Azure Data CLI</source>
-        <target state="new">Azure Data CLI</target>
+        <target state="translated">Azure Data CLI</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
         <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="new">deleting previously downloaded Azdata.msi if one exists …</target>
+        <target state="translated">suppression du fichier Azdata.msi précédemment téléchargé, le cas échéant...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
         <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="new">downloading Azdata.msi and installing azdata-cli …</target>
+        <target state="translated">téléchargement d'azdata.msi et installation d'azdata-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
         <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
+        <target state="translated">affichage du journal d'installation...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
         <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="new">tapping into the brew repository for azdata-cli …</target>
+        <target state="translated">recherche dans le dépôt brew pour azdata-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
         <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="new">updating the brew repository for azdata-cli installation …</target>
+        <target state="translated">mise à jour du dépôt brew pour l'installation d'azdata-cli...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
         <source xml:lang="en">installing azdata …</source>
-        <target state="new">installing azdata …</target>
+        <target state="translated">installation d'azdata...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
         <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
+        <target state="translated">mise à jour des informations de dépôt...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
         <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="new">getting packages needed for azdata installation …</target>
+        <target state="translated">obtention des packages nécessaires à l'installation d'azdata...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="new">downloading and installing the signing key for azdata …</target>
+        <target state="translated">téléchargement et installation de la clé de signature pour azdata...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
         <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="new">adding the azdata repository information …</target>
+        <target state="translated">ajout des informations du dépôt azdata...</target>
       </trans-unit>
     </body>
   </file>
@@ -2484,7 +2348,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="deploymentDialog.deploymentOptions">
         <source xml:lang="en">Deployment options</source>
-        <target state="new">Deployment options</target>
+        <target state="translated">Options de déploiement</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/schema-compare.fr.xlf
+++ b/resources/xlf/fr/schema-compare.fr.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Source</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">Cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">Fichier</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">Fichier d'application de la couche Données (.dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de données</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Type</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">Serveur</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de données</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">Comparer les schémas</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Un autre schéma source a été sélectionné. Comparer pour voir les différences ?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Un autre schéma cible a été sélectionné. Comparer pour voir les différences ?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">Vous avez sélectionné des schémas cible et source différents. Comparer pour voir les différences ?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">Fichier source</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">Fichier cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Base de données source</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Base de données cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Serveur source</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Serveur cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">par défaut</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Ouvrir</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">Sélectionner un fichier source</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">Sélectionner le fichier cible</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">Réinitialiser</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">Inclure les types d'objet</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">Comparer les détails</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">Voulez-vous vraiment mettre à jour la cible ?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">Appuyez sur Comparer pour actualiser la comparaison.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">Générer un script pour déployer les changements sur la cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">Aucun changement de script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">Appliquer les changements à la cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">Aucun changement à appliquer</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">Veuillez noter que le calcul des dépendances affectées peut prendre quelques instants si les opérations incluent/exclues.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Supprimer</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">Changer</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">Ajouter</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">Comparaison entre source et cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">Initialisation de la comparaison. Cette opération peut durer un certain temps.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">Pour comparer deux schémas, sélectionnez d'abord un schéma source et un schéma cible, puis appuyez sur Comparer.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">Aucune différence de schéma.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Type</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">Nom de la source</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">Inclure</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Action</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">Nom de la cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">La génération de script est activée quand la cible est une base de données</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">L'option Appliquer est activée quand la cible est une base de données</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">Impossible d’exclure {0}. Les dépendants inclus existent, tels que {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">Ne peut pas inclure {0}. Il existe des dépendants exclus, tels que {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">Impossible d’exclure {0}. Il existe des dépendants inclus</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">Ne peut pas inclure {0}. Il existe des dépendants exclus</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">Comparer</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Arrêter</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Générer le script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Options</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Appliquer</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">Changer de sens</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">Basculer entre la source et la cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">Sélectionner la source</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">Sélectionner la cible</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">Ouvrir le fichier .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">Charger la source, la cible et les options enregistrées dans un fichier .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">Enregistrer le fichier .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">Enregistrer la source et la cible, les options et les éléments exclus</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">Enregistrer</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">Voulez-vous vous connecter à {0}?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">Sélectionner la connexion</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,8 +663,8 @@
         <target state="translated">Rôles de base de données</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
-        <target state="translated">DatabaseTriggers</target>
+        <source xml:lang="en">Database Triggers</source>
+        <target state="translated">Déclencheurs de base de données</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
         <source xml:lang="en">Defaults</source>
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">Formats de fichier externe</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">Flux externes</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">Travaux de streaming externes</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">Tables externes</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">Groupes de fichiers</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Fichiers</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">Signatures</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">Procédures stockées</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">Clés symétriques</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">Spécifie si les différences d'ordre des colonnes de table doivent être ignorées ou mises à jour quand vous publiez dans une base de données.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Source</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Cible</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">Fichier</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">Fichier d'application de la couche Données (.dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de données</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Type</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">Serveur</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de données</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">Aucune connexion active</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Comparer les schémas</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Un autre schéma source a été sélectionné. Comparer pour voir les différences ?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Un autre schéma cible a été sélectionné. Comparer pour voir les différences ?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">Vous avez sélectionné des schémas cible et source différents. Comparer pour voir les différences ?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Ouvrir</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">par défaut</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">Comparer les détails</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">Voulez-vous vraiment mettre à jour la cible ?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">Appuyez sur Comparer pour actualiser la comparaison.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">Générer un script pour déployer les changements sur la cible</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">Aucun changement de script</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">Appliquer les changements à la cible</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">Aucun changement à appliquer</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Supprimer</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">Changer</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">Ajouter</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Comparer les schémas</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Source</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Cible</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">Initialisation de la comparaison. Cette opération peut durer un certain temps.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">Pour comparer deux schémas, sélectionnez d'abord un schéma source et un schéma cible, puis appuyez sur Comparer.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">Aucune différence de schéma.</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">Comparer les schémas a échoué : {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Type</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">Nom de la source</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">Inclure</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Action</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">Nom de la cible</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">La génération de script est activée quand la cible est une base de données</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">L'option Appliquer est activée quand la cible est une base de données</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Comparer</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Comparer</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arrêter</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arrêter</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">L'enregistrement de scmp a échoué : '{0}'</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">L'annulation de Comparer les schémas a échoué : « {0} »</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Générer le script</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">La génération de script a échoué : '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Options</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Options</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Appliquer</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">Échec d'application de Comparer les schémas « {0} »</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">Changer de sens</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">Basculer entre la source et la cible</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">Sélectionner la source</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">Sélectionner la cible</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">Ouvrir le fichier .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">Charger la source, la cible et les options enregistrées dans un fichier .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Ouvrir</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">L'ouverture de scmp a échoué : '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">Enregistrer le fichier .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">Enregistrer la source et la cible, les options et les éléments exclus</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">Enregistrer</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">L'enregistrement de scmp a échoué : '{0}'</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/fr/sql.fr.xlf
+++ b/resources/xlf/fr/sql.fr.xlf
@@ -1,2251 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">La copie d'images n'est pas prise en charge</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">Démarrer</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">Afficher la prise en main</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">Pri&amp;&amp;se en main</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">QueryHistory</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">Indique si la capture de l'historique des requêtes est activée. Si la valeur est false, les requêtes exécutées ne sont pas capturées.</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Voir</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Historique des requêtes</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">Historique des requêtes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">Connexion : {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">Exécution de la commande : {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">Ouverture d'une nouvelle requête : {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">Connexion impossible, car aucune information du serveur n'a été fournie</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">Impossible d'ouvrir l'URL en raison de l'erreur {0}</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">Cette opération établit une connexion au serveur {0}</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">Voulez-vous vraiment vous connecter ?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">&amp;&amp;Ouvrir</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">Connexion du fichier de requête</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">1 ou plusieurs tâches sont en cours. Voulez-vous vraiment quitter ?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">Les fonctionnalités en préversion améliorent votre expérience dans Azure Data Studio en vous donnant un accès total aux nouvelles fonctionnalités et améliorations. Vous pouvez en savoir plus sur les fonctionnalités en préversion [ici] ({0}). Voulez-vous activer les fonctionnalités en préversion ?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">Oui (recommandé)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">Non, ne plus afficher</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">Activer/désactiver l'historique des requêtes</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Supprimer</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">Effacer tout l'historique</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">Ouvrir la requête</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Exécuter la requête</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">Activer/désactiver la capture de l'historique des requêtes</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">Suspendre la capture de l'historique des requêtes</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">Démarrer la capture de l'historique des requêtes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">Aucune requête à afficher.</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">Historique des requêtes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Erreur</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Avertissement</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">Informations</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">Ignorer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">L'enregistrement des résultats dans un format différent est désactivé pour ce fournisseur de données.</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">Impossible de sérialiser les données, car aucun fournisseur n'est inscrit</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">La sérialisation a échoué avec une erreur inconnue</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">La connexion est nécessaire pour interagir avec adminservice</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Aucun gestionnaire inscrit</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">Sélectionnez un fichier</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">La connexion est nécessaire pour interagir avec le service d'évaluation</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Aucun gestionnaire inscrit</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">Grille de résultats et messages</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">Contrôle la famille de polices.</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">Contrôle l'épaisseur de police.</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">Contrôle la taille de police en pixels.</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">Contrôle l'espacement des lettres en pixels.</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">Contrôle la hauteur de ligne en pixels</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">Contrôle l'espacement des cellules en pixels</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">Dimensionnez automatiquement la largeur de colonne en fonction des résultats initiaux. Problèmes de performance possibles avec les grands nombres de colonnes ou les grandes cellules</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">Largeur maximale en pixels des colonnes dimensionnées automatiquement</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Voir</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">Connexions de base de données</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">connexions de source de données</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">groupes de source de données</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">Configuration de démarrage</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">True pour afficher la vue des serveurs au lancement d'Azure Data Studio par défaut, false pour afficher la dernière vue ouverte</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Déconnecter</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualiser</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">Fonctionnalités en préversion</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">Activer les fonctionnalités en préversion non publiées</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">Afficher la boîte de dialogue de connexion au démarrage</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">Notification d'API obsolète</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">Activer/désactiver la notification d'utilisation d'API obsolète</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">Problèmes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} tâches en cours</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Voir</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">Tâches</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Tâches</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">Nombre maximal de connexions récemment utilisées à stocker dans la liste de connexions.</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">Moteur SQL par défaut à utiliser. Définit le fournisseur de langage par défaut dans les fichiers .sql et la valeur par défaut quand vous créez une connexion.</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">Essayez d'analyser le contenu du presse-papiers quand la boîte de dialogue de connexion est ouverte ou qu'une opération de collage est effectuée.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">Palette de couleurs du groupe de serveurs utilisée dans la viewlet Explorateur d'objets.</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">Développez automatiquement les groupes de serveurs dans la viewlet Explorateur d'objets.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(Préversion) Utilisez la nouvelle arborescence de serveur asynchrone pour la vue des serveurs et la boîte de dialogue de connexion avec prise en charge des nouvelles fonctionnalités, comme le filtrage dynamique de nœuds.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">Identificateur du type de compte</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(Facultatif) Icône utilisée pour représenter le compte dans l'interface utilisateur. Peut être un chemin de fichier ou une configuration à thèmes</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Chemin de l'icône quand un thème clair est utilisé</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Chemin de l'icône quand un thème foncé est utilisé</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">Ajoute des icônes à un fournisseur de compte.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">Afficher le volet Modifier les données SQL au démarrage</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Valeur minimale de l'axe Y</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Valeur maximale de l'axe Y</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Étiquette de l'axe Y</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">Valeur minimale de l'axe X</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">Valeur maximale de l'axe X</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">Étiquette de l'axe X</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visionneuse de ressources</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">Indique la propriété de données d'un jeu de données pour un graphique.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">Pour chaque colonne d'un jeu de résultats, affiche la valeur de la ligne 0 sous forme de chiffre suivi du nom de la colonne. Prend en charge '1 Healthy', '3 Unhealthy', par exemple, où 'Healthy' est le nom de la colonne et 1 est la valeur de la ligne 1, cellule 1</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">Affiche les résultats dans un tableau simple</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">Affiche une image, par exemple, celle retournée par une requête de type R utilisant ggplot2</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">Format attendu : JPEG, PNG ou un autre format ?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">Cet objet est-il encodé en hexadécimal, base64 ou un autre format ?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gérer</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Tableau de bord</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">Vue web à afficher sous cet onglet.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">Controlhost à afficher sous cet onglet.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">Liste des widgets à afficher sous cet onglet.</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">La liste des widgets est attendue à l'intérieur du conteneur de widgets pour l'extension.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">Liste des widgets ou des vues web à afficher sous cet onglet.</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">les widgets ou les vues web sont attendus dans un conteneur de widgets pour l'extension.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">Identificateur unique de ce conteneur.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">Conteneur à afficher sous l'onglet.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">Fournit un ou plusieurs conteneurs de tableau de bord que les utilisateurs peuvent ajouter à leur tableau de bord.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">Aucun ID de conteneur de tableau de bord spécifié pour l'extension.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">Aucun conteneur dans le conteneur de tableau de bord spécifié pour l'extension.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">1 seul conteneur de tableau de bord doit être défini par espace.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">Type de conteneur inconnu défini dans le conteneur de tableau de bord pour l'extension.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificateur unique pour cette section de navigation. Est transmis à l'extension pour toutes les demandes.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Facultatif) Icône utilisée pour représenter cette section de navigation dans l'interface utilisateur (chemin de fichier ou configuration à thèmes)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Chemin de l'icône quand un thème clair est utilisé</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Chemin de l'icône quand un thème foncé est utilisé</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">Titre de la section de navigation à montrer à l'utilisateur.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">Conteneur à afficher dans cette section de navigation.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">Liste des conteneurs de tableau de bord à afficher dans cette section de navigation.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">Aucun titre dans la section de navigation n'a été spécifié pour l'extension.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">Aucun conteneur dans la section de navigation n'a été spécifié pour l'extension.</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">1 seul conteneur de tableau de bord doit être défini par espace.</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION dans NAV_SECTION est un conteneur non valide pour l'extension.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">Vue de modèles à afficher sous cet onglet.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Sauvegarder</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurer</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">Ouvrir dans le portail Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">déconnecté</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">Développement impossible, car le fournisseur de connexion nécessaire '{0}' est introuvable</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">Annulé par l'utilisateur</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">Boîte de dialogue de pare-feu annulée</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">Une connexion est nécessaire pour interagir avec JobManagementService</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Aucun gestionnaire inscrit</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">Une erreur s'est produite pendant le chargement de l'explorateur de fichiers.</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">Erreur de l'explorateur de fichiers</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">ID courant du fournisseur</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">Nom d'affichage du fournisseur</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">Alias du noyau de notebook pour le fournisseur</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">Chemin de l'icône du type de serveur</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">Options de connexion</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificateur unique pour cet onglet. Est transmis à l'extension pour toutes les demandes.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">Titre de l'onglet à montrer à l'utilisateur.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">Description de cet onglet à montrer à l'utilisateur.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Condition qui doit être true pour afficher cet élément</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">Définit les types de connexion avec lesquels cet onglet est compatible. La valeur par défaut est 'MSSQL' si aucune valeur n'est définie</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">Conteneur à afficher sous cet onglet.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">Indique si cet onglet doit toujours apparaître ou uniquement quand l'utilisateur l'ajoute.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">Indique si cet onglet doit être utilisé comme onglet d'accueil pour un type de connexion.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">Identificateur unique du groupe auquel appartient cet onglet, valeur du groupe d'accueil : accueil.</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Facultatif) Icône utilisée pour représenter cet onglet dans l'interface utilisateur (chemin de fichier ou configuration à thèmes)</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Chemin de l'icône quand un thème clair est utilisé</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Chemin de l'icône quand un thème foncé est utilisé</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">Fournit un ou plusieurs onglets que les utilisateurs peuvent ajouter à leur tableau de bord.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">Aucun titre spécifié pour l'extension.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">Aucune description spécifiée à afficher.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">Aucun conteneur spécifié pour l'extension.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">1 seul conteneur de tableau de bord doit être défini par espace</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">Identificateur unique de ce groupe d'onglets.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">Titre du groupe d'onglets.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">Fournit un ou plusieurs groupes d'onglets que les utilisateurs peuvent ajouter à leur tableau de bord.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">Aucun ID spécifié pour le groupe d'onglets.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">Aucun titre spécifié pour le groupe d'onglets.</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">Administration</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">Supervision</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">Performances</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">Sécurité</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">Résolution des problèmes</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Paramètres</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">onglet de bases de données</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">Bases de données</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">succès</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">échec</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">Erreur de connexion</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">La connexion a échoué en raison d'une erreur Kerberos.</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">L'aide pour configurer Kerberos est disponible sur {0}</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">Si vous vous êtes déjà connecté, vous devez peut-être réexécuter kinit.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fermer</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">Ajout du compte...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">L'actualisation du compte a été annulée par l'utilisateur</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">Résultats de la requête</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Éditeur de requêtes</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nouvelle requête</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Éditeur de requêtes</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">Quand la valeur est true, les en-têtes de colonne sont inclus dans l'enregistrement des résultats au format CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">Délimiteur personnalisé à utiliser entre les valeurs pendant l'enregistrement au format CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">Caractère(s) utilisé(s) pour séparer les lignes pendant l'enregistrement des résultats au format CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">Caractère utilisé pour englober les champs de texte pendant l'enregistrement des résultats au format CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">Encodage de fichier utilisé pendant l'enregistrement des résultats au format CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">Quand la valeur est true, la sortie XML est mise en forme pendant l'enregistrement des résultats au format XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">Encodage de fichier utilisé pendant l'enregistrement des résultats au format XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">Activer le streaming des résultats, contient quelques problèmes visuels mineurs</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">Options de configuration pour copier les résultats de la Vue Résultats</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">Options de configuration pour copier les résultats multilignes de la vue Résultats</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(Expérimental) Utilisez une table optimisée dans la sortie des résultats. Certaines fonctionnalités sont peut-être manquantes et en préparation.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">Spécifie si la durée d'exécution doit être indiquée pour chaque lot</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">Messages de retour automatique à la ligne</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">Type de graphique par défaut à utiliser à l'ouverture de la visionneuse graphique à partir des résultats d'une requête</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">La coloration des onglets est désactivée</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">La bordure supérieure de chaque onglet de l'éditeur est colorée pour correspondre au groupe de serveurs concerné</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">La couleur d'arrière-plan de chaque onglet de l'éditeur correspond au groupe de serveurs concerné</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">Contrôle comment colorer les onglets en fonction du groupe de serveurs de leur connexion active</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">Contrôle s'il faut montrer les informations de connexion d'un onglet dans le titre.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">Inviter à enregistrer les fichiers SQL générés</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">Définissez la combinaison de touches workbench.action.query.shortcut{0} pour exécuter le texte de raccourci comme un appel de procédure. Tout texte sélectionné dans l'éditeur de requête est passé en paramètre</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">Spécifie des modèles de vue</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">Spécifie les modèles de session</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Filtres Profiler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script de création</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script de suppression</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Sélectionnez les 1000 premiers</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script d'exécution</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script de modification</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Modifier les données</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Sélectionnez les 1000 premiers</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Prendre 10</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script de création</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script d'exécution</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script de modification</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script de suppression</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualiser</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">La validation de la ligne a échoué : </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">Exécution de la requête démarrée à </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">L'exécution de la requête "{0}" a démarré</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">Ligne {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">L'annulation de la requête a échoué : {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">La mise à jour de la cellule a échoué : </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">Aucun URI passé pendant la création d'un gestionnaire de notebook</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">Le fournisseur de notebooks n'existe pas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Éditeur de notebook</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nouveau notebook</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nouveau notebook</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">Définir l'espace de travail et l'ouvrir</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">Noyau SQL : arrêtez l'exécution du notebook quand l'erreur se produit dans une cellule.</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(Préversion) Affichez tous les noyaux du fournisseur de notebook actuel.</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">Autorisez les notebooks à exécuter des commandes Azure Data Studio.</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">Activer le double-clic pour modifier les cellules de texte dans les notebooks</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">Définir le mode Vue de texte enrichi par défaut pour les cellules de texte</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(Préversion) Enregistrez le nom de connexion dans les métadonnées du notebook.</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">Contrôle la hauteur de ligne utilisée dans l'aperçu Markdown du notebook. Ce nombre est relatif à la taille de police.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Voir</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">Rechercher dans les notebooks</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">Configurez des modèles glob pour exclure des fichiers et des dossiers dans les recherches en texte intégral et le mode Quick Open. Hérite tous les modèles glob du paramètre '#files.exclude#'. Découvrez plus d'informations sur les modèles glob [ici](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">Modèle Glob auquel les chemins de fichiers doivent correspondre. Affectez la valeur true ou false pour activer ou désactiver le modèle.</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">Vérification supplémentaire des frères d'un fichier correspondant. Utilisez $(basename) comme variable pour le nom de fichier correspondant.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">Ce paramètre est déprécié et remplacé par "search.usePCRE2".</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">Déprécié. Utilisez "search.usePCRE2" pour prendre en charge la fonctionnalité regex avancée.</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">Si activé, le processus searchService est maintenu actif au lieu d'être arrêté au bout d'une heure d'inactivité. Ce paramètre conserve le cache de recherche de fichier en mémoire.</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Contrôle s'il faut utiliser les fichiers `.gitignore` et `.ignore` par défaut pendant la recherche de fichiers.</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Détermine s'il faut utiliser les fichiers généraux '.gitignore' et '.ignore' pendant la recherche de fichiers.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">Indique s’il faut inclure les résultats d’une recherche de symbole global dans les résultats de fichier pour Quick Open.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">Indique si vous souhaitez inclure les résultats de fichiers récemment ouverts dans les résultats de fichiers pour Quick Open.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">Les entrées d'historique sont triées par pertinence en fonction de la valeur de filtre utilisée. Les entrées les plus pertinentes apparaissent en premier.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">Les entrées d'historique sont triées par date. Les dernières entrées ouvertes sont affichées en premier.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">Contrôle l'ordre de tri de l'historique de l'éditeur en mode Quick Open pendant le filtrage.</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">Contrôle s'il faut suivre les symlinks pendant la recherche.</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">Faire une recherche non sensible à la casse si le modèle est tout en minuscules, dans le cas contraire, faire une rechercher sensible à la casse.</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">Contrôle si la vue de recherche doit lire ou modifier le presse-papiers partagé sur macOS.</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">Contrôle si la recherche s’affiche comme une vue dans la barre latérale ou comme un panneau dans la zone de panneaux pour plus d'espace horizontal.</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">Ce paramètre est déprécié. Utilisez le menu contextuel de la vue de recherche à la place.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">Les fichiers avec moins de 10 résultats sont développés. Les autres sont réduits.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">Contrôle si les résultats de recherche seront réduits ou développés.</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">Détermine s'il faut ouvrir l'aperçu du remplacement quand vous sélectionnez ou remplacez une correspondance.</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">Détermine s'il faut afficher les numéros de ligne dans les résultats de recherche.</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">Détermine s'il faut utiliser le moteur regex PCRE2 dans la recherche de texte. Cette option permet d'utiliser des fonctionnalités regex avancées comme lookahead et les références arrière. Toutefois, les fonctionnalités PCRE2 ne sont pas toutes prises en charge, seulement celles qui sont aussi prises en charge par JavaScript.</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">Déprécié. PCRE2 est utilisé automatiquement lors de l'utilisation de fonctionnalités regex qui ne sont prises en charge que par PCRE2.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">Positionnez la barre d'action à droite quand la vue de recherche est étroite et immédiatement après le contenu quand la vue de recherche est large.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">Positionnez toujours la barre d'action à droite.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">Contrôle le positionnement de la barre d'action sur des lignes dans la vue de recherche.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">Recherchez dans tous les fichiers à mesure que vous tapez.</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">Activez l'essaimage de la recherche à partir du mot le plus proche du curseur quand l'éditeur actif n'a aucune sélection.</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">Mettez à jour la requête de recherche d'espace de travail en fonction du texte sélectionné de l'éditeur quand vous placez le focus sur la vue de recherche. Cela se produit soit au moment du clic de souris, soit au déclenchement de la commande 'workbench.views.search.focus'.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">Quand '#search.searchOnType' est activé, contrôle le délai d'attente avant expiration en millisecondes entre l'entrée d'un caractère et le démarrage de la recherche. N'a aucun effet quand 'search.searchOnType' est désactivé.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">Double-cliquez pour sélectionner le mot sous le curseur.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">Double-cliquez sur le résultat pour l'ouvrir dans le groupe d'éditeurs actif.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">Double-cliquez pour ouvrir le résultat dans le groupe d'éditeurs ouvert ou dans un nouveau groupe d'éditeurs le cas échéant.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">Configurez ce qui se passe après un double clic sur un résultat dans un éditeur de recherche.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">Les résultats sont triés par dossier et noms de fichier, dans l'ordre alphabétique.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">Les résultats sont triés par noms de fichier en ignorant l'ordre des dossiers, dans l'ordre alphabétique.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">Les résultats sont triés par extensions de fichier dans l'ordre alphabétique.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">Les résultats sont triés par date de dernière modification de fichier, dans l'ordre décroissant.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">Les résultats sont triés par nombre dans chaque fichier, dans l'ordre décroissant.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">Les résultats sont triés par nombre dans chaque fichier, dans l'ordre croissant.</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">Contrôle l'ordre de tri des résultats de recherche.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nouvelle requête</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Exécuter</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">Expliquer</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">Réel</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Déconnecter</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Changer la connexion</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Connecter</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">Activer SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">Désactiver SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">Sélectionner une base de données</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Le changement de base de données a échoué</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">Le changement de la base de données {0} a échoué</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">Exporter au format Notebook</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fermer</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Action</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">Copier les détails</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">Ajouter un groupe de serveurs</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">Modifier le groupe de serveurs</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">Extension</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">La création d'une session de l'Explorateur d'objets a échoué</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">Plusieurs erreurs :</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Erreur d'ajout de compte</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">Erreur de règle de pare-feu</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">Certaines des extensions chargées utilisent des API obsolètes, recherchez les informations détaillées sous l'onglet Console de la fenêtre Outils de développement</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Ne plus afficher</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">Identificateur de la vue. Utilisez-le pour inscrire un fournisseur de données au moyen de l'API 'vscode.window.registerTreeDataProviderForView', ainsi que pour déclencher l'activation de votre extension en inscrivant l'événement 'onView:${id}' dans 'activationEvents'.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Nom de la vue, contrôlable de visu. À afficher</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">Condition qui doit être true pour afficher cette vue</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">Ajoute des vues à l'éditeur</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">Ajoute des vues au conteneur Explorateur de données dans la barre d'activités</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">Ajoute des vues au conteneur de vues ajoutées</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">Impossible d'inscrire plusieurs vues avec le même ID '{0}' dans le conteneur de vues '{1}'</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">Une vue avec l'ID '{0}' est déjà inscrite dans le conteneur de vues '{1}'</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">les vues doivent figurer dans un tableau</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">la propriété '{0}' est obligatoire et doit être de type 'string'</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">La propriété '{0}' peut être omise ou doit être de type 'string'</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">{0} a été remplacé par {1} dans vos paramètres utilisateur.</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">{0} a été remplacé par {1} dans vos paramètres d'espace de travail.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gérer</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Afficher les détails</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">En savoir plus</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">Effacer tous les comptes enregistrés</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">Activer/désactiver des tâches</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">État de la connexion</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">Nom visible de l'utilisateur pour le fournisseur d'arborescence</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">ID du fournisseur, doit être le même que celui utilisé pendant l'inscription du fournisseur de données d'arborescence et doit commencer par « connectionDialog/ »</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">Affiche les résultats d'une requête dans un graphique sur le tableau de bord</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">Mappe 'nom de colonne' -&gt; couleur. Par exemple, ajouter 'colonne1': rouge pour que la colonne utilise la couleur rouge </target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">Indique la position par défaut et la visibilité de la légende de graphique. Il s'agit des noms des colonnes de votre requête mappés à l'étiquette de chaque entrée du graphique</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">Si la valeur de dataDirection est horizontale, la définition de ce paramètre sur true utilise la valeur des premières colonnes pour la légende.</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">Si la valeur de dataDirection est verticale, la définition de ce paramètre sur true utilise les noms de colonnes pour la légende.</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">Définit si les données sont lues dans une colonne (vertical) ou une ligne (horizontal). Pour les séries chronologiques, ce paramètre est ignoré, car la direction doit être verticale.</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">Si showTopNData est défini, seules les N premières données sont affichées dans le graphique.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilisé dans les tableaux de bord</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Afficher les actions</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visionneuse de ressources</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">Identificateur de la ressource.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Nom de la vue, contrôlable de visu. À afficher</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">Chemin de l'icône de ressource.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">Fournit une ressource dans la vue des ressources</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">la propriété '{0}' est obligatoire et doit être de type 'string'</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">La propriété '{0}' peut être omise ou doit être de type 'string'</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">Arborescence de la visionneuse de ressources</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilisé dans les tableaux de bord</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilisé dans les tableaux de bord</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget utilisé dans les tableaux de bord</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Condition qui doit être true pour afficher cet élément</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">Indique s'il faut masquer l'en-tête du widget. La valeur par défaut est false</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">Titre du conteneur</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">Ligne du composant dans la grille</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">Rowspan du composant dans la grille. La valeur par défaut est 1. Utilisez '*' pour le définir sur le nombre de lignes dans la grille.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">Colonne du composant dans la grille</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">Colspan du composant dans la grille. La valeur par défaut est 1. Utilisez '*' pour le définir sur le nombre de colonnes dans la grille.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificateur unique pour cet onglet. Est transmis à l'extension pour toutes les demandes.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">L'onglet d'extension est inconnu ou non installé.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Activer ou désactiver le widget de propriétés</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valeurs de propriété à afficher</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nom d'affichage de la propriété</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">Valeur de l'objet d'informations de base de données</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">Spécifiez des valeurs spécifiques à ignorer</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">Mode de récupération</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">Dernière sauvegarde de base de données</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">Dernière sauvegarde de journal</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">Niveau de compatibilité</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Propriétaire</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">Personnalise la page de tableau de bord de base de données</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Recherche</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">Personnalise les onglets de tableau de bord de base de données</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Activer ou désactiver le widget de propriétés</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valeurs de propriété à afficher</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nom d'affichage de la propriété</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">Valeur de l'objet d'informations de serveur</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Version</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">Édition</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">Nom de l'ordinateur</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">Version de système d'exploitation</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Recherche</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">Personnalise la page de tableau de bord de serveur</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">Personnalise les onglets de tableau de bord de serveur</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gérer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">la propriété 'icon' peut être omise, ou doit être une chaîne ou un littéral de type '{dark, light}'</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">Ajoute un widget qui peut interroger un serveur ou une base de données, et afficher les résultats de plusieurs façons (par exemple, dans un graphique, sous forme de nombre total, etc.)</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">Identificateur unique utilisé pour mettre en cache les résultats de l'insight.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">Requête SQL à exécuter. Doit retourner exactement 1 jeu de résultat.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[Facultatif] Chemin d'un fichier contenant une requête. Utilisez-le si 'query' n'est pas défini.</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[Facultatif] Intervalle d'actualisation automatique en minutes, si la valeur n'est pas définie, il n'y a pas d'actualisation automatique</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">Actions à utiliser</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Base de données cible de l'action. Peut être au format '${ columnName }' pour utiliser un nom de colonne piloté par les données.</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Serveur cible de l'action. Peut être au format '${ columnName }' pour utiliser un nom de colonne piloté par les données.</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Utilisateur cible de l'action. Peut être au format '${ columnName } pour utiliser un nom de colonne piloté par les données.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">Identificateur de l'insight</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">Ajoute des insights à la palette de tableau de bord.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Sauvegarder</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">Vous devez activer les fonctionnalités en préversion pour utiliser la sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">La commande de sauvegarde n'est pas prise en charge pour les bases de données Azure SQL.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">La commande de sauvegarde n'est pas prise en charge dans un contexte de serveur. Sélectionnez une base de données et réessayez.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurer</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">Vous devez activer les fonctionnalités en préversion pour utiliser la restauration</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">La commande de restauration n'est pas prise en charge pour les bases de données Azure SQL.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Afficher les recommandations</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">Installer les extensions</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">Créer une extension...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">La connexion à la session de modification des données a échoué</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">Ouvrir les extensions de tableau de bord</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">Aucune extension de tableau de bord n'est actuellement installée. Accédez au gestionnaire d'extensions pour explorer les extensions recommandées.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">Chemin sélectionné</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">Fichiers de type</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Ignorer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">Aucun profil de connexion n'a été passé au menu volant des insights</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">Erreur d'insights</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">Une erreur s'est produite à la lecture du fichier de requête : </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">Une erreur s'est produite à l'analyse de la configuration d'insight. Tableau/chaîne de requête ou fichier de requête introuvable</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Compte Azure</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Locataire Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">Afficher les connexions</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Serveurs</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Connexions</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">Aucun historique des tâches à afficher.</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">Historique des tâches</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">Erreur de tâche</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">Effacer la liste</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">Liste des dernières connexions effacée</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">Voulez-vous vraiment supprimer toutes les connexions de la liste ?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Supprimer</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">Obtenir la chaîne de connexion actuelle</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">Chaîne de connexion non disponible</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">Aucune connexion active disponible</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualiser</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">Modifier la connexion</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Déconnecter</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">Nouvelle connexion</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">Nouveau groupe de serveurs</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">Modifier le groupe de serveurs</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">Afficher les connexions actives</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">Afficher toutes les connexions</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Connexions récentes</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">Supprimer la connexion</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">Supprimer le groupe</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Exécuter</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">La modification de Dispose a échoué avec l'erreur : </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arrêter</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">Afficher le volet SQL</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">Fermer le volet SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">Non connecté</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">La session XEvent Profiler s'est arrêtée de manière inattendue sur le serveur {0}.</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">Erreur au démarrage d'une nouvelle session</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">La session XEvent Profiler pour {0} a des événements perdus.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2257,743 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">Groupes de serveurs</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">Masquer les étiquettes de texte</target>
       </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">Nom de groupe de serveurs</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">Le nom du groupe est obligatoire.</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">Description de groupe</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">Couleur de groupe</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">Afficher les étiquettes de texte</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Erreur d'ajout de compte</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">Élément</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valeur</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">Détails de l'insight</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">Propriété</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valeur</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">Insights</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">Éléments</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">Détails d'élément</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">Impossible de démarrer une authentification OAuth automatique. Il y en a déjà une en cours.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">Trier par événement</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">Trier par colonne</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">Tout effacer</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Appliquer</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">Filtres</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">Supprimer cette clause</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">Enregistrer le filtre</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">Charger le filtre</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">Ajouter une clause</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">Champ</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">Opérateur</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valeur</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">Est Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">N'est pas Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">Contient</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">Ne contient pas</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">Commence par</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">Ne commence pas par</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Enregistrer au format CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Enregistrer au format JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Enregistrer au format Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Enregistrer au format XML</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copier</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copier avec les en-têtes</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Tout sélectionner</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">Définit une propriété à afficher sur le tableau de bord</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">Valeur à utiliser comme étiquette de la propriété</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">Valeur à atteindre dans l'objet</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">Spécifier les valeurs à ignorer</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">Valeur par défaut à afficher en cas d'omission ou d'absence de valeur</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">Saveur pour définir les propriétés de tableau de bord</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">ID de la saveur</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">Condition pour utiliser cette saveur</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">Champ à comparer</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">Opérateur à utiliser pour la comparaison</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">Valeur avec laquelle comparer le champ</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">Propriétés à afficher pour la page de base de données</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">Propriétés à afficher pour la page de serveur</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">Définit que ce fournisseur prend en charge le tableau de bord</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">ID de fournisseur (par ex., MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">Valeurs de propriété à afficher sur le tableau de bord</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">Valeur non valide</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Chargement</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Chargement effectué</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">vide</target>
-      </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">cocher toutes les cases dans la colonne : {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">Aucune arborescence avec l'ID "{0}" n'est inscrite.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">L'initialisation de la session de modification des données a échoué : </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">Identificateur du fournisseur de notebooks.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">Extensions de fichier à inscrire dans ce fournisseur de notebooks</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">Noyaux devant être standard avec ce fournisseur de notebooks</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">Ajoute des fournisseurs de notebooks.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">Nom de la cellule magique, par exemple, '%%sql'.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">Langage de cellule à utiliser si cette commande magique est incluse dans la cellule</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">Cible d'exécution facultative que cette commande magique indique, par exemple, Spark vs. SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">Ensemble facultatif de noyaux, valable, par exemple, pour python3, pyspark, sql</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">Ajoute un langage de notebook.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">La touche de raccourci F5 nécessite la sélection d'une cellule de code. Sélectionnez une cellule de code à exécuter.</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">L'effacement du résultat nécessite la sélection d'une cellule de code. Sélectionnez une cellule de code à exécuter.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">Nombre maximal de lignes :</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">Sélectionner une vue</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">Sélectionner une session</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">Sélectionner une session :</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">Sélectionner une vue :</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Texte</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">Étiquette</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valeur</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Détails</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">Temps écoulé</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">Nombre de lignes</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} lignes</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">Exécution de la requête...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">État d'exécution</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">Récapitulatif de la sélection</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">Moyenne : {0}, nombre : {1}, somme : {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">Choisir un langage SQL</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">Changer le fournisseur de langage SQL</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">Saveur de langage SQL</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">Changer le fournisseur de moteur SQL</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">Une connexion qui utilise le moteur {0} existe déjà. Pour changer, déconnectez-vous ou changez de connexion</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">Aucun éditeur de texte actif actuellement</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">Sélectionner un fournisseur de langage</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">Erreur d'affichage du graphe Plotly : {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Aucun renderer {0} pour la sortie. Elle a les types MIME suivants : {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(sécurisé) </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Sélectionnez les 1000 premiers</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Prendre 10</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script d'exécution</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script de modification</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Modifier les données</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script de création</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script de suppression</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">Un NotebookProvider avec un providerId valide doit être passé à cette méthode</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">Un NotebookProvider avec un providerId valide doit être passé à cette méthode</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">aucun fournisseur de notebooks</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">Aucun gestionnaire</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">Le gestionnaire du notebook {0} n'a pas de gestionnaire de serveur. Impossible d'y effectuer des opérations</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">Le gestionnaire du notebook {0} n'a pas de gestionnaire de contenu. Impossible d'y effectuer des opérations</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">Le gestionnaire du notebook {0} n'a pas de gestionnaire de session. Impossible d'y exécuter des opérations</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">L'obtention d'un jeton de compte Azure pour la connexion a échoué</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">Connexion non acceptée</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">Voulez-vous vraiment annuler cette connexion ?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">Fermer</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">Chargement des noyaux...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">Changement du noyau...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">Attacher à </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">Noyau </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">Chargement des contextes...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Changer la connexion</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">Sélectionner une connexion</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">Pas de noyau</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">Effacer les résultats</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">Approuvé</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">Non approuvé</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">Réduire les cellules</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">Développer les cellules</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">Aucun(e)</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nouveau notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Rechercher la chaîne suivante</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Rechercher la chaîne précédente</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">Plan de requête</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualiser</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">Étape {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">Doit être une option de la liste</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">Zone de sélection</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Connexion</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">Connexion</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">Type de connexion</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Dernières connexions</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connexions enregistrées</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">Détails de la connexion</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Connecter</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Connexions récentes</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">Aucune connexion récente</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connexions enregistrées</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">Aucune connexion enregistrée</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">aucune donnée disponible</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">Arborescence de l'explorateur de fichiers</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">Tout sélectionner/désélectionner</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">De</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">Afficher le filtre</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">À</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Tout sélectionner</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">Créer une règle de pare-feu</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Recherche</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} Résultats</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">{0} sélectionné(s)</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">Tri croissant</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">Tri décroissant</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">Effacer</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Annuler</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">L'adresse IP de votre client n'a pas accès au serveur. Connectez-vous à un compte Azure et créez une règle de pare-feu pour autoriser l'accès.</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">En savoir plus sur les paramètres de pare-feu</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">Règle de pare-feu</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">Ajouter l'adresse IP de mon client </target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">Ajouter la plage d'adresses IP de mon sous-réseau</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">Options de filtre</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">Tous les fichiers</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Chargement</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">Fichier de requête introuvable dans les chemins suivants :
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">Chargement de l'erreur...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">Vous devez actualiser les informations d'identification de ce compte.</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">Afficher/masquer plus</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">Activez la recherche de mises à jour automatique pour que Azure Data Studio recherche les mises à jour automatiquement et régulièrement.</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">Activer pour télécharger et installer les nouvelles versions de Azure Data Studio en arrière-plan sur Windows</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">Afficher les notes de publication après une mise à jour. Les notes de publication sont ouvertes dans une nouvelle fenêtre de navigateur web.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">Menu action de la barre d’outils tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">Menu titre de la cellule du bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">Menu titre du bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">Menu de la barre d’outils du bloc-notes</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">Menu d’action du conteneur d’affichage DataExplorer</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">Menu contextuel de l’élément dataexplorer</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">Menu contextuel de l’élément de l’Explorateur d’objets</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">Menu contextuel de l’arborescence de navigation de la boîte de dialogue de connexion</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">Menu contextuel de l’élément de grille de données</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">Définit la stratégie de sécurité pour le téléchargement des extensions.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">Votre stratégie d’extension ne permet pas d’installer des extensions. Modifiez votre stratégie d’extension et recommencez.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">Installation terminée de l’extension {0} à partir de VSIX. Rechargez Azure Data Studio pour l’activer.</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">Rechargez Azure Data Studio pour désinstaller cette extension.</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">Rechargez Azure Data Studio pour activer l'extension mise à jour.</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">Rechargez Azure Data Studio pour activer cette extension localement.</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">Rechargez Azure Data Studio pour activer cette extension.</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">Rechargez Azure Data Studio pour désactiver cette extension.</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">Rechargez Azure Data Studio pour désinstaller de l’extension {0}.</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">Rechargez Azure Data Studio pour activer cette extension dans {0}</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">L'installation de l'extension {0} a été effectuée. Rechargez Azure Data Studio pour l'activer.</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">Rechargez Azure Data Studio pour terminer la réinstallation de l'extension {0}.</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Place de marché</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Le type de scénario pour les recommandations d'extension doit être fourni.</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">Impossible d'installer l'extension '{0}', car elle n'est pas compatible avec Azure Data Studio '{1}'.</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nouvelle requête</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Nouvelle &amp;&amp;requête</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Nouveau notebook</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">Contrôle la mémoire disponible pour Azure Data Studio après le redémarrage en cas de tentative d'ouverture de fichiers volumineux. Même effet que de spécifier '--max-memory=NEWSIZE' sur la ligne de commande.</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">Souhaitez-vous changer la langue de l’interface d’Azure Data Studio en {0} et redémarrer ?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">Pour utiliser Azure Data Studio dans {0}, Azure Data Studio doit redémarrer.</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">Nouveau fichier SQL</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nouveau notebook</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Installer l’extension à partir du package VSIX</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">Doit être une option de la liste</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">Zone de sélection</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">Afficher les notebooks</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">Résultats de la recherche</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">Chemin de recherche introuvable : {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">La copie d'images n'est pas prise en charge</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">Se concentrer sur la requête actuelle</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Exécuter la requête</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">Exécuter la requête actuelle</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">Copier la requête avec les résultats</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">La requête et les résultats ont été copiés.</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">Exécuter la requête actuelle avec le plan réel</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">Annuler la requête</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">Actualiser le cache IntelliSense</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">Activer/désactiver les résultats de requête</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">Basculer le focus entre la requête et les résultats</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">Le paramètre de l'éditeur est nécessaire pour exécuter un raccourci</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">Analyser la requête</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">Commandes exécutées</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">La commande a échoué : </target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">Connectez-vous à un serveur</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">Un groupe de serveurs du même nom existe déjà.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">succès</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">échec</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">en cours</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">non démarré</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">annulé</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">annulation</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilisé dans les tableaux de bord</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">Le graphique ne peut pas être affiché avec les données spécifiées</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilisé dans les tableaux de bord</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilisé dans les tableaux de bord</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget utilisé dans les tableaux de bord</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">Erreur d'ouverture du lien : {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">Erreur durant l'exécution de la commande « {0} » : {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">La copie a échoué avec l'erreur {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">Afficher le graphique</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">Afficher la table</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Double-cliquer pour modifier&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Ajouter du contenu ici...&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">Erreur pendant l'actualisation du nœud « {0} » : {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Terminé</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Générer le script</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Suivant</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">Précédent</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">Les onglets ne sont pas initialisés</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated"> est nécessaire.</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">Entrée non valide. Valeur numérique attendue.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">Chemin du fichier de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">Base de données cible</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurer</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Restaurer la base de données</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de données</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">Fichier de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Restaurer la base de données</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Source</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">Restaurer à partir de</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">Le chemin du fichier de sauvegarde est obligatoire.</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">Entrez un ou plusieurs chemins de fichier séparés par des virgules</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de données</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">Destination</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">Restaurer vers</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">Plan de restauration</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">Jeux de sauvegarde à restaurer</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">Restaurer les fichiers de base de données en tant que</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">Restaurer les détails du fichier de base de données</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">Nom de fichier logique</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">Type de fichier</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">Nom de fichier d'origine</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">Restaurer comme</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">Options de restauration</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">Sauvegarde de la fin du journal</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">Connexions du serveur</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">Général</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">Fichiers</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Options</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">Copier la cellule</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Terminé</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">Copier et ouvrir</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">Code utilisateur</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">Site web</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">L'index {0} n'est pas valide.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">Description du serveur (facultatif)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">Propriétés avancées</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Abandonner</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">nbformat v{0}.{1} non reconnu</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">Ce fichier n'a pas un format de notebook valide</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">Type de cellule {0} inconnu</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Type de sortie {0} non reconnu</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">Les données de {0} doivent être une chaîne ou un tableau de chaînes</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Type de sortie {0} non reconnu</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Bienvenue</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Pack d'administration SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Pack d'administration SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">Le pack d'administration de SQL Server est une collection d'extensions d'administration de base de données courantes qui vous permet de gérer SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Écrire et exécuter des scripts PowerShell à l'aide de l'éditeur de requêtes complet d'Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">Virtualisation des données</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">Virtualiser les données avec SQL Server 2019 et créer des tables externes à l'aide d'Assistants interactifs</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">Connecter, interroger et gérer les bases de données Postgres avec Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">Le support pour {0} est déjà installé.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">La fenêtre se recharge après l'installation d'un support supplémentaire pour {0}.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">Installation d'un support supplémentaire pour {0}...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">Le support pour {0} avec l'ID {1} est introuvable.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nouvelle connexion</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nouvelle requête</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Nouveau notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Déployer un serveur</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Bienvenue</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">Nouveau</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">Ouvrir…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">Ouvrir le fichier...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">Ouvrir le dossier...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">Démarrer la visite guidée</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">Fermer la barre de présentation rapide</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">Voulez-vous voir une présentation rapide d'Azure Data Studio ?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">Bienvenue !</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">Ouvrir le dossier {0} avec le chemin {1}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">Installer</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">Installer le mappage de touches {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">Installer un support supplémentaire pour {0} </target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Installé</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">Le mappage de touches '{0}' est déjà installé</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">Le support {0} est déjà installé.</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Détails</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">Couleur d'arrière-plan de la page d'accueil.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">Editeur Profiler pour le texte d'événement. En lecture seule</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">L'enregistrement des résultats a échoué. </target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">Choisir le fichier de résultats</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (valeurs séparées par des virgules)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Classeur Excel</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">Texte brut</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">Enregistrement du fichier...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">Résultats enregistrés dans {0}</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Ouvrir un fichier</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">Masquer les étiquettes de texte</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">Afficher les étiquettes de texte</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">éditeur de code vue modèle pour le modèle de vue.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">Informations</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Avertissement</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Erreur</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Afficher les détails</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copier</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fermer</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">Précédent</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">Masquer les détails</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">Comptes</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">Comptes liés</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fermer</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">Aucun compte lié. Ajoutez un compte.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">Ajouter un compte</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">Aucun cloud n'est activé. Accéder à Paramètres -&gt; Rechercher dans la configuration de compte Azure -&gt; Activer au moins un cloud</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">Vous n'avez sélectionné aucun fournisseur d'authentification. Réessayez.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">L'exécution a échoué en raison d'une erreur inattendue : {0}	{1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">Durée d'exécution totale : {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">L'exécution de la requête a démarré à la ligne {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">Démarrage de l'exécution du lot {0}</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">Durée d'exécution en lot : {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">La copie a échoué avec l'erreur {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Démarrer</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nouvelle connexion</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nouvelle requête</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Nouveau notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Ouvrir un fichier</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Ouvrir un fichier</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">Déployer</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">Nouveau déploiement...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">Récent</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">Plus...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">Aucun dossier récent</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Aide</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">Démarrer</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentation</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">Signaler un problème ou une demande de fonctionnalité</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">Dépôt GitHub</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">Notes de publication</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Afficher la page d'accueil au démarrage</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">Personnaliser</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensions</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">Téléchargez les extensions dont vous avez besoin, notamment le pack d'administration SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">Raccourcis clavier</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">Rechercher vos commandes préférées et les personnaliser</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">Thème de couleur</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">Personnalisez l'apparence de l'éditeur et de votre code</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">Apprendre</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">Rechercher et exécuter toutes les commandes</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">La palette de commandes ({0}) permet d'accéder rapidement aux commandes pour en rechercher une</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">Découvrir les nouveautés de la dernière version</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">Nouveaux billets de blog mensuels mettant en avant nos nouvelles fonctionnalités</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Suivez-nous sur Twitter</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">Informez-vous de la façon dont la communauté utilise Azure Data Studio et discutez directement avec les ingénieurs.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Connecter</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Déconnecter</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Démarrer</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">Nouvelle session</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">Suspendre</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">Reprendre</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arrêter</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">Effacer les données</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">Voulez-vous vraiment effacer les données ?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">Défilement automatique : activé</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">Défilement automatique : désactivé</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">Afficher/masquer le panneau réduit</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">Modifier les colonnes</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Rechercher la chaîne suivante</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Rechercher la chaîne précédente</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Lancer Profiler</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">Filtrer...</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">Effacer le filtre</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">Voulez-vous vraiment effacer les filtres ?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">Événements (filtrés) : {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">Événements : {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">Nombre d'événements</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">aucune donnée disponible</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">Résultats</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">Messages</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">Aucun script n'a été retourné pendant l'appel du script sélectionné sur l'objet </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">Sélectionner</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">Créer</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">Insérer</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">Mettre à jour</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Supprimer</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">Aucun script n'a été retourné pendant la création du script {0} sur l'objet {1}</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">Échec des scripts</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">Aucun script n'a été retourné pendant la création du script {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">Couleur d'arrière-plan de l'en-tête du tableau</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">Couleur de premier plan de l'en-tête du tableau</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">Couleur d'arrière-plan de la liste/table pour les éléments sélectionnés et qui ont le focus quand la liste/table est active</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">Couleur du contour d'une cellule.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">Arrière plan de la zone d'entrée désactivée.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">Premier plan de la zone d'entrée désactivée.</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">Couleur de contour du bouton quand il a le focus.</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">Premier plan de la case à cocher désactivée.</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">Couleur d'arrière-plan de la table SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">Couleur d'arrière-plan des cellules de la table SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">Couleur d'arrière-plan du pointage de la table SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">Couleur d'arrière-plan du titre SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">Couleur de bordure des cellules de la table SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">Couleurs d'erreur des messages de résultats.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">Nom de la sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">Mode de récupération</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">Type de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">Fichiers de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">Algorithme</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">Certificat ou clé asymétrique</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">Support</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">Sauvegarder sur le support de sauvegarde existant</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">Sauvegarder sur un nouveau support de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">Ajouter au jeu de sauvegarde existant</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">Remplacer tous les jeux de sauvegarde existants</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">Nom du nouveau support de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">Description du nouveau support de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">Effectuer la somme de contrôle avant d'écrire sur le support</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">Vérifier la sauvegarde une fois terminée</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">Continuer en cas d'erreur</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">Expiration</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">Définir le délai de conservation de sauvegarde en jours</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">Sauvegarde de copie uniquement</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">Configuration avancée</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">Compression</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">Définir la compression de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">Chiffrement</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">Journal des transactions</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">Tronquer le journal des transactions</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">Sauvegarder la fin du journal</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">Fiabilité</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">Le nom de support est obligatoire</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">Aucun certificat ni clé asymétrique n'est disponible</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">Ajouter un fichier</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">Supprimer les fichiers</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">Entrée non valide. La valeur doit être supérieure ou égale à 0.</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Sauvegarder</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">Seule la sauvegarde dans un fichier est prise en charge</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">Le chemin du fichier de sauvegarde est obligatoire</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">L'enregistrement des résultats dans un format différent est désactivé pour ce fournisseur de données.</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">Impossible de sérialiser les données, car aucun fournisseur n'est inscrit</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">La sérialisation a échoué avec une erreur inconnue</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">Aucun fournisseur de données inscrit pouvant fournir des données de vue.</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">Couleur d'arrière-plan de l'en-tête du tableau</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualiser</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">Couleur de premier plan de l'en-tête du tableau</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Tout réduire</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">Couleur d'arrière-plan de la liste/table pour les éléments sélectionnés et qui ont le focus quand la liste/table est active</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">Erreur pendant l'exécution de la commande {1} : {0}. Probablement due à l'extension qui contribue à {1}.</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">Couleur du contour d'une cellule.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">Arrière plan de la zone d'entrée désactivée.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">Premier plan de la zone d'entrée désactivée.</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">Couleur de contour du bouton quand il a le focus.</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">Premier plan de la case à cocher désactivée.</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">Couleur d'arrière-plan de la table SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">Couleur d'arrière-plan des cellules de la table SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">Couleur d'arrière-plan du pointage de la table SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">Couleur d'arrière-plan du titre SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">Couleur de bordure des cellules de la table SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">Couleurs d'erreur des messages de résultats.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">Sélectionnez la cellule active et réessayez</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">Certaines des extensions chargées utilisent des API obsolètes, recherchez les informations détaillées sous l'onglet Console de la fenêtre Outils de développement</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">Exécuter la cellule</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">Annuler l'exécution</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">Erreur de la dernière exécution. Cliquer pour réexécuter</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Ne plus afficher</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">L'annulation de la tâche a échoué.</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">Afficher/masquer plus</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Chargement</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">Accueil</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">La section "{0}" a un contenu non valide. Contactez le propriétaire de l'extension.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">Travaux</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Alertes</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">Proxys</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">Opérateurs</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">Propriétés du serveur</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">Propriétés de la base de données</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">Tout sélectionner/désélectionner</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">Afficher le filtre</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">Effacer</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Connexions récentes</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Serveurs</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Serveurs</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">Fichiers de sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">Tous les fichiers</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">Rechercher : tapez le terme de recherche, puis appuyez sur Entrée pour lancer la recherche, ou sur Échap pour l'annuler</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Recherche</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Le changement de base de données a échoué</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">Dernière occurrence</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Activé</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">Délai entre les réponses (en secondes)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">Nom de catégorie</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">Adresse e-mail</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Activé</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">Nom de compte</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">Nom d'identification</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Description</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Activé</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">chargement des objets</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">chargement des bases de données</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">les objets ont été chargés.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">les bases de données ont été chargées.</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">Rechercher par nom de type (t:, v:, f:, ou sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">Rechercher dans les bases de données</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">Impossible de charger les objets</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">Impossible de charger les bases de données</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">Chargement des propriétés</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">Les propriétés ont été chargées</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">Impossible de charger les propriétés de tableau de bord</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">Chargement de {0}</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">{0} a été chargé</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">Actualisation automatique : désactivée</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">Dernière mise à jour : {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">Aucun résultat à afficher</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Étapes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Enregistrer au format CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Enregistrer au format JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Enregistrer au format Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Enregistrer au format XML</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">L'encodage des résultats n'est pas enregistré quand vous les exportez au format JSON, n'oubliez pas d'enregistrer le fichier que vous créez avec l'encodage souhaité.</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">L'enregistrement dans un fichier n'est pas pris en charge par la source de données de stockage</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copier</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copier avec les en-têtes</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Tout sélectionner</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">Maximiser</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurer</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Graphique</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">Visualiseur</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">La touche de raccourci F5 nécessite la sélection d'une cellule de code. Sélectionnez une cellule de code à exécuter.</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">L'effacement du résultat nécessite la sélection d'une cellule de code. Sélectionnez une cellule de code à exécuter.</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">ID d'étape</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Terminé</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">Nom de l'étape</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">Message</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Générer le script</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Suivant</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">Précédent</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">Les onglets ne sont pas initialisés</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Rechercher</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">Aucune arborescence avec l'ID "{0}" n'est inscrite.</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Rechercher</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">Un NotebookProvider avec un providerId valide doit être passé à cette méthode</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Correspondance précédente</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">aucun fournisseur de notebooks</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Correspondance suivante</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">Aucun gestionnaire</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">Le gestionnaire du notebook {0} n'a pas de gestionnaire de serveur. Impossible d'y effectuer des opérations</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">Le gestionnaire du notebook {0} n'a pas de gestionnaire de contenu. Impossible d'y effectuer des opérations</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">Le gestionnaire du notebook {0} n'a pas de gestionnaire de session. Impossible d'y exécuter des opérations</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">Un NotebookProvider avec un providerId valide doit être passé à cette méthode</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gérer</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Afficher les détails</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">En savoir plus</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">Effacer tous les comptes enregistrés</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">Fonctionnalités en préversion</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">Activer les fonctionnalités en préversion non publiées</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">Afficher la boîte de dialogue de connexion au démarrage</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">Notification d'API obsolète</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">Activer/désactiver la notification d'utilisation d'API obsolète</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">La connexion à la session de modification des données a échoué</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">Non connecté</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">La session XEvent Profiler s'est arrêtée de manière inattendue sur le serveur {0}.</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">Erreur au démarrage d'une nouvelle session</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">La session XEvent Profiler pour {0} a des événements perdus.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Afficher les actions</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visionneuse de ressources</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">Informations</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Avertissement</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Erreur</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Afficher les détails</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copier</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">Fermer</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">Votre recherche a retourné un grand nombre de résultats, seuls les 999 premières correspondances sont mises en surbrillance.</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">Précédent</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} sur {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Aucun résultat</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">Masquer les détails</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">Histogramme horizontal</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">Histogramme</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">Ligne</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">Camembert</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">Nuage de points</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">Time Series</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Image</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">Nombre</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">Table</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">Anneau</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">L'obtention des lignes du jeu de données à afficher dans le graphique a échoué.</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">Le type de graphique « {0} » n'est pas pris en charge.</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">Paramètres</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated"> est nécessaire.</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">Entrée non valide. Valeur numérique attendue.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">Connecté à</target>
-      </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
-        <target state="translated">Déconnecté</target>
-      </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">Connexions non enregistrées</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">L'index {0} n'est pas valide.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">Parcourir (préversion)</target>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">vide</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">Tapez ici pour filtrer la liste</target>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">cocher toutes les cases dans la colonne : {0}</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">Filtrer les connexions</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">Application du filtre</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">Suppression du filtre</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">Filtre appliqué</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">Filtre supprimé</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connexions enregistrées</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connexions enregistrées</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">Arborescence du navigateur de connexion</target>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Afficher les actions</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Cette extension est recommandée par Azure Data Studio.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Chargement</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Chargement effectué</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Ne plus afficher</target>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">Valeur non valide</target>
       </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio a des recommandations d'extension.</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio a des recommandations d'extension pour la visualisation des données.
-Après l'avoir installé, vous pouvez sélectionner l'icône Visualiseur pour visualiser les résultats de votre requête.</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">Tout installer</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Afficher les recommandations</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">Le type de scénario pour les recommandations d'extension doit être fourni.</target>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}. {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">Cette page de fonctionnalité est en préversion. Les fonctionnalités en préversion sont des nouvelles fonctionnalités en passe d'être définitivement intégrées dans le produit. Elles sont stables, mais ont besoin d'améliorations d'accessibilité supplémentaires. Nous vous invitons à nous faire part de vos commentaires en avant-première pendant leur développement.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Chargement</target>
       </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">Aperçu</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">Créer une connexion</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">Connectez-vous à une instance de base de données en utilisant la boîte de dialogue de connexion.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">Exécuter une requête</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">Interagir avec des données par le biais d'un éditeur de requête.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">Créer un notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">Générez un nouveau notebook à l'aide d'un éditeur de notebook natif.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Déployer un serveur</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">Créez une instance de service de données relationnelles sur la plateforme de votre choix.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">Ressources</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">Historique</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">Localisation</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">Afficher plus</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Afficher la page d'accueil au démarrage</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">Liens utiles</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">Démarrer</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Découvrez les fonctionnalités offertes par Azure Data Studio et comment en tirer le meilleur parti.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentation</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">Visitez le centre de documentation pour obtenir des guides de démarrage rapide, des guides pratiques et des références pour PowerShell, les API, etc.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Vue d'ensemble d'Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Présentation des notebooks Azure Data Studio | Données exposées</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensions</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">Tout afficher</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">En savoir plus </target>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Chargement effectué</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">Date de création : </target>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">éditeur de code vue modèle pour le modèle de vue.</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Erreur de notebook : </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">Composant introuvable pour le type {0}</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">Erreur de travail : </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">Le changement des types d'éditeur pour les fichiers non enregistrés n'est pas pris en charge</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">Épinglé</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Sélectionnez les 1000 premiers</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">Dernières exécutions</target>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Prendre 10</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">Exécutions précédentes</target>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script d'exécution</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script de modification</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Modifier les données</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script de création</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script de suppression</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">Aucun script n'a été retourné pendant l'appel du script sélectionné sur l'objet </target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">Sélectionner</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">Créer</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">Insérer</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">Mettre à jour</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Supprimer</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">Aucun script n'a été retourné pendant la création du script {0} sur l'objet {1}</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">Échec des scripts</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">Aucun script n'a été retourné pendant la création du script {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
+        <target state="translated">déconnecté</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
+        <target state="translated">Extension</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">Couleur d’arrière-plan de l’onglet actif pour les onglets verticaux</target>
+      </trans-unit>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">Couleur des bordures du tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">Couleur du titre du widget de tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">Couleur du sous-texte du widget de tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">Couleur des valeurs de propriété affichées dans le composant conteneur des propriétés</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">Couleur des noms de propriété affichées dans le composant conteneur des propriétés</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">Couleur d’ombre de dépassement de la barre d’outils</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">Identificateur du type de compte</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(Facultatif) Icône utilisée pour représenter le compte dans l'interface utilisateur. Peut être un chemin de fichier ou une configuration à thèmes</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Chemin de l'icône quand un thème clair est utilisé</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Chemin de l'icône quand un thème foncé est utilisé</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">Ajoute des icônes à un fournisseur de compte.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">Voir les règles applicables</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">Voir les règles applicables à {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">Appeler l'évaluation</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">Appeler l'évaluation pour {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">Exporter sous forme de script</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">Voir toutes les règles et en savoir plus sur GitHub</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">Créer un rapport HTML</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">Le rapport a été enregistré. Voulez-vous l'ouvrir ?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Ouvrir</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Après l'avoir installé, vous pouvez sélectionner l'icône Visualiseur pour vi
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">La base de données {0} est totalement conforme aux bonnes pratiques. Bon travail !</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Graphique</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">Opération</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">Objet</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">Coût estimé</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">Coût estimé de la sous-arborescence</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">Lignes réelles</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">Lignes estimées</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">Exécutions réelles</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">Coût estimé du processeur</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">Coût estimé des E/S</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">Parallèle</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">Reliaisons réelles</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">Reliaisons estimées</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">Rembobinages réels</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">Rembobinages estimés</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">Partitionné</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">Principales opérations</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">Aucune connexion.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">Ajouter une connexion</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">Ajouter un compte...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Par défaut&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Chargement...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">Groupe de serveurs</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Par défaut&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">Ajouter un nouveau groupe...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;Ne pas enregistrer&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} est obligatoire.</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0} est tronqué.</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">Se souvenir du mot de passe</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">Compte</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">Actualiser les informations d'identification du compte</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Locataire Azure AD</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">Nom (facultatif)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">Avancé...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">Vous devez sélectionner un compte</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Base de données</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">Fichiers et groupes de fichiers</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">Complète</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">Différentielle</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">Journal des transactions</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">Disque</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">Utiliser le paramètre de serveur par défaut</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">Compresser la sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">Ne pas compresser la sauvegarde</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">Certificat de serveur</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">Clé asymétrique</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">Vous n'avez ouvert aucun dossier contenant des notebooks/books. </target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">Ouvrir les notebooks</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">Le jeu de résultats contient uniquement un sous-ensemble de toutes les correspondances. Soyez plus précis dans votre recherche de façon à limiter les résultats retournés.</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">Recherche en cours... - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">Résultats introuvables pour '{0}' excluant '{1}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">Résultats introuvables dans '{0}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">Résultats introuvables avec l'exclusion de '{0}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">Aucun résultat. Vérifiez les exclusions configurées dans vos paramètres et examinez vos fichiers gitignore -</target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">Chercher à nouveau</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Annuler la recherche</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">Rechercher à nouveau dans tous les fichiers</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">Ouvrir les paramètres</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">La recherche a retourné {0} résultats dans {1} fichiers</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">Activer/désactiver les options Réduire et Développer</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Annuler la recherche</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">Tout développer</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Tout réduire</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">Effacer les résultats de la recherche</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Connexions</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">Connectez, interrogez et gérez vos connexions SQL Server, Azure, etc.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Suivant</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">Démarrez en créant votre propre notebook ou collection de notebooks au même endroit.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensions</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Étendez les fonctionnalités d'Azure Data Studio en installant des extensions développées par nous/Microsoft ainsi que par la communauté (vous !).</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Paramètres</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">Personnalisez Azure Data Studio en fonction de vos préférences. Vous pouvez configurer des paramètres comme l'enregistrement automatique et la taille des onglets, personnaliser vos raccourcis clavier et adopter le thème de couleur de votre choix.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">Page d'accueil</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">Découvrez les fonctionnalités principales, les fichiers récemment ouverts et les extensions recommandées dans la page d'accueil. Pour plus d'informations sur le démarrage avec Azure Data Studio, consultez nos vidéos et notre documentation.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">Terminer</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">Visite de bienvenue de l'utilisateur</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">Masquer la visite de bienvenue</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">En savoir plus</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Aide</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">Supprimer la ligne</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">Rétablir la ligne actuelle</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Après l'avoir installé, vous pouvez sélectionner l'icône Visualiseur pour vi
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">Panneau des messages</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copier</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">Tout copier</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">Ouvrir dans le portail Azure</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Chargement</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">Nom de la sauvegarde</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Chargement effectué</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">Mode de récupération</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">Type de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">Fichiers de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">Algorithme</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">Certificat ou clé asymétrique</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">Support</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">Sauvegarder sur le support de sauvegarde existant</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">Sauvegarder sur un nouveau support de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">Ajouter au jeu de sauvegarde existant</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">Remplacer tous les jeux de sauvegarde existants</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">Nom du nouveau support de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">Description du nouveau support de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">Effectuer la somme de contrôle avant d'écrire sur le support</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">Vérifier la sauvegarde une fois terminée</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">Continuer en cas d'erreur</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">Expiration</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">Définir le délai de conservation de sauvegarde en jours</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">Sauvegarde de copie uniquement</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">Configuration avancée</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">Compression</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">Définir la compression de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">Chiffrement</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">Journal des transactions</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">Tronquer le journal des transactions</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">Sauvegarder la fin du journal</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">Fiabilité</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">Le nom de support est obligatoire</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">Aucun certificat ni clé asymétrique n'est disponible</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">Ajouter un fichier</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">Supprimer les fichiers</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">Entrée non valide. La valeur doit être supérieure ou égale à 0.</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Sauvegarder</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">Seule la sauvegarde dans un fichier est prise en charge</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">Le chemin du fichier de sauvegarde est obligatoire</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">Cliquer sur</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ Code</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">ou</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ Texte</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">pour ajouter une cellule de code ou de texte</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Sauvegarder</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">StdIn :</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">Vous devez activer les fonctionnalités en préversion pour utiliser la sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">La commande Sauvegarder n'est pas prise en charge en dehors d’un contexte de base de données. Sélectionnez une base de données et réessayez.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">La commande de sauvegarde n'est pas prise en charge pour les bases de données Azure SQL.</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Sauvegarder</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">Développer le contenu de la cellule de code</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de données</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">Réduire le contenu de la cellule de code</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">Fichiers et groupes de fichiers</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">Complète</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">Différentielle</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">Journal des transactions</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">Disque</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">Utiliser le paramètre de serveur par défaut</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">Compresser la sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">Ne pas compresser la sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">Certificat de serveur</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">Clé asymétrique</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">Plan d'exécution de requêtes XML</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">Grille de résultats</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Ajouter une cellule</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Cellule de code</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Cellule de texte</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">Déplacer la cellule vers le bas</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">Déplacer la cellule vers le haut</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Supprimer</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Ajouter une cellule</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Cellule de code</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Cellule de texte</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">Erreur de noyau SQL</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">Une connexion doit être choisie pour exécuter des cellules de notebook</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">Affichage des {0} premières lignes.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Dernière exécution</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Exécution suivante</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Activé</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">État</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Catégorie</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">Exécutable</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">Planification</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Résultats de la dernière exécution</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Exécutions précédentes</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Aucune étape disponible pour ce travail.</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Erreur : </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">Composant introuvable pour le type {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Rechercher</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Rechercher</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Correspondance précédente</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Correspondance suivante</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fermer</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">Votre recherche a retourné un grand nombre de résultats, seuls les 999 premières correspondances sont mises en surbrillance.</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} sur {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Aucun résultat</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">Schéma</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Type</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Exécuter la requête</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Aucun renderer {0} pour la sortie. Types MIME : {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">sécurisé </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">Aucun composant pour le sélecteur {0}</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">Erreur de rendu du composant : {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Chargement...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Chargement...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Modifier</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">Quitter</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Actualiser</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Afficher les actions</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">Supprimer le widget</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">Cliquer pour désépingler</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">Cliquer pour épingler</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">Ouvrir les fonctionnalités installées</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">Réduire le widget</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">Développer le widget</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} est un conteneur inconnu.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nom</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Base de données cible</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Dernière exécution</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Exécution suivante</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">État</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Résultats de la dernière exécution</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Exécutions précédentes</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Aucune étape disponible pour ce travail.</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Erreur : </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Erreur de notebook : </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">Chargement de l'erreur...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Afficher les actions</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">Aucun élément correspondant n'a été trouvé</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">Liste de recherche filtrée sur 1 élément</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">Liste de recherche filtrée sur {0} éléments</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">Échec</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">Réussite</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">Réessayer</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">Annulé</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">En cours</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">État inconnu</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">Exécution</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">En attente de thread</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">Entre les tentatives</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">Inactif</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">Suspendu</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[Obsolète]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Oui</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Non</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">Non planifié</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">Ne jamais exécuter</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">Gras</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">Italique</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">Souligné</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">Recommandation</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Code</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">Lien</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">Liste</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">Liste triée</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Image</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Bouton bascule d'aperçu Markdown - désactivé</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">Titre</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">Titre 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">Titre 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">Titre 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">Paragraphe</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">Insérer un lien</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">Insérer une image</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">Vue de texte enrichi</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">Mode fractionné</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Vue Markdown</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">Créer un insight</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">Impossible de créer un insight, car l'éditeur actif n'est pas un éditeur SQL</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">Mon widget</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">Configurer le graphique</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">Copier comme une image</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">Aucun graphique à enregistrer</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">Enregistrer comme une image</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">Graphique enregistré dans le chemin : {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Après l'avoir installé, vous pouvez sélectionner l'icône Visualiseur pour vi
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Graphique</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">Histogramme horizontal</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">Histogramme</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">Ligne</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">Camembert</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">Nuage de points</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">Time Series</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Image</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">Nombre</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">Table</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">Anneau</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">L'obtention des lignes du jeu de données à afficher dans le graphique a échoué.</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">Le type de graphique « {0} » n'est pas pris en charge.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Graphiques intégrés</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">Le nombre maximal de lignes à afficher pour les graphiques. Attention : augmenter ce nombre peut avoir un impact sur les performances.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">Fermer</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">Un groupe de serveurs du même nom existe déjà.</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">Série {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">La table n'a pas d'image valide</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">Le nombre maximal de lignes pour les graphiques intégrés a été dépassé, seules les premières {0} lignes sont utilisées. Pour configurer la valeur, vous pouvez ouvrir les paramètres utilisateur et rechercher : « builtinCharts.maxRowCount ».</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Ne plus afficher</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">Connexion : {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">Exécution de la commande : {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">Ouverture d'une nouvelle requête : {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">Connexion impossible, car aucune information du serveur n'a été fournie</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">Impossible d'ouvrir l'URL en raison de l'erreur {0}</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">Cette opération établit une connexion au serveur {0}</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">Voulez-vous vraiment vous connecter ?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">&amp;&amp;Ouvrir</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">Connexion du fichier de requête</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">{0} a été remplacé par {1} dans vos paramètres utilisateur.</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">{0} a été remplacé par {1} dans vos paramètres d'espace de travail.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">Nombre maximal de connexions récemment utilisées à stocker dans la liste de connexions.</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">Moteur SQL par défaut à utiliser. Définit le fournisseur de langage par défaut dans les fichiers .sql et la valeur par défaut quand vous créez une connexion.</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">Essayez d'analyser le contenu du presse-papiers quand la boîte de dialogue de connexion est ouverte ou qu'une opération de collage est effectuée.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">État de la connexion</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">ID courant du fournisseur</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">Nom d'affichage du fournisseur</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">Alias du noyau de notebook pour le fournisseur</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">Chemin de l'icône du type de serveur</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">Options de connexion</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">Nom visible de l'utilisateur pour le fournisseur d'arborescence</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">ID du fournisseur, doit être le même que celui utilisé pendant l'inscription du fournisseur de données d'arborescence et doit commencer par « connectionDialog/ »</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">Identificateur unique de ce conteneur.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">Conteneur à afficher sous l'onglet.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">Fournit un ou plusieurs conteneurs de tableau de bord que les utilisateurs peuvent ajouter à leur tableau de bord.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">Aucun ID de conteneur de tableau de bord spécifié pour l'extension.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">Aucun conteneur dans le conteneur de tableau de bord spécifié pour l'extension.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">1 seul conteneur de tableau de bord doit être défini par espace.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">Type de conteneur inconnu défini dans le conteneur de tableau de bord pour l'extension.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">Controlhost à afficher sous cet onglet.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">La section "{0}" a un contenu non valide. Contactez le propriétaire de l'extension.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">Liste des widgets ou des vues web à afficher sous cet onglet.</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">les widgets ou les vues web sont attendus dans un conteneur de widgets pour l'extension.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">Vue de modèles à afficher sous cet onglet.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificateur unique pour cette section de navigation. Est transmis à l'extension pour toutes les demandes.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Facultatif) Icône utilisée pour représenter cette section de navigation dans l'interface utilisateur (chemin de fichier ou configuration à thèmes)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Chemin de l'icône quand un thème clair est utilisé</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Chemin de l'icône quand un thème foncé est utilisé</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">Titre de la section de navigation à montrer à l'utilisateur.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">Conteneur à afficher dans cette section de navigation.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">Liste des conteneurs de tableau de bord à afficher dans cette section de navigation.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">Aucun titre dans la section de navigation n'a été spécifié pour l'extension.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">Aucun conteneur dans la section de navigation n'a été spécifié pour l'extension.</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">1 seul conteneur de tableau de bord doit être défini par espace.</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION dans NAV_SECTION est un conteneur non valide pour l'extension.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">Vue web à afficher sous cet onglet.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">Liste des widgets à afficher sous cet onglet.</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">La liste des widgets est attendue à l'intérieur du conteneur de widgets pour l'extension.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Modifier</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">Quitter</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualiser</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Afficher les actions</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">Supprimer le widget</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">Cliquer pour désépingler</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">Cliquer pour épingler</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">Ouvrir les fonctionnalités installées</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">Réduire le widget</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">Développer le widget</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} est un conteneur inconnu.</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Après l'avoir installé, vous pouvez sélectionner l'icône Visualiseur pour vi
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">Créer un insight</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificateur unique pour cet onglet. Est transmis à l'extension pour toutes les demandes.</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">Impossible de créer un insight, car l'éditeur actif n'est pas un éditeur SQL</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">Titre de l'onglet à montrer à l'utilisateur.</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">Mon widget</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">Description de cet onglet à montrer à l'utilisateur.</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">Configurer le graphique</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Condition qui doit être true pour afficher cet élément</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">Copier comme une image</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">Définit les types de connexion avec lesquels cet onglet est compatible. La valeur par défaut est 'MSSQL' si aucune valeur n'est définie</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">Aucun graphique à enregistrer</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">Conteneur à afficher sous cet onglet.</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">Enregistrer comme une image</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">Indique si cet onglet doit toujours apparaître ou uniquement quand l'utilisateur l'ajoute.</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">Indique si cet onglet doit être utilisé comme onglet d'accueil pour un type de connexion.</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">Graphique enregistré dans le chemin : {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">Identificateur unique du groupe auquel appartient cet onglet, valeur du groupe d'accueil : accueil.</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Facultatif) Icône utilisée pour représenter cet onglet dans l'interface utilisateur (chemin de fichier ou configuration à thèmes)</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Chemin de l'icône quand un thème clair est utilisé</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Chemin de l'icône quand un thème foncé est utilisé</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">Fournit un ou plusieurs onglets que les utilisateurs peuvent ajouter à leur tableau de bord.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">Aucun titre spécifié pour l'extension.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">Aucune description spécifiée à afficher.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">Aucun conteneur spécifié pour l'extension.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">1 seul conteneur de tableau de bord doit être défini par espace</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">Identificateur unique de ce groupe d'onglets.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">Titre du groupe d'onglets.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">Fournit un ou plusieurs groupes d'onglets que les utilisateurs peuvent ajouter à leur tableau de bord.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">Aucun ID spécifié pour le groupe d'onglets.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">Aucun titre spécifié pour le groupe d'onglets.</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">Administration</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">Supervision</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">Performances</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">Sécurité</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">Résolution des problèmes</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Paramètres</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">onglet de bases de données</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">Bases de données</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">Ajouter du code</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gérer</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">Ajouter du texte</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Tableau de bord</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">Créer un fichier</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gérer</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">Impossible d'afficher le contenu : {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">la propriété 'icon' peut être omise, ou doit être une chaîne ou un littéral de type '{dark, light}'</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Ajouter une cellule</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">Définit une propriété à afficher sur le tableau de bord</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Cellule de code</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">Valeur à utiliser comme étiquette de la propriété</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Cellule de texte</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">Valeur à atteindre dans l'objet</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">Tout exécuter</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">Spécifier les valeurs à ignorer</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">Cellule</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">Valeur par défaut à afficher en cas d'omission ou d'absence de valeur</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Code</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">Saveur pour définir les propriétés de tableau de bord</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Texte</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">ID de la saveur</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">Exécuter les cellules</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">Condition pour utiliser cette saveur</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; Précédent</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">Champ à comparer</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">Suivant &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">Opérateur à utiliser pour la comparaison</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">la cellule avec l'URI {0} est introuvable dans ce modèle</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">Valeur avec laquelle comparer le champ</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">L'exécution des cellules a échoué. Pour plus d'informations, consultez l'erreur dans la sortie de la cellule actuellement sélectionnée.</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">Propriétés à afficher pour la page de base de données</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">Propriétés à afficher pour la page de serveur</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">Définit que ce fournisseur prend en charge le tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">ID de fournisseur (par ex., MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">Valeurs de propriété à afficher sur le tableau de bord</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Condition qui doit être true pour afficher cet élément</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">Indique s'il faut masquer l'en-tête du widget. La valeur par défaut est false</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">Titre du conteneur</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">Ligne du composant dans la grille</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">Rowspan du composant dans la grille. La valeur par défaut est 1. Utilisez '*' pour le définir sur le nombre de lignes dans la grille.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">Colonne du composant dans la grille</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">Colspan du composant dans la grille. La valeur par défaut est 1. Utilisez '*' pour le définir sur le nombre de colonnes dans la grille.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificateur unique pour cet onglet. Est transmis à l'extension pour toutes les demandes.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">L'onglet d'extension est inconnu ou non installé.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">Propriétés de la base de données</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Activer ou désactiver le widget de propriétés</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valeurs de propriété à afficher</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nom d'affichage de la propriété</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">Valeur de l'objet d'informations de base de données</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">Spécifiez des valeurs spécifiques à ignorer</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">Mode de récupération</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">Dernière sauvegarde de base de données</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">Dernière sauvegarde de journal</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">Niveau de compatibilité</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Propriétaire</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">Personnalise la page de tableau de bord de base de données</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Recherche</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">Personnalise les onglets de tableau de bord de base de données</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">Propriétés du serveur</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Activer ou désactiver le widget de propriétés</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valeurs de propriété à afficher</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nom d'affichage de la propriété</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">Valeur de l'objet d'informations de serveur</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Version</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">Édition</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">Nom de l'ordinateur</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">Version de système d'exploitation</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Recherche</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">Personnalise la page de tableau de bord de serveur</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">Personnalise les onglets de tableau de bord de serveur</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">Accueil</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Le changement de base de données a échoué</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Afficher les actions</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">Aucun élément correspondant n'a été trouvé</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">Liste de recherche filtrée sur 1 élément</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">Liste de recherche filtrée sur {0} éléments</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">Schéma</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Type</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">chargement des objets</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">chargement des bases de données</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">les objets ont été chargés.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">les bases de données ont été chargées.</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">Rechercher par nom de type (t:, v:, f:, ou sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">Rechercher dans les bases de données</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">Impossible de charger les objets</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">Impossible de charger les bases de données</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Exécuter la requête</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">Chargement de {0}</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">{0} a été chargé</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">Actualisation automatique : désactivée</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">Dernière mise à jour : {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">Aucun résultat à afficher</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">Ajoute un widget qui peut interroger un serveur ou une base de données, et afficher les résultats de plusieurs façons (par exemple, dans un graphique, sous forme de nombre total, etc.)</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">Identificateur unique utilisé pour mettre en cache les résultats de l'insight.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">Requête SQL à exécuter. Doit retourner exactement 1 jeu de résultat.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[Facultatif] Chemin d'un fichier contenant une requête. Utilisez-le si 'query' n'est pas défini.</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[Facultatif] Intervalle d'actualisation automatique en minutes, si la valeur n'est pas définie, il n'y a pas d'actualisation automatique</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">Actions à utiliser</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Base de données cible de l'action. Peut être au format '${ columnName }' pour utiliser un nom de colonne piloté par les données.</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Serveur cible de l'action. Peut être au format '${ columnName }' pour utiliser un nom de colonne piloté par les données.</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Utilisateur cible de l'action. Peut être au format '${ columnName } pour utiliser un nom de colonne piloté par les données.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">Identificateur de l'insight</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">Ajoute des insights à la palette de tableau de bord.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">Le graphique ne peut pas être affiché avec les données spécifiées</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">Affiche les résultats d'une requête dans un graphique sur le tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">Mappe 'nom de colonne' -&gt; couleur. Par exemple, ajouter 'colonne1': rouge pour que la colonne utilise la couleur rouge </target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">Indique la position par défaut et la visibilité de la légende de graphique. Il s'agit des noms des colonnes de votre requête mappés à l'étiquette de chaque entrée du graphique</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">Si la valeur de dataDirection est horizontale, la définition de ce paramètre sur true utilise la valeur des premières colonnes pour la légende.</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">Si la valeur de dataDirection est verticale, la définition de ce paramètre sur true utilise les noms de colonnes pour la légende.</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">Définit si les données sont lues dans une colonne (vertical) ou une ligne (horizontal). Pour les séries chronologiques, ce paramètre est ignoré, car la direction doit être verticale.</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">Si showTopNData est défini, seules les N premières données sont affichées dans le graphique.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Valeur minimale de l'axe Y</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Valeur maximale de l'axe Y</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Étiquette de l'axe Y</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">Valeur minimale de l'axe X</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">Valeur maximale de l'axe X</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">Étiquette de l'axe X</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">Indique la propriété de données d'un jeu de données pour un graphique.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">Pour chaque colonne d'un jeu de résultats, affiche la valeur de la ligne 0 sous forme de chiffre suivi du nom de la colonne. Prend en charge '1 Healthy', '3 Unhealthy', par exemple, où 'Healthy' est le nom de la colonne et 1 est la valeur de la ligne 1, cellule 1</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">Affiche une image, par exemple, celle retournée par une requête de type R utilisant ggplot2</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">Format attendu : JPEG, PNG ou un autre format ?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">Cet objet est-il encodé en hexadécimal, base64 ou un autre format ?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">Affiche les résultats dans un tableau simple</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">Chargement des propriétés</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">Les propriétés ont été chargées</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">Impossible de charger les propriétés de tableau de bord</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">Connexions de base de données</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">connexions de source de données</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">groupes de source de données</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">Les connexions enregistrées sont triées en fonction des dates auxquelles elles ont été ajoutées.</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">Les connexions enregistrées sont triées par ordre alphabétique de leurs noms d’affichage.</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">Contrôle l’ordre de tri des connexions et des groupes de connexions enregistrés.</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">Configuration de démarrage</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">True pour afficher la vue des serveurs au lancement d'Azure Data Studio par défaut, false pour afficher la dernière vue ouverte</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">Identificateur de la vue. Utilisez-le pour inscrire un fournisseur de données au moyen de l'API 'vscode.window.registerTreeDataProviderForView', ainsi que pour déclencher l'activation de votre extension en inscrivant l'événement 'onView:${id}' dans 'activationEvents'.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Nom de la vue, contrôlable de visu. À afficher</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">Condition qui doit être true pour afficher cette vue</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">Ajoute des vues à l'éditeur</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">Ajoute des vues au conteneur Explorateur de données dans la barre d'activités</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">Ajoute des vues au conteneur de vues ajoutées</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">Impossible d'inscrire plusieurs vues avec le même ID '{0}' dans le conteneur de vues '{1}'</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">Une vue avec l'ID '{0}' est déjà inscrite dans le conteneur de vues '{1}'</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">les vues doivent figurer dans un tableau</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">la propriété '{0}' est obligatoire et doit être de type 'string'</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">La propriété '{0}' peut être omise ou doit être de type 'string'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Serveurs</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Connexions</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">Afficher les connexions</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Déconnecter</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualiser</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">Afficher le volet Modifier les données SQL au démarrage</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Exécuter</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">La modification de Dispose a échoué avec l'erreur : </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Arrêter</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">Afficher le volet SQL</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">Fermer le volet SQL</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">Nombre maximal de lignes :</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">Supprimer la ligne</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">Rétablir la ligne actuelle</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Enregistrer au format CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Enregistrer au format JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Enregistrer au format Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Enregistrer au format XML</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copier</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copier avec les en-têtes</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Tout sélectionner</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">Onglets de tableau de bord ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Titre</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Description</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">Insights de tableau de bord ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">Quand</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">Obtient des informations d’extension à partir de la galerie</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">ID d'extension</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">Extension '{0}' introuvable.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Afficher les recommandations</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">Installer les extensions</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">Créer une extension...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Ne plus afficher</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio a des recommandations d'extension.</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio a des recommandations d'extension pour la visualisation des données.
+Après l'avoir installé, vous pouvez sélectionner l'icône Visualiseur pour visualiser les résultats de votre requête.</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">Tout installer</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Afficher les recommandations</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Le type de scénario pour les recommandations d'extension doit être fourni.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Cette extension est recommandée par Azure Data Studio.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">Travaux</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Alertes</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">Proxys</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">Opérateurs</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">Dernière occurrence</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Activé</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">Délai entre les réponses (en secondes)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">Nom de catégorie</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Erreur : {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">Voir les règles applicables</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">ID d'étape</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">Voir les règles applicables à {0}</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">Nom de l'étape</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">Appeler l'évaluation</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">Appeler l'évaluation pour {0}</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">Exporter sous forme de script</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">Voir toutes les règles et en savoir plus sur GitHub</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">Créer un rapport HTML</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">Le rapport a été enregistré. Voulez-vous l'ouvrir ?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Ouvrir</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annuler</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">Message</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">Données</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Connexion</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Éditeur de requêtes</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Tableau de bord</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Étapes</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">Onglets de tableau de bord ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">Titre</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Description</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">Insights de tableau de bord ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">Nom</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">Quand</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Dernière exécution</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Exécution suivante</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Activé</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">État</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Catégorie</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">Exécutable</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">Planification</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Résultats de la dernière exécution</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Exécutions précédentes</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Aucune étape disponible pour ce travail.</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Erreur : </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">La table n'a pas d'image valide</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">Date de création : </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Erreur de notebook : </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">Erreur de travail : </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">Épinglé</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">Dernières exécutions</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">Exécutions précédentes</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">Plus</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Modifier</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Base de données cible</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fermer</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Dernière exécution</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">Convertir la cellule</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Exécution suivante</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">Exécuter les cellules au-dessus</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">État</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">Exécuter les cellules en dessous</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Résultats de la dernière exécution</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">Insérer du code au-dessus</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Exécutions précédentes</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">Insérer du code en dessous</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Aucune étape disponible pour ce travail.</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">Insérer le texte au-dessus</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Erreur : </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">Insérer le texte en dessous</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">Réduire la cellule</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">Développer la cellule</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">Créer une cellule de paramètre</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">Supprimer la cellule de paramètre</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">Effacer le résultat</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Erreur de notebook : </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">Une erreur s'est produite au démarrage d'une session de notebook</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">Le serveur n'a pas démarré pour une raison inconnue</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">Adresse e-mail</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">Noyau {0} introuvable. Le noyau par défaut est utilisé à la place.</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Activé</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">Série {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">Nom de compte</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fermer</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">Nom d'identification</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="fr">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated"># Paramètres injectés
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Description</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">Sélectionnez une connexion afin d'exécuter les cellules pour ce noyau</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">La suppression de la cellule a échoué.</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">Le changement de noyau a échoué. Le noyau {0} est utilisé. Erreur : {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">Le changement de noyau a échoué en raison de l'erreur : {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">Le changement de contexte a échoué : {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">Impossible de démarrer la session : {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">Une erreur de session du client s'est produite pendant la fermeture du notebook : {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">Gestionnaire de notebook introuvable pour le fournisseur {0}</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Activé</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Erreur : {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">Plus</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Modifier</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fermer</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">Convertir la cellule</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">Exécuter les cellules au-dessus</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">Exécuter les cellules en dessous</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">Insérer du code au-dessus</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">Insérer du code en dessous</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">Insérer le texte au-dessus</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">Insérer le texte en dessous</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">Réduire la cellule</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">Développer la cellule</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">Créer une cellule de paramètre</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">Supprimer la cellule de paramètre</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">Effacer le résultat</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Ajouter une cellule</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Cellule de code</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Cellule de texte</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">Déplacer la cellule vers le bas</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">Déplacer la cellule vers le haut</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Supprimer</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Ajouter une cellule</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Cellule de code</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Cellule de texte</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">Paramètres</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">Sélectionnez la cellule active et réessayez</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">Exécuter la cellule</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">Annuler l'exécution</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">Erreur de la dernière exécution. Cliquer pour réexécuter</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">Développer le contenu de la cellule de code</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">Réduire le contenu de la cellule de code</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">Gras</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">Italique</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">Souligné</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">Recommandation</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Code</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">Lien</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">Liste</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">Liste triée</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Image</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Bouton bascule d'aperçu Markdown - désactivé</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">Titre</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">Titre 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">Titre 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">Titre 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">Paragraphe</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">Insérer un lien</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">Insérer une image</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">Vue de texte enrichi</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Mode fractionné</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Vue Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Aucun renderer {0} pour la sortie. Types MIME : {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">sécurisé </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">Aucun composant pour le sélecteur {0}</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">Erreur de rendu du composant : {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">Cliquer sur</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ Code</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">ou</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ Texte</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">pour ajouter une cellule de code ou de texte</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">Ajouter une cellule de code</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">Ajouter une cellule de texte</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">StdIn :</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Double-cliquer pour modifier&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Ajouter du contenu ici...&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Rechercher</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Rechercher</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Correspondance précédente</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Correspondance suivante</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fermer</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">Votre recherche a retourné un grand nombre de résultats, seuls les 999 premières correspondances sont mises en surbrillance.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} sur {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Aucun résultat</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">Ajouter du code</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">Ajouter du texte</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">Créer un fichier</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">Impossible d'afficher le contenu : {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Ajouter une cellule</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Cellule de code</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Cellule de texte</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">Tout exécuter</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">Cellule</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Code</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Texte</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">Exécuter les cellules</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; Précédent</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">Suivant &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">la cellule avec l'URI {0} est introuvable dans ce modèle</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">L'exécution des cellules a échoué. Pour plus d'informations, consultez l'erreur dans la sortie de la cellule actuellement sélectionnée.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nouveau notebook</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nouveau notebook</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">Définir l'espace de travail et l'ouvrir</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">Noyau SQL : arrêtez l'exécution du notebook quand l'erreur se produit dans une cellule.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(Préversion) Affichez tous les noyaux du fournisseur de notebook actuel.</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">Autorisez les notebooks à exécuter des commandes Azure Data Studio.</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">Activer le double-clic pour modifier les cellules de texte dans les notebooks</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">Le texte est affiché sous forme de texte enrichi (également appelé WYSIWYG).</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">Markdown s’affiche à gauche, avec un aperçu du texte rendu à droite.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">Le texte s’affiche sous forme de Markdown.</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">Mode Édition par défaut utilisé pour les cellules de texte</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(Préversion) Enregistrez le nom de connexion dans les métadonnées du notebook.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">Contrôle la hauteur de ligne utilisée dans l'aperçu Markdown du notebook. Ce nombre est relatif à la taille de police.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(Aperçu) Afficher le bloc-notes rendu dans l’éditeur de différences.</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">Nombre maximal de modifications stockées dans l’historique des annulations pour l’éditeur de texte enrichi de bloc-notes.</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">Rechercher dans les notebooks</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">Configurez des modèles glob pour exclure des fichiers et des dossiers dans les recherches en texte intégral et le mode Quick Open. Hérite tous les modèles glob du paramètre '#files.exclude#'. Découvrez plus d'informations sur les modèles glob [ici](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">Modèle Glob auquel les chemins de fichiers doivent correspondre. Affectez la valeur true ou false pour activer ou désactiver le modèle.</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">Vérification supplémentaire des frères d'un fichier correspondant. Utilisez $(basename) comme variable pour le nom de fichier correspondant.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">Ce paramètre est déprécié et remplacé par "search.usePCRE2".</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">Déprécié. Utilisez "search.usePCRE2" pour prendre en charge la fonctionnalité regex avancée.</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">Si activé, le processus searchService est maintenu actif au lieu d'être arrêté au bout d'une heure d'inactivité. Ce paramètre conserve le cache de recherche de fichier en mémoire.</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Contrôle s'il faut utiliser les fichiers `.gitignore` et `.ignore` par défaut pendant la recherche de fichiers.</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Détermine s'il faut utiliser les fichiers généraux '.gitignore' et '.ignore' pendant la recherche de fichiers.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">Indique s’il faut inclure les résultats d’une recherche de symbole global dans les résultats de fichier pour Quick Open.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">Indique si vous souhaitez inclure les résultats de fichiers récemment ouverts dans les résultats de fichiers pour Quick Open.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">Les entrées d'historique sont triées par pertinence en fonction de la valeur de filtre utilisée. Les entrées les plus pertinentes apparaissent en premier.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">Les entrées d'historique sont triées par date. Les dernières entrées ouvertes sont affichées en premier.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">Contrôle l'ordre de tri de l'historique de l'éditeur en mode Quick Open pendant le filtrage.</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">Contrôle s'il faut suivre les symlinks pendant la recherche.</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">Faire une recherche non sensible à la casse si le modèle est tout en minuscules, dans le cas contraire, faire une rechercher sensible à la casse.</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">Contrôle si la vue de recherche doit lire ou modifier le presse-papiers partagé sur macOS.</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">Contrôle si la recherche s’affiche comme une vue dans la barre latérale ou comme un panneau dans la zone de panneaux pour plus d'espace horizontal.</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">Ce paramètre est déprécié. Utilisez le menu contextuel de la vue de recherche à la place.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">Les fichiers avec moins de 10 résultats sont développés. Les autres sont réduits.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">Contrôle si les résultats de recherche seront réduits ou développés.</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">Détermine s'il faut ouvrir l'aperçu du remplacement quand vous sélectionnez ou remplacez une correspondance.</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">Détermine s'il faut afficher les numéros de ligne dans les résultats de recherche.</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">Détermine s'il faut utiliser le moteur regex PCRE2 dans la recherche de texte. Cette option permet d'utiliser des fonctionnalités regex avancées comme lookahead et les références arrière. Toutefois, les fonctionnalités PCRE2 ne sont pas toutes prises en charge, seulement celles qui sont aussi prises en charge par JavaScript.</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">Déprécié. PCRE2 est utilisé automatiquement lors de l'utilisation de fonctionnalités regex qui ne sont prises en charge que par PCRE2.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">Positionnez la barre d'action à droite quand la vue de recherche est étroite et immédiatement après le contenu quand la vue de recherche est large.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">Positionnez toujours la barre d'action à droite.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">Contrôle le positionnement de la barre d'action sur des lignes dans la vue de recherche.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">Recherchez dans tous les fichiers à mesure que vous tapez.</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">Activez l'essaimage de la recherche à partir du mot le plus proche du curseur quand l'éditeur actif n'a aucune sélection.</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">Mettez à jour la requête de recherche d'espace de travail en fonction du texte sélectionné de l'éditeur quand vous placez le focus sur la vue de recherche. Cela se produit soit au moment du clic de souris, soit au déclenchement de la commande 'workbench.views.search.focus'.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">Quand '#search.searchOnType' est activé, contrôle le délai d'attente avant expiration en millisecondes entre l'entrée d'un caractère et le démarrage de la recherche. N'a aucun effet quand 'search.searchOnType' est désactivé.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">Double-cliquez pour sélectionner le mot sous le curseur.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">Double-cliquez sur le résultat pour l'ouvrir dans le groupe d'éditeurs actif.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">Double-cliquez pour ouvrir le résultat dans le groupe d'éditeurs ouvert ou dans un nouveau groupe d'éditeurs le cas échéant.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">Configurez ce qui se passe après un double clic sur un résultat dans un éditeur de recherche.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">Les résultats sont triés par dossier et noms de fichier, dans l'ordre alphabétique.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">Les résultats sont triés par noms de fichier en ignorant l'ordre des dossiers, dans l'ordre alphabétique.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">Les résultats sont triés par extensions de fichier dans l'ordre alphabétique.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">Les résultats sont triés par date de dernière modification de fichier, dans l'ordre décroissant.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">Les résultats sont triés par nombre dans chaque fichier, dans l'ordre décroissant.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">Les résultats sont triés par nombre dans chaque fichier, dans l'ordre croissant.</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">Contrôle l'ordre de tri des résultats de recherche.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">Chargement des noyaux...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">Changement du noyau...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">Attacher à </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">Noyau </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">Chargement des contextes...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Changer la connexion</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">Sélectionner une connexion</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">Pas de noyau</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Ce bloc-notes ne peut pas être exécuté avec des paramètres, car le noyau n’est pas pris en charge. Utilisez les noyaux et le format pris en charge. [En savoir plus] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Ce bloc-notes ne peut pas être exécuté avec des paramètres tant qu'une cellule de paramètre n'est pas ajoutée. [En savoir plus](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Ce bloc-notes ne peut pas s’exécuter avec des paramètres tant que des paramètres n’ont pas été ajoutés à la cellule de paramètres. [En savoir plus] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">Effacer les résultats</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">Approuvé</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">Non approuvé</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">Réduire les cellules</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">Développer les cellules</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">Exécuter avec des paramètres</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">Aucun(e)</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nouveau notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Rechercher la chaîne suivante</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Rechercher la chaîne précédente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">Résultats de la recherche</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">Chemin de recherche introuvable : {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">Vous n'avez ouvert aucun dossier contenant des notebooks/books. </target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">Ouvrir les notebooks</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">Le jeu de résultats contient uniquement un sous-ensemble de toutes les correspondances. Soyez plus précis dans votre recherche de façon à limiter les résultats retournés.</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">Recherche en cours... - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">Résultats introuvables pour '{0}' excluant '{1}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">Résultats introuvables dans '{0}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">Résultats introuvables avec l'exclusion de '{0}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">Aucun résultat. Vérifiez les exclusions configurées dans vos paramètres et examinez vos fichiers gitignore -</target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">Chercher à nouveau</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">Rechercher à nouveau dans tous les fichiers</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">Ouvrir les paramètres</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">La recherche a retourné {0} résultats dans {1} fichiers</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">Activer/désactiver les options Réduire et Développer</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">Annuler la recherche</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">Tout développer</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Tout réduire</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">Effacer les résultats de la recherche</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">Rechercher : tapez le terme de recherche, puis appuyez sur Entrée pour lancer la recherche, ou sur Échap pour l'annuler</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Recherche</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">la cellule avec l'URI {0} est introuvable dans ce modèle</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">L'exécution des cellules a échoué. Pour plus d'informations, consultez l'erreur dans la sortie de la cellule actuellement sélectionnée.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">Exécutez cette cellule pour afficher les sorties.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">Cette vue est vide. Ajoutez une cellule à cette vue en cliquant sur le bouton Insérer des cellules.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">La copie a échoué avec l'erreur {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">Afficher le graphique</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">Afficher la table</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Aucun renderer {0} pour la sortie. Elle a les types MIME suivants : {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(sécurisé) </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">Erreur d'affichage du graphe Plotly : {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">Aucune connexion.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">Ajouter une connexion</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">Palette de couleurs du groupe de serveurs utilisée dans la viewlet Explorateur d'objets.</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">Développez automatiquement les groupes de serveurs dans la viewlet Explorateur d'objets.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(Préversion) Utilisez la nouvelle arborescence de serveur asynchrone pour la vue des serveurs et la boîte de dialogue de connexion avec prise en charge des nouvelles fonctionnalités, comme le filtrage dynamique de nœuds.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">Données</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Connexion</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Éditeur de requêtes</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Graphiques intégrés</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">Spécifie des modèles de vue</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">Spécifie les modèles de session</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Filtres Profiler</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Connecter</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Déconnecter</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Démarrer</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">Nouvelle session</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">Suspendre</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">Reprendre</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Arrêter</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">Effacer les données</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">Voulez-vous vraiment effacer les données ?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">Défilement automatique : activé</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">Défilement automatique : désactivé</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">Afficher/masquer le panneau réduit</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">Modifier les colonnes</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Rechercher la chaîne suivante</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Rechercher la chaîne précédente</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Lancer Profiler</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">Filtrer...</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">Effacer le filtre</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">Voulez-vous vraiment effacer les filtres ?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">Sélectionner une vue</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">Sélectionner une session</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">Sélectionner une session :</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">Sélectionner une vue :</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Texte</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">Étiquette</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valeur</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Détails</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Rechercher</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Rechercher</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Correspondance précédente</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Correspondance suivante</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fermer</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">Votre recherche a retourné un grand nombre de résultats, seuls les 999 premières correspondances sont mises en surbrillance.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} sur {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Aucun résultat</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">Editeur Profiler pour le texte d'événement. En lecture seule</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">Événements (filtrés) : {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">Événements : {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">Nombre d'événements</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Enregistrer au format CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Enregistrer au format JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Enregistrer au format Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Enregistrer au format XML</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">L'encodage des résultats n'est pas enregistré quand vous les exportez au format JSON, n'oubliez pas d'enregistrer le fichier que vous créez avec l'encodage souhaité.</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">L'enregistrement dans un fichier n'est pas pris en charge par la source de données de stockage</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copier</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copier avec les en-têtes</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Tout sélectionner</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">Maximiser</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurer</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Graphique</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">Visualiseur</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">Choisir un langage SQL</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">Changer le fournisseur de langage SQL</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">Saveur de langage SQL</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">Changer le fournisseur de moteur SQL</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">Une connexion qui utilise le moteur {0} existe déjà. Pour changer, déconnectez-vous ou changez de connexion</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">Aucun éditeur de texte actif actuellement</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">Sélectionner un fournisseur de langage</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">Plan d'exécution de requêtes XML</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">Grille de résultats</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">Le nombre maximal de lignes pour le filtrage/tri a été dépassé. Pour le mettre à jour, vous pouvez accéder aux paramètres utilisateur et modifier le paramètre : 'queryeditor.results. inMemoryDataProcessingThreshold'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">Se concentrer sur la requête actuelle</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Exécuter la requête</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">Exécuter la requête actuelle</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">Copier la requête avec les résultats</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">La requête et les résultats ont été copiés.</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">Exécuter la requête actuelle avec le plan réel</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">Annuler la requête</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">Actualiser le cache IntelliSense</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">Activer/désactiver les résultats de requête</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">Basculer le focus entre la requête et les résultats</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">Le paramètre de l'éditeur est nécessaire pour exécuter un raccourci</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">Analyser la requête</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">Commandes exécutées</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">La commande a échoué : </target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">Connectez-vous à un serveur</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">Panneau des messages</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copier</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">Tout copier</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">Résultats de la requête</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nouvelle requête</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Éditeur de requêtes</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">Quand la valeur est true, les en-têtes de colonne sont inclus dans l'enregistrement des résultats au format CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">Délimiteur personnalisé à utiliser entre les valeurs pendant l'enregistrement au format CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">Caractère(s) utilisé(s) pour séparer les lignes pendant l'enregistrement des résultats au format CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">Caractère utilisé pour englober les champs de texte pendant l'enregistrement des résultats au format CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">Encodage de fichier utilisé pendant l'enregistrement des résultats au format CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">Quand la valeur est true, la sortie XML est mise en forme pendant l'enregistrement des résultats au format XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">Encodage de fichier utilisé pendant l'enregistrement des résultats au format XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">Activer le streaming des résultats, contient quelques problèmes visuels mineurs</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">Options de configuration pour copier les résultats de la Vue Résultats</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">Options de configuration pour copier les résultats multilignes de la vue Résultats</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(Expérimental) Utilisez une table optimisée dans la sortie des résultats. Certaines fonctionnalités sont peut-être manquantes et en préparation.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">Contrôle le nombre maximal de lignes autorisées pour effectuer le filtrage et le tri en mémoire. Si ce nombre est dépassé, le tri et le filtrage sont désactivés. Avertissement : l’augmentation de cette valeur peut avoir un impact sur les performances.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">Indique si le fichier doit être ouvert dans Azure Data Studio une fois le résultat enregistré.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">Spécifie si la durée d'exécution doit être indiquée pour chaque lot</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">Messages de retour automatique à la ligne</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">Type de graphique par défaut à utiliser à l'ouverture de la visionneuse graphique à partir des résultats d'une requête</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">La coloration des onglets est désactivée</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">La bordure supérieure de chaque onglet de l'éditeur est colorée pour correspondre au groupe de serveurs concerné</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">La couleur d'arrière-plan de chaque onglet de l'éditeur correspond au groupe de serveurs concerné</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">Contrôle comment colorer les onglets en fonction du groupe de serveurs de leur connexion active</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">Contrôle s'il faut montrer les informations de connexion d'un onglet dans le titre.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">Inviter à enregistrer les fichiers SQL générés</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">Définissez la combinaison de touches workbench.action.query.shortcut{0} pour exécuter le texte du raccourci en tant qu’appel de procédure ou exécution de la requête. Tout texte sélectionné dans l’éditeur de requête est passé en tant que paramètre à la fin de votre requête, ou vous pouvez le référencer avec {arg}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nouvelle requête</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Exécuter</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">Expliquer</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">Réel</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Déconnecter</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Changer la connexion</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Connecter</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">Activer SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">Désactiver SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Sélectionner une base de données</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Le changement de base de données a échoué</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">Le changement de la base de données {0} a échoué</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">Exporter au format Notebook</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">Résultats</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">Messages</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">Temps écoulé</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">Nombre de lignes</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} lignes</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">Exécution de la requête...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">État d'exécution</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">Récapitulatif de la sélection</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">Moyenne : {0}, nombre : {1}, somme : {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">Grille de résultats et messages</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">Contrôle la famille de polices.</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">Contrôle l'épaisseur de police.</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">Contrôle la taille de police en pixels.</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">Contrôle l'espacement des lettres en pixels.</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">Contrôle la hauteur de ligne en pixels</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">Contrôle l'espacement des cellules en pixels</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">Dimensionnez automatiquement la largeur de colonne en fonction des résultats initiaux. Problèmes de performance possibles avec les grands nombres de colonnes ou les grandes cellules</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">Largeur maximale en pixels des colonnes dimensionnées automatiquement</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">Activer/désactiver l'historique des requêtes</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Supprimer</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Effacer tout l'historique</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">Ouvrir la requête</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Exécuter la requête</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">Activer/désactiver la capture de l'historique des requêtes</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Suspendre la capture de l'historique des requêtes</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Démarrer la capture de l'historique des requêtes</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">succès</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">échec</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">Aucune requête à afficher.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">Historique des requêtes</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">QueryHistory</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">Indique si la capture de l'historique des requêtes est activée. Si la valeur est false, les requêtes exécutées ne sont pas capturées.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Effacer tout l'historique</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Suspendre la capture de l'historique des requêtes</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Démarrer la capture de l'historique des requêtes</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Voir</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Historique des requêtes</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">Historique des requêtes</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">Plan de requête</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">Opération</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">Objet</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">Coût estimé</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">Coût estimé de la sous-arborescence</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">Lignes réelles</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">Lignes estimées</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">Exécutions réelles</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">Coût estimé du processeur</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">Coût estimé des E/S</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">Parallèle</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">Reliaisons réelles</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">Reliaisons estimées</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">Rembobinages réels</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">Rembobinages estimés</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">Partitionné</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">Principales opérations</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visionneuse de ressources</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualiser</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">Erreur d'ouverture du lien : {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">Erreur durant l'exécution de la commande « {0} » : {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">Arborescence de la visionneuse de ressources</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">Identificateur de la ressource.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Nom de la vue, contrôlable de visu. À afficher</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">Chemin de l'icône de ressource.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">Fournit une ressource dans la vue des ressources</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">la propriété '{0}' est obligatoire et doit être de type 'string'</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">La propriété '{0}' peut être omise ou doit être de type 'string'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurer</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">Vous devez activer les fonctionnalités en préversion pour utiliser la restauration</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">La commande de Restaurer n'est pas prise en charge en dehors d’un contexte du serveur. Sélectionnez un serveur ou une base de données et réessayez.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">La commande de restauration n'est pas prise en charge pour les bases de données Azure SQL.</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script de création</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script de suppression</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Sélectionnez les 1000 premiers</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script d'exécution</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script de modification</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Modifier les données</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Sélectionnez les 1000 premiers</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Prendre 10</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script de création</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script d'exécution</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script de modification</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script de suppression</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualiser</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">Erreur pendant l'actualisation du nœud « {0} » : {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} tâches en cours</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Voir</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">Tâches</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Tâches</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">Activer/désactiver des tâches</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">succès</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">échec</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">en cours</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">non démarré</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">annulé</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">annulation</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">Aucun historique des tâches à afficher.</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">Historique des tâches</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">Erreur de tâche</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">Échec de l’annulation de la tâche.</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">Aucun fournisseur de données inscrit pouvant fournir des données de vue.</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualiser</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Tout réduire</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">Erreur pendant l'exécution de la commande {1} : {0}. Probablement due à l'extension qui contribue à {1}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fermer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">Les fonctionnalités en préversion améliorent votre expérience dans Azure Data Studio en vous donnant un accès total aux nouvelles fonctionnalités et améliorations. Vous pouvez en savoir plus sur les fonctionnalités en préversion [ici] ({0}). Voulez-vous activer les fonctionnalités en préversion ?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">Oui (recommandé)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">Non, ne plus afficher</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">Cette page de fonctionnalité est en préversion. Les fonctionnalités en préversion sont des nouvelles fonctionnalités en passe d'être définitivement intégrées dans le produit. Elles sont stables, mais ont besoin d'améliorations d'accessibilité supplémentaires. Nous vous invitons à nous faire part de vos commentaires en avant-première pendant leur développement.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">Aperçu</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">Créer une connexion</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">Connectez-vous à une instance de base de données en utilisant la boîte de dialogue de connexion.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">Exécuter une requête</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">Interagir avec des données par le biais d'un éditeur de requête.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">Créer un notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">Générez un nouveau notebook à l'aide d'un éditeur de notebook natif.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Déployer un serveur</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">Créez une instance de service de données relationnelles sur la plateforme de votre choix.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">Ressources</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">Historique</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nom</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">Localisation</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">Afficher plus</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Afficher la page d'accueil au démarrage</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">Liens utiles</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">Démarrer</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Découvrez les fonctionnalités offertes par Azure Data Studio et comment en tirer le meilleur parti.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentation</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">Visitez le centre de documentation pour obtenir des guides de démarrage rapide, des guides pratiques et des références pour PowerShell, les API, etc.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">Vidéos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Vue d'ensemble d'Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Présentation des notebooks Azure Data Studio | Données exposées</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensions</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">Tout afficher</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">En savoir plus </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Connexions</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">Connectez, interrogez et gérez vos connexions SQL Server, Azure, etc.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Suivant</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">Démarrez en créant votre propre notebook ou collection de notebooks au même endroit.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensions</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Étendez les fonctionnalités d'Azure Data Studio en installant des extensions développées par nous/Microsoft ainsi que par la communauté (vous !).</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Paramètres</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">Personnalisez Azure Data Studio en fonction de vos préférences. Vous pouvez configurer des paramètres comme l'enregistrement automatique et la taille des onglets, personnaliser vos raccourcis clavier et adopter le thème de couleur de votre choix.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">Page d'accueil</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">Découvrez les fonctionnalités principales, les fichiers récemment ouverts et les extensions recommandées dans la page d'accueil. Pour plus d'informations sur le démarrage avec Azure Data Studio, consultez nos vidéos et notre documentation.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">Terminer</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">Visite de bienvenue de l'utilisateur</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">Masquer la visite de bienvenue</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">En savoir plus</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Aide</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Bienvenue</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Pack d'administration SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Pack d'administration SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">Le pack d'administration de SQL Server est une collection d'extensions d'administration de base de données courantes qui vous permet de gérer SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server Agent</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">Importation SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">Package DAC SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Écrire et exécuter des scripts PowerShell à l'aide de l'éditeur de requêtes complet d'Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">Virtualisation des données</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">Virtualiser les données avec SQL Server 2019 et créer des tables externes à l'aide d'Assistants interactifs</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">Connecter, interroger et gérer les bases de données Postgres avec Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">Le support pour {0} est déjà installé.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">La fenêtre se recharge après l'installation d'un support supplémentaire pour {0}.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">Installation d'un support supplémentaire pour {0}...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">Le support pour {0} avec l'ID {1} est introuvable.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nouvelle connexion</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nouvelle requête</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Nouveau notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Déployer un serveur</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Bienvenue</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">Nouveau</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">Ouvrir…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">Ouvrir le fichier...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">Ouvrir le dossier...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">Démarrer la visite guidée</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">Fermer la barre de présentation rapide</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">Voulez-vous voir une présentation rapide d'Azure Data Studio ?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">Bienvenue !</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">Ouvrir le dossier {0} avec le chemin {1}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Installer</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">Installer le mappage de touches {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">Installer un support supplémentaire pour {0} </target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">Installé</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">Le mappage de touches '{0}' est déjà installé</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">Le support {0} est déjà installé.</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Détails</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">Couleur d'arrière-plan de la page d'accueil.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Démarrer</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nouvelle connexion</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nouvelle requête</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Nouveau notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Ouvrir un fichier</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Ouvrir un fichier</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">Déployer</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">Nouveau déploiement...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Récent</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">Plus...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">Aucun dossier récent</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Aide</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">Démarrer</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentation</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">Signaler un problème ou une demande de fonctionnalité</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">Dépôt GitHub</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">Notes de publication</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Afficher la page d'accueil au démarrage</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">Personnaliser</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensions</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">Téléchargez les extensions dont vous avez besoin, notamment le pack d'administration SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">Raccourcis clavier</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">Rechercher vos commandes préférées et les personnaliser</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">Thème de couleur</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">Personnalisez l'apparence de l'éditeur et de votre code</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">Apprendre</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">Rechercher et exécuter toutes les commandes</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">La palette de commandes ({0}) permet d'accéder rapidement aux commandes pour en rechercher une</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">Découvrir les nouveautés de la dernière version</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">Nouveaux billets de blog mensuels mettant en avant nos nouvelles fonctionnalités</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Suivez-nous sur Twitter</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">Informez-vous de la façon dont la communauté utilise Azure Data Studio et discutez directement avec les ingénieurs.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">Comptes</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">Comptes liés</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fermer</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">Aucun compte lié. Ajoutez un compte.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">Ajouter un compte</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">Aucun cloud n'est activé. Accéder à Paramètres -&gt; Rechercher dans la configuration de compte Azure -&gt; Activer au moins un cloud</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">Vous n'avez sélectionné aucun fournisseur d'authentification. Réessayez.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Erreur d'ajout de compte</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">Vous devez actualiser les informations d'identification de ce compte.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fermer</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">Ajout du compte...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">L'actualisation du compte a été annulée par l'utilisateur</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Compte Azure</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Locataire Azure</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">Copier et ouvrir</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">Code utilisateur</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">Site web</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">Impossible de démarrer une authentification OAuth automatique. Il y en a déjà une en cours.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">La connexion est nécessaire pour interagir avec adminservice</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Aucun gestionnaire inscrit</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">La connexion est nécessaire pour interagir avec le service d'évaluation</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Aucun gestionnaire inscrit</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">Propriétés avancées</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Abandonner</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">Description du serveur (facultatif)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">Effacer la liste</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">Liste des dernières connexions effacée</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">Voulez-vous vraiment supprimer toutes les connexions de la liste ?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Supprimer</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">Obtenir la chaîne de connexion actuelle</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">Chaîne de connexion non disponible</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">Aucune connexion active disponible</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Parcourir</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">Tapez ici pour filtrer la liste</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">Filtrer les connexions</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">Application du filtre</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">Suppression du filtre</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">Filtre appliqué</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">Filtre supprimé</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Connexions enregistrées</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Connexions enregistrées</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">Arborescence du navigateur de connexion</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">Erreur de connexion</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">La connexion a échoué en raison d'une erreur Kerberos.</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">L'aide pour configurer Kerberos est disponible sur {0}</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">Si vous vous êtes déjà connecté, vous devez peut-être réexécuter kinit.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Connexion</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">Connexion</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">Type de connexion</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Récent</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">Détails de la connexion</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Connecter</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Connexions récentes</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">Aucune connexion récente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">L'obtention d'un jeton de compte Azure pour la connexion a échoué</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">Connexion non acceptée</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">Voulez-vous vraiment annuler cette connexion ?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">Ajouter un compte...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Par défaut&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Chargement...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">Groupe de serveurs</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Par défaut&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">Ajouter un nouveau groupe...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;Ne pas enregistrer&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} est obligatoire.</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0} est tronqué.</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">Se souvenir du mot de passe</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">Compte</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">Actualiser les informations d'identification du compte</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Locataire Azure AD</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">Nom (facultatif)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">Avancé...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">Vous devez sélectionner un compte</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">Connecté à</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">Déconnecté</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">Connexions non enregistrées</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">Ouvrir les extensions de tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">Aucune extension de tableau de bord n'est actuellement installée. Accédez au gestionnaire d'extensions pour explorer les extensions recommandées.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">Étape {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Terminé</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">L'initialisation de la session de modification des données a échoué : </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fermer</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Action</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">Copier les détails</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Erreur</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Avertissement</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">Informations</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">Ignorer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">Chemin sélectionné</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">Fichiers de type</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Ignorer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">Sélectionnez un fichier</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">Arborescence de l'explorateur de fichiers</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">Une erreur s'est produite pendant le chargement de l'explorateur de fichiers.</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">Erreur de l'explorateur de fichiers</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">Tous les fichiers</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">Copier la cellule</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">Aucun profil de connexion n'a été passé au menu volant des insights</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">Erreur d'insights</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">Une erreur s'est produite à la lecture du fichier de requête : </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">Une erreur s'est produite à l'analyse de la configuration d'insight. Tableau/chaîne de requête ou fichier de requête introuvable</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">Élément</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valeur</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">Détails de l'insight</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">Propriété</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valeur</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">Insights</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">Éléments</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">Détails d'élément</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">Fichier de requête introuvable dans les chemins suivants :
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">Échec</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">Réussite</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">Réessayer</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">Annulé</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">En cours</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">État inconnu</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">Exécution</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">En attente de thread</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">Entre les tentatives</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">Inactif</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">Suspendu</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[Obsolète]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">Non planifié</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">Ne jamais exécuter</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">Une connexion est nécessaire pour interagir avec JobManagementService</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Aucun gestionnaire inscrit</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Erreur : {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">Une erreur s'est produite au démarrage d'une session de notebook</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">Le serveur n'a pas démarré pour une raison inconnue</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">Noyau {0} introuvable. Le noyau par défaut est utilisé à la place.</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="fr">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Erreur : {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="fr">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="fr">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">Le changement des types d'éditeur pour les fichiers non enregistrés n'est pas pris en charge</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated"># Paramètres injectés
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">Sélectionnez une connexion afin d'exécuter les cellules pour ce noyau</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">La suppression de la cellule a échoué.</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">Le changement de noyau a échoué. Le noyau {0} est utilisé. Erreur : {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">Le changement de noyau a échoué en raison de l'erreur : {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">Le changement de contexte a échoué : {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">Impossible de démarrer la session : {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">Une erreur de session du client s'est produite pendant la fermeture du notebook : {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">Gestionnaire de notebook introuvable pour le fournisseur {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">Aucun URI passé pendant la création d'un gestionnaire de notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">Le fournisseur de notebooks n'existe pas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">Une vue portant le nom {0} existe déjà dans ce bloc-notes.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">Erreur de noyau SQL</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">Une connexion doit être choisie pour exécuter des cellules de notebook</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">Affichage des {0} premières lignes.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">Texte riche</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Mode fractionné</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">nbformat v{0}.{1} non reconnu</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">Ce fichier n'a pas un format de notebook valide</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">Type de cellule {0} inconnu</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Type de sortie {0} non reconnu</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">Les données de {0} doivent être une chaîne ou un tableau de chaînes</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Type de sortie {0} non reconnu</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">Identificateur du fournisseur de notebooks.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">Extensions de fichier à inscrire dans ce fournisseur de notebooks</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">Noyaux devant être standard avec ce fournisseur de notebooks</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">Ajoute des fournisseurs de notebooks.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">Nom de la cellule magique, par exemple, '%%sql'.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">Langage de cellule à utiliser si cette commande magique est incluse dans la cellule</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">Cible d'exécution facultative que cette commande magique indique, par exemple, Spark vs. SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">Ensemble facultatif de noyaux, valable, par exemple, pour python3, pyspark, sql</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">Ajoute un langage de notebook.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Chargement...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Actualiser</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">Modifier la connexion</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Déconnecter</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">Nouvelle connexion</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">Nouveau groupe de serveurs</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">Modifier le groupe de serveurs</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">Afficher les connexions actives</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">Afficher toutes les connexions</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">Supprimer la connexion</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">Supprimer le groupe</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">La création d'une session de l'Explorateur d'objets a échoué</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">Plusieurs erreurs :</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">Développement impossible, car le fournisseur de connexion nécessaire '{0}' est introuvable</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">Annulé par l'utilisateur</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">Boîte de dialogue de pare-feu annulée</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Chargement...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Connexions récentes</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Serveurs</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Serveurs</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">Trier par événement</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">Trier par colonne</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">Tout effacer</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Appliquer</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">Filtres</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">Supprimer cette clause</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">Enregistrer le filtre</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">Charger le filtre</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">Ajouter une clause</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">Champ</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">Opérateur</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valeur</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">Est Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">N'est pas Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">Contient</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">Ne contient pas</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">Commence par</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">Ne commence pas par</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">La validation de la ligne a échoué : </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">Exécution de la requête démarrée à </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">L'exécution de la requête "{0}" a démarré</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">Ligne {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">L'annulation de la requête a échoué : {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">La mise à jour de la cellule a échoué : </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">L'exécution a échoué en raison d'une erreur inattendue : {0}	{1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">Durée d'exécution totale : {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">L'exécution de la requête a démarré à la ligne {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">Démarrage de l'exécution du lot {0}</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">Durée d'exécution en lot : {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">La copie a échoué avec l'erreur {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">L'enregistrement des résultats a échoué. </target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">Choisir le fichier de résultats</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (valeurs séparées par des virgules)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Classeur Excel</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">Texte brut</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">Enregistrement du fichier...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">Résultats enregistrés dans {0}</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Ouvrir un fichier</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">De</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">À</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">Créer une règle de pare-feu</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">L'adresse IP de votre client n'a pas accès au serveur. Connectez-vous à un compte Azure et créez une règle de pare-feu pour autoriser l'accès.</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">En savoir plus sur les paramètres de pare-feu</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">Règle de pare-feu</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">Ajouter l'adresse IP de mon client </target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">Ajouter la plage d'adresses IP de mon sous-réseau</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Erreur d'ajout de compte</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">Erreur de règle de pare-feu</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">Chemin du fichier de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">Base de données cible</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurer</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Restaurer la base de données</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de données</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">Fichier de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Restaurer la base de données</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Source</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">Restaurer à partir de</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">Le chemin du fichier de sauvegarde est obligatoire.</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">Entrez un ou plusieurs chemins de fichier séparés par des virgules</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Base de données</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">Destination</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">Restaurer vers</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">Plan de restauration</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">Jeux de sauvegarde à restaurer</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">Restaurer les fichiers de base de données en tant que</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">Restaurer les détails du fichier de base de données</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">Nom de fichier logique</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">Type de fichier</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">Nom de fichier d'origine</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">Restaurer comme</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">Options de restauration</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">Sauvegarde de la fin du journal</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">Connexions du serveur</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">Général</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Fichiers</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Options</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">Fichiers de sauvegarde</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">Tous les fichiers</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">Groupes de serveurs</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annuler</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">Nom de groupe de serveurs</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">Le nom du groupe est obligatoire.</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">Description de groupe</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">Couleur de groupe</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">Ajouter un groupe de serveurs</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">Modifier le groupe de serveurs</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">1 ou plusieurs tâches sont en cours. Voulez-vous vraiment quitter ?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Oui</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Non</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="fr">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">Démarrer</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">Afficher la prise en main</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Pri&amp;&amp;se en main</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/it/admin-tool-ext-win.it.xlf
+++ b/resources/xlf/it/admin-tool-ext-win.it.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/it/agent.it.xlf
+++ b/resources/xlf/it/agent.it.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">Nuova pianificazione</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Annulla</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nome della pianificazione</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Pianificazioni</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">Crea proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">Modifica proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Generale</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">Nome del proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">Nome della credenziale</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrizione</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">Sottosistema</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">Sistema operativo (CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">Snapshot repliche</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">Lettura log delle transazioni di replica</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">Database di distribuzione repliche</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">Merge repliche</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">Lettore coda di repliche</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">Query di SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">Comando di SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">Pacchetto SQL Server Integration Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">Attivo nei sottosistemi seguenti</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">Pianificazioni processi</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">Pianificazioni disponibili:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrizione</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">Crea operatore</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">Modifica operatore</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Generale</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notifiche</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Abilitato</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">Indirizzo di posta elettronica</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">Indirizzo cercapersone</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">Lunedì</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">Martedì</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">Mercoledì</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">Giovedì</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">Venerdì</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">Sabato</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">Domenica</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">Inizio della giornata lavorativa</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">Fine della giornata lavorativa</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">Pianificazione cercapersone per operatore in servizio</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">Elenco avvisi</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">Nome dell'avviso</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">Posta elettronica</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">Cercapersone</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">Generale</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">Pianificazioni processi</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Passaggi</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Pianificazioni</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Avvisi</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">Pianificazioni disponibili:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notifiche</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">Il nome del processo non può essere vuoto.</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Proprietario</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">ID</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Categoria</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">Descrizione</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Abilitato</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">Elenco dei passaggi del processo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">Passaggio</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">In caso di riuscita</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">In caso di errore</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">Nuovo passaggio</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">Modifica passaggio</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">Elimina passaggio</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">Sposta passaggio su</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">Sposta passaggio giù</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">Passaggio iniziale</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">Azioni da eseguire quando il processo viene completato</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">Messaggio di posta elettronica</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">Pagina</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">Scrivi nel log eventi dell'applicazione di Windows</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">Elimina automaticamente il processo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">Elenco pianificazioni</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">Seleziona pianificazione</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nome della pianificazione</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">Elenco avvisi</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">Nuovo avviso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">Nome dell'avviso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Abilitato</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">Nuovo processo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">Modifica processo</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">Messaggio di notifica aggiuntivo da inviare</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">Ritardo tra le risposte</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">Ritardo in minuti</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">Crea operatore</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">Modifica operatore</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Generale</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notifiche</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Abilitato</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">Indirizzo di posta elettronica</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">Indirizzo cercapersone</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">Lunedì</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">Martedì</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">Mercoledì</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">Giovedì</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">Venerdì</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">Sabato</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">Domenica</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">Inizio della giornata lavorativa</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">Fine della giornata lavorativa</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">Pianificazione cercapersone per operatore in servizio</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">Elenco avvisi</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">Nome dell'avviso</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">Posta elettronica</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">Cercapersone</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">L'aggiornamento del proxy non è riuscito: '{0}'</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Generale</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">Il proxy '{0}' è stato aggiornato</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Passaggi</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">Il proxy '{0}' è stato creato</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">Pianificazioni</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Avvisi</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notifiche</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">Il nome del processo non può essere vuoto.</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Proprietario</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Categoria</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrizione</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Abilitato</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">Elenco dei passaggi del processo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">Passaggio</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">In caso di riuscita</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">In caso di errore</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">Nuovo passaggio</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">Modifica passaggio</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">Elimina passaggio</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">Sposta passaggio su</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">Sposta passaggio giù</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">Passaggio iniziale</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">Azioni da eseguire quando il processo viene completato</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">Messaggio di posta elettronica</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">Pagina</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">Scrivi nel log eventi dell'applicazione di Windows</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">Elimina automaticamente il processo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Elenco pianificazioni</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Seleziona pianificazione</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Rimuovi pianificazione</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">Elenco avvisi</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">Nuovo avviso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">Nome dell'avviso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Abilitato</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">Nuovo processo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">Modifica processo</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">L'aggiornamento del passaggio non è riuscito: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">È necessario specificare il nome del processo</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">È necessario specificare il nome del passaggio</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">L'aggiornamento del passaggio non è riuscito: '{0}'</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">È necessario specificare il nome del processo</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">È necessario specificare il nome del passaggio</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">Questa funzionalità è in fase di sviluppo. Per provare le ultime novità, vedere la build più recente per utenti Insider.</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">Il modello è stato aggiornato</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">Errore di aggiornamento del modello</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">Prima di pianificare il notebook, è necessario salvarlo. Salvare, quindi ripetere la pianificazione.</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">Aggiungere nuova connessione</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">Selezionare una connessione</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">Selezionare una connessione valida.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">Questa funzionalità è in fase di sviluppo. Per provare le ultime novità, vedere la build più recente per utenti Insider.</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">Crea proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">Modifica proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Generale</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">Nome del proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">Nome della credenziale</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrizione</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">Sottosistema</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">Sistema operativo (CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">Snapshot repliche</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">Lettura log delle transazioni di replica</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">Database di distribuzione repliche</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">Merge repliche</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">Lettore coda di repliche</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">Query di SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">Comando di SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">Pacchetto SQL Server Integration Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">L'aggiornamento del proxy non è riuscito: '{0}'</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">Il proxy '{0}' è stato aggiornato</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">Il proxy '{0}' è stato creato</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">Nuovo processo notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">Modifica processo notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Generale</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">Dettagli dei notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">Percorso del notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">Database di archiviazione</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">Database di esecuzione</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Seleziona database</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">Dettagli processo</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Proprietario</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Elenco pianificazioni</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Seleziona pianificazione</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Rimuovi pianificazione</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrizione</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">Selezionare un notebook da pianificare dal computer</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">Selezionare un database per archiviare tutti i metadati e i risultati del processo del notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">Selezionare un database in cui verranno eseguite le query del notebook</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">Quando il notebook completa</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">Quando il notebook ha esito negativo</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">Quando il notebook ha esito positivo</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">È necessario specificare il nome del notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">È necessario fornire il percorso del modello</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">Percorso del notebook non valido</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">Selezionare il database di archiviazione</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">Selezionare il database di esecuzione</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">Un processo con un nome simile esiste già</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">Aggiornamento del blocco appunti non riuscito '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">Creazione del notebook non riuscita '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">Il notebook '{0}' è stato aggiornato</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">Il notebook '{0}' è stato creato</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/it/azurecore.it.xlf
+++ b/resources/xlf/it/azurecore.it.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">Errore durante il recupero dei gruppi di risorse per l'account {0} ({1}) sottoscrizione {2} ({3}) tenant {4}: {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">Errore durante il recupero delle posizioni per l'account {0} ({1}) sottoscrizione {2} ({3}) tenant {4} : {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">Query non valida</target>
@@ -379,8 +383,8 @@
         <target state="translated">SQL Server - Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
-        <target state="translated">PostgreSQL Hyperscale con abilitazione di Azure Arc</target>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
+        <target state="translated">PostgreSQL Hyperscale abilitato per Azure Arc</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
         <source xml:lang="en">Unable to open link, missing required values</source>
@@ -411,7 +415,7 @@
         <target state="translated">Errore non identificato con l'autenticazione di Azure</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">Il tenant specificato con ID '{0}' non è stato trovato.</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,7 +423,7 @@
         <target state="translated">Si è verificato un errore durante l'autenticazione oppure i token sono stati eliminati dal sistema. Provare ad aggiungere di nuovo l'account ad Azure Data Studio.</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">Il recupero del token non è riuscito con un errore. Aprire gli strumenti di sviluppo per visualizzare l'errore</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">Non è stato possibile ottenere le credenziali per l'account {0}. Passare alla finestra di dialogo degli account e aggiornare l'account.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">Le richieste da questo account sono state limitate. Per riprovare, selezionare un numero inferiore di sottoscrizioni.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">Si è verificato un errore durante il caricamento delle risorse di Azure: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Cluster di Esplora dati di Azure</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/it/big-data-cluster.it.xlf
+++ b/resources/xlf/it/big-data-cluster.it.xlf
@@ -60,6 +60,126 @@
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">Se è true, ignora gli errori di verifica SSL in endpoint del cluster Big Data di SQL Server come HDFS, Spark e Controller</target>
       </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">Cluster Big Data di SQL Server</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">Il cluster Big Data di SQL Server consente di distribuire cluster scalabili di contenitori SQL Server, Spark e HDFS in esecuzione in Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versione</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">Destinazione di distribuzione</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">Nuovo cluster del servizio Azure Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">Cluster esistente del servizio Azure Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">Cluster Kubernetes esistente (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">Cluster Azure Red Hat OpenShift esistente</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">Cluster OpenShift esistente</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">Impostazioni del cluster Big Data di SQL Server</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">Nome del cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">Nome utente del controller</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">Password</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">Conferma password</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Impostazioni di Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">ID sottoscrizione</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">Usa la sottoscrizione di Azure predefinita personale</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">Nome del gruppo di risorse</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">Area</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">Nome del cluster del servizio Azure Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">Dimensioni della macchina virtuale</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">Numero di macchine virtuali</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">Nome della classe di archiviazione</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">Capacità per i dati (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">Capacità per i log (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">Accetto {0}, {1} e {2}.</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Informativa sulla privacy di Microsoft</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">Condizioni di licenza di azdata</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">Condizioni di licenza di SQL Server</target>
+      </trans-unit>
     </body>
   </file>
   <file original="extensions/big-data-cluster/dist/bigDataCluster/utils" source-language="en" datatype="plaintext" target-language="it">

--- a/resources/xlf/it/cms.it.xlf
+++ b/resources/xlf/it/cms.it.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">Caricamento...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">Si è verificato un errore imprevisto durante il caricamento dei server salvati {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">Caricamento...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">Il gruppo di server di gestione centrale include già un server registrato denominato {0}</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">I server del database SQL di Azure non possono essere usati come server di gestione centrale</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">I server Azure SQL non possono essere usati come server di gestione centrale</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/it/dacpac.it.xlf
+++ b/resources/xlf/it/dacpac.it.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="it">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Pacchetto di applicazione livello dati</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">Percorso completo della cartella in cui vengono salvati i file DACPAC e BAPAC per impostazione predefinita</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Server di destinazione</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Server di origine</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Database di origine</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Database di destinazione</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">Percorso file</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">Seleziona file</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">Riepilogo delle impostazioni</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versione</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">Impostazione</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valore</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">Nome database</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Apri</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">Aggiorna database esistente</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">Nuovo database</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">{0} delle azioni di distribuzione elencate potrebbero causare la perdita di dati. Assicurarsi di avere a disposizione un backup o uno snapshot in caso di problemi con la distribuzione.</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">Procedi nonostante la possibile perdita di dati</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">Non si verificherà alcuna perdita di dati dalle azioni di distribuzione elencate.</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">Salva</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">Percorso file</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">Versione (usare x.x.x.x dove x è un numero)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Apri</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">Distribuisci un file con estensione dacpac dell'applicazione livello dati in un'istanza di SQL Server [Distribuisci DACPAC]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">Esporta lo schema e i dati da un database nel formato di file logico con estensione bacpac [Esporta BACPAC]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">Nome database</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">Aggiorna database esistente</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">Nuovo database</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Database di destinazione</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">Server di destinazione</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">Server di origine</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">Database di origine</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Versione</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">Impostazione</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valore</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">predefinito</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">Procedura guidata per l'applicazione livello dati</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">Genera script</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">È possibile visualizzare lo stato della generazione dello script nella visualizzazione attività dopo la chiusura della procedura guidata. Lo script generato verrà aperto dopo il completamento.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">predefinito</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">Distribuire le operazioni del piano</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">Esiste già un database con lo stesso nome nell'istanza di SQL Server</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">Nome non definito</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">Il nome file non può terminare con un punto</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">Il nome file non può essere vuoto</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">Caratteri di file non validi</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">Questo nome file è riservato per l'uso da parte di Windows. Scegliere un altro nome e riprovare</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">Nome file riservato. Scegliere un altro nome e riprovare</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">Il nome file non può terminare con uno spazio vuoto</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">Il nome file ha più di 255 caratteri</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">La generazione del piano di distribuzione non è riuscita: '{0}'</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">La generazione dello script di distribuzione non è riuscita{0}'</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">Operazione {0} non riuscita '{1}'</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">È possibile visualizzare lo stato della generazione dello script nella visualizzazione attività dopo la chiusura della procedura guidata. Lo script generato verrà aperto dopo il completamento.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/it/import.it.xlf
+++ b/resources/xlf/it/import.it.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="it">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">Configurazione dell'importazione file flat</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[Facoltativa] Registrare l'output di debug nella console (Visualizza -&gt; Output), quindi selezionare il canale di output appropriato dall'elenco a discesa</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">{0} avviato</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">Avvio di {0}</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">Non è stato possibile avviare {0}: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">Installazione di {0} in {1}</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">Installazione del servizio {0}</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">{0} installato</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Download di {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Download di {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">Il download {0} è stato completato</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">Estratto {0} ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">Feedback</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">non è stato possibile avviare il componente del servizio</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">Server in cui si trova il database</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">Database in cui viene creata la tabella</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">Percorso file non valido. Provare un file di input diverso</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Sfoglia</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Apri</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">Percorso del file da importare</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">Nuovo nome della tabella</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">Schema della tabella</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">Importa dati</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Avanti</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">Nome colonna</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">Tipo di dati</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">Chiave primaria</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">Consenti valori Null</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">Questa operazione ha analizzato la struttura del file di input per generare l'anteprima seguente per le prime 50 righe.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">Questa operazione non è riuscita. Provare con un file di input diverso.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">Informazioni sull'importazione</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ I dati sono stati inseriti in una tabella.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">Questa operazione ha analizzato la struttura del file di input per generare l'anteprima seguente per le prime 50 righe.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">Questa operazione non è riuscita. Provare con un file di input diverso.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aggiorna</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">Importa dati</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Avanti</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">Nome colonna</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">Tipo di dati</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">Chiave primaria</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">Consenti valori Null</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">Server in cui si trova il database</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">Database in cui viene creata la tabella</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">Sfoglia</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Apri</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">Percorso del file da importare</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">Nuovo nome della tabella</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">Schema della tabella</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="it">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">Connettersi a un server prima di usare questa procedura guidata.</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">L'estensione SQL Server Import non supporta questo tipo di connessione</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">Importa nuovo file</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">Feedback</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">non è stato possibile avviare il componente del servizio</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">Servizio avviato</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">Avvio del servizio</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">Non è stato possibile avviare il servizio di importazione {0}</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">Installazione del servizio {0} in {1}</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">Installazione del servizio</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Installato</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">Download di {0}</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">Download del servizio</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">Operazione completata.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/it/notebook.it.xlf
+++ b/resources/xlf/it/notebook.it.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Percorso locale di un'installazione preesistente di Python usata da Notebooks.</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">Non visualizzare la richiesta di aggiornamento di Python.</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">Tempo di attesa (in minuti) prima dell'arresto di un server dopo la chiusura di tutti i notebook. (Immettere 0 per non arrestare)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Esegue l'override delle impostazioni predefinite dell'editor di Notebook. Le impostazioni includono il colore di sfondo, il colore della riga corrente e il bordo</target>
@@ -49,6 +57,10 @@
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
         <target state="translated">Notebook aggiunti dall'utente per l'area di lavoro corrente</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,24 +151,24 @@
         <target state="translated">Book di Jupyter</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">Salva book</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Salva il Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="translated">Considera attendibile il libro</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Jupyter Book attendibile</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">Cerca nel book</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Cerca nel Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
         <target state="translated">Notebook</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="translated">Libri forniti</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">Jupyter Book disponibili</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
@@ -174,17 +186,29 @@
         <source xml:lang="en">Close Jupyter Book</source>
         <target state="translated">Chiudi libro Jupyter</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="translated">Chiudi notebook Jupyter</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">Chiudere blocco appunti</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">Rimuovere il blocco appunti</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">Aggiungere blocco appunti</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">Aggiungi file markdown</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
         <target state="translated">Visualizza nei libri</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="translated">Crea libro (anteprima)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Crea Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
@@ -263,8 +287,8 @@
         <target state="translated">Seleziona cartella</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="translated">Seleziona libro</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Seleziona Jupyter Book</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
@@ -283,40 +307,40 @@
         <target state="translated">Apri collegamento esterno</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="translated">Il libro è considerato attendibile nell'area di lavoro.</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">Jupyter Book è ora considerato attendibile nell'area di lavoro.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="translated">Il libro è già considerato attendibile in questa area di lavoro.</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">Il Book è già considerato attendibile in questa area di lavoro.</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="translated">Il libro non è più considerato attendibile in questa area di lavoro</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">Il Book non è più considerato attendibile in questa area di lavoro</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="translated">Il libro è già considerato non attendibile in questa area di lavoro.</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">Il Book è già considerato non attendibile in questa area di lavoro.</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="translated">Il libro {0} è stato aggiunto nell'area di lavoro.</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">Il Book {0} è stato aggiunto nell'area di lavoro.</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="translated">Il libro {0} è stato rimosso da questa area di lavoro</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Il Book {0} è stato rimosso da questa area di lavoro</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="translated">Non è stato possibile trovare un file del sommario nel libro specificato.</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">Non è stato possibile trovare un file del sommario nel Book specificato.</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="translated">Nessun libro è attualmente selezionato nel viewlet.</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">Nessun Book è attualmente selezionato nel viewlet.</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="translated">Seleziona sezione del libro</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Seleziona la sezione Jupyter Book</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
@@ -339,12 +363,12 @@
         <target state="translated">File di configurazione mancante</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="translated">L'apertura del book {0} non è riuscita: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Apertura Jupyter Book {0} non riuscita: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="translated">Non è stato possibile leggere il libro {0}: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">Non è possibile leggere Jupyter Book {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
@@ -363,8 +387,8 @@
         <target state="translated">L'apertura del collegamento {0} non è riuscita: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="translated">La chiusura del libro {0} non è riuscita: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Chiusura Jupyter Book {0} non riuscita: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
@@ -373,12 +397,16 @@
  Il file è stato rinominato in {2} per evitare la perdita di dati.</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="translated">Si è verificato un errore durante la modifica del libro {0}: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Errore durante la modifica del Book {0}: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="translated">Si è verificato un errore durante la selezione di un libro o di una sezione da modificare: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">Si è verificato un errore durante la selezione di un Jupyter Book o di una sezione da modificare: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">Non è stato possibile trovare {0} in {1}.</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
@@ -393,8 +421,8 @@
         <target state="translated">Posizione</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="translated">Aggiungi libro remoto</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">Aggiungi libro remoto Jupyter</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
@@ -409,8 +437,8 @@
         <target state="translated">Versioni</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="translated">Libro</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter Book</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
@@ -421,8 +449,8 @@
         <target state="translated">Lingua</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="translated">Non sono attualmente disponibili libri nel collegamento fornito</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">Non sono attualmente disponibili Book nel collegamento fornito</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
@@ -445,44 +473,44 @@
         <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="translated">Il download del libro remoto è in corso</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">È in corso il download remoto del Jupyter Book</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="translated">Il download del libro remoto è stato completato</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">Download remoto del Jupyter Book completato</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="translated">Si è verificato un errore durante il download del libro remoto</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">Errore durante il download remoto di Jupyter Book</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="translated">Si è verificato un errore durante la decompressione del libro remoto</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">Errore durante la decompressione del Jupyter Book remoto</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="translated">Si è verificato un errore durante la creazione della directory del libro remoto</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">Si è verificato un errore durante la creazione della directory del Book remoto</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="translated">Download del libro remoto</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">Download del Jupyter Book remoto</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
         <target state="translated">Risorsa non trovata</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="translated">Libri non trovati</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">Jupyter Book non trovati</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
         <target state="translated">Versioni non trovate</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="translated">Il libro selezionato non è valido</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">Il Book selezionato non è valido</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
@@ -492,21 +520,21 @@
         <source xml:lang="en">Downloading to {0}</source>
         <target state="translated">Download di {0}</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="translated">Nuovo gruppo</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">Nuovo libro Jupyter (anteprima)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="translated">I gruppi vengono usati per organizzare i notebook.</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">I libri Jupyter vengono usati per organizzare i blocchi appunti.</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="translated">Sfoglia posizioni...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">Altre informazioni.</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="translated">Seleziona cartella del contenuto</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">Cartella del contenuto</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
@@ -524,7 +552,7 @@
         <source xml:lang="en">Save location</source>
         <target state="translated">Salva posizione</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
         <target state="translated">Cartella del contenuto (facoltativo)</target>
       </trans-unit>
@@ -533,8 +561,44 @@
         <target state="translated">Il percorso della cartella del contenuto non esiste</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="translated">Il percorso di salvataggio non esiste</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">Il percorso di salvataggio non esiste.</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">Errore durante il tentativo di accesso: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">Nuovo blocco appunti (anteprima)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">Nuovo markdown (anteprima)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">Estensione file</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">Il file esiste già. Si vuole davvero sovrascrivere il file?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Titolo</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">Nome file</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">Il percorso di salvataggio non è valido.</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">Il file {0} esiste già nella cartella di destinazione</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">È già in corso un'altra installazione di Python. Attendere che venga completata.</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">Le sessioni del notebook di Python attive verranno arrestate per l'aggiornamento. Procedere ora?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">Python {0} è ora disponibile in Azure Data Studio. La versione corrente di Python (3.6.6) non sarà supportata da dicembre 2021. Eseguire ora l'aggiornamento a Python {0} ?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">Python {0} verrà installato e sostituirà Python 3.6.6. Alcuni pacchetti potrebbero non essere più compatibili con la nuova versione o potrebbero dover essere reinstallati. Verrà creato un notebook che consente di reinstallare tutti i pacchetti pip. Continuare con l'aggiornamento ora?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">L'installazione delle dipendenze di Notebook non è riuscita. Errore: {0}</target>
@@ -603,6 +679,18 @@
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
         <target state="translated">Si è verificato un errore durante il recupero del percorso utente di Python: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">Non chiedere più</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">L'azione {0} non è supportata per questo gestore</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">Non è possibile aprire il collegamento {0} perché sono supportati solo i collegamenti HTTP e HTTPS</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">Non è possibile aprire il collegamento {0} perché sono supportati solo i collegamenti HTTP, HTTPS e file</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/it/profiler.it.xlf
+++ b/resources/xlf/it/profiler.it.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/it/resource-deployment.it.xlf
+++ b/resources/xlf/it/resource-deployment.it.xlf
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">Esegue l'immagine del contenitore di SQL Server con Docker</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">Cluster Big Data di SQL Server</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">Il cluster Big Data di SQL Server consente di distribuire cluster scalabili di contenitori SQL Server, Spark e HDFS in esecuzione in Kubernetes</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">Versione</target>
@@ -45,34 +37,6 @@
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
         <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">Destinazione di distribuzione</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">Nuovo cluster del servizio Azure Kubernetes</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">Cluster esistente del servizio Azure Kubernetes</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">Cluster Kubernetes esistente (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="translated">Cluster Azure Red Hat OpenShift esistente</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="translated">Cluster OpenShift esistente</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">Porta</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">Impostazioni del cluster Big Data di SQL Server</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">Nome del cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">Nome utente del controller</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">Password</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">Conferma password</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Impostazioni di Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">ID sottoscrizione</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">Usa la sottoscrizione di Azure predefinita personale</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">Nome del gruppo di risorse</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">Area</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">Nome del cluster del servizio Azure Kubernetes</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">Dimensioni della macchina virtuale</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">Numero di macchine virtuali</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">Nome della classe di archiviazione</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">Capacità per i dati (GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">Capacità per i log (GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">SQL Server in Windows</target>
@@ -170,21 +70,9 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">Consente di eseguire SQL Server in Windows. Selezionare una versione per iniziare.</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">Accetto {0}, {1} e {2}.</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
         <target state="translated">Informativa sulla privacy di Microsoft</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">Condizioni di licenza di azdata</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">Condizioni di licenza di SQL Server</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
@@ -485,6 +373,22 @@
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
         <target state="translated">Accetta contratto di licenza e seleziona</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">L'estensione "{0}" è necessaria per distribuire la risorsa, si vuole installarla subito?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Installare</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">Installazione dell'estensione "{0}" in corso...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">Estensione "{0}" sconosciuta</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
@@ -1096,10 +1000,6 @@
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">Non è stato possibile caricare l'estensione: {0}. È stato rilevato un errore nella definizione dei tipi di risorse nel file package.json. Per dettagli, vedere la console di debug.</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">Il tipo di risorsa {0} non è definito</target>
@@ -2222,13 +2122,13 @@ Selezionare una sottoscrizione diversa contenente almeno un server</target>
         <source xml:lang="en">Deployment pre-requisites</source>
         <target state="translated">Prerequisiti di distribuzione</target>
       </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="translated">Per procedere è necessario accettare le condizioni del contratto di licenza</target>
-      </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
         <target state="translated">Alcuni strumenti non sono stati ancora individuati. Assicurarsi che siano installati, in esecuzione e individuabili</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">Per procedere è necessario accettare le condizioni del contratto di licenza</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
@@ -2378,6 +2278,10 @@ Selezionare una sottoscrizione diversa contenente almeno un server</target>
         <source xml:lang="en">Azure Data CLI</source>
         <target state="translated">Interfaccia della riga di comando di Azure Data</target>
       </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">Per distribuire la risorsa, è necessario installare l'estensione AZURE Data CLI. Installare l'estensione tramite la raccolta estensioni e riprovare.</target>
+      </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
         <target state="translated">Errore durante il recupero delle informazioni sulla versione. Per altri dettagli, vedere il canale di output '{0}'</target>
@@ -2385,46 +2289,6 @@ Selezionare una sottoscrizione diversa contenente almeno un server</target>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
         <target state="translated">Errore durante il recupero delle informazioni sulla versione.{0}È stato ricevuto un output non valido. Ottenere l'output del comando della versione: '{1}' </target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="translated">eliminazione del file Azdata.msi scaricato in precedenza se presente…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="translated">download di Azdata.msi e installazione di azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="translated">visualizzazione del log di installazione…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="translated">accesso al repository brew per azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="translated">aggiornamento del repository brew per l'installazione di azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="translated">installazione di azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="translated">aggiornamento delle informazioni sul repository…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="translated">recupero dei pacchetti necessari per l'installazione di azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="translated">download e installazione della chiave di firma per azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="translated">aggiunta delle informazioni sul repository azdata…</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/it/schema-compare.it.xlf
+++ b/resources/xlf/it/schema-compare.it.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Origine</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">Destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">File</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">File dell'applicazione livello dati (con estensione dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Database</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Database</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">Confronto schemi</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">È stato selezionato uno schema di origine diverso. Eseguire il confronto?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">È stato selezionato uno schema di destinazione diverso. Eseguire il confronto?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">Sono stati selezionati schemi di origine e di destinazione diversi. Eseguire il confronto?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">File di origine</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">File di destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Database di origine</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Database di destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Server di origine</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Server di destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">predefinito</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Apri</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">Selezionare file di origine</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">Selezionare il file di destinazione</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">Reimposta</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">Includi tipi di oggetto</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">Dettagli confronto</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">Aggiornare la destinazione?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">Fare clic su Confronta per aggiornare il confronto.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">Genera script per distribuire le modifiche nella destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">Non sono presenti modifiche per cui generare lo script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">Applica modifiche alla destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">Non sono presenti modifiche da applicare</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">Tenere presente che le operazioni di inclusione/esclusione possono richiedere qualche minuto per calcolare le dipendenze interessate</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Elimina</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">Modifica</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">Aggiungi</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">Confronto tra origine e destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">Inizializzazione del confronto. L'operazione potrebbe richiedere qualche istante.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">Per confrontare due schemi, selezionare lo schema di origine e quello di destinazione, quindi fare clic su Confronta.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">Non sono state trovate differenze di schema.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">Nome origine</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">Includi</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Azione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">Nome destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">L'opzione Genera script è abilitata quando la destinazione è un database</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">L'opzione Applica è abilitata quando la destinazione è un database</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">Non è possibile escludere {0}. Esistono dipendenti inclusi, ad esempio {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">Non è possibile includere {0}. Esistono dipendenti esclusi, ad esempio {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">Non è possibile escludere {0}. Esistono dipendenti inclusi</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">Non è possibile includere {0}. Esistono dipendenti esclusi</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">Confronta</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Arresta</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Genera script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Opzioni</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Applica</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">Cambia direzione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">Scambia origine e destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">Seleziona origine</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">Seleziona destinazione</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">Apri file con estensione scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">Carica origine, destinazione e opzioni salvate in un file con estensione scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">Salva file con estensione scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">Salva origine e destinazione, opzioni ed elementi esclusi</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">Salva</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">Si desidera connettersi a {0}?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">Selezionare connessione</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,7 +663,7 @@
         <target state="translated">Ruoli database</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
+        <source xml:lang="en">Database Triggers</source>
         <target state="translated">Trigger database</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">Formati di file esterni</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">Flussi esterni</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">Processi di streaming esterni</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">Tabelle esterne</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">Filegroup</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">File</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,11 +771,11 @@
         <target state="translated">Firme</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
+        <source xml:lang="en">Stored Procedures</source>
         <target state="translated">Stored procedure</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
+        <source xml:lang="en">Symmetric Keys</source>
         <target state="translated">Chiavi simmetriche</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">Specifica se le differenze nell'ordine colonne della tabella devono essere ignorate o aggiornate durante la pubblicazione di un database.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Origine</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Destinazione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">File</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">File dell'applicazione livello dati (con estensione dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Database</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Database</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">Non ci sono connessioni attive</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Confronto schemi</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">È stato selezionato uno schema di origine diverso. Eseguire il confronto?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">È stato selezionato uno schema di destinazione diverso. Eseguire il confronto?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">Sono stati selezionati schemi di origine e di destinazione diversi. Eseguire il confronto?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Apri</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">predefinito</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">Dettagli confronto</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">Aggiornare la destinazione?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">Fare clic su Confronta per aggiornare il confronto.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">Genera script per distribuire le modifiche nella destinazione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">Non sono presenti modifiche per cui generare lo script</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">Applica modifiche alla destinazione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">Non sono presenti modifiche da applicare</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Elimina</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">Modifica</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">Aggiungi</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Confronto schemi</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Origine</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Destinazione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">Inizializzazione del confronto. L'operazione potrebbe richiedere qualche istante.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">Per confrontare due schemi, selezionare lo schema di origine e quello di destinazione, quindi fare clic su Confronta.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">Non sono state trovate differenze di schema.</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">Il confronto schemi non è riuscito: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">Nome origine</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">Includi</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Azione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">Nome destinazione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">L'opzione Genera script è abilitata quando la destinazione è un database</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">L'opzione Applica è abilitata quando la destinazione è un database</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Confronta</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Confronta</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arresta</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arresta</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">Il salvataggio del file scmp non è riuscito: '{0}'</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">L'annullamento del confronto schemi non è riuscito: '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Genera script</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">La generazione dello script non è riuscita: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opzioni</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opzioni</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Applica</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">L'applicazione del confronto schemi non è riuscita: '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">Cambia direzione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">Scambia origine e destinazione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">Seleziona origine</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">Seleziona destinazione</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">Apri file con estensione scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">Carica origine, destinazione e opzioni salvate in un file con estensione scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Apri</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">L'apertura del file scmp non è riuscita: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">Salva file con estensione scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">Salva origine e destinazione, opzioni ed elementi esclusi</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">Salva</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">Il salvataggio del file scmp non è riuscito: '{0}'</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/it/sql.it.xlf
+++ b/resources/xlf/it/sql.it.xlf
@@ -1,2559 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">La copia delle immagini non è supportata</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">Attività iniziali</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">Mostra introduzione</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Introduzione</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">Cronologia query</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">Indica se l'acquisizione della cronologia delle query è abilitata. Se è false, le query eseguite non verranno acquisite.</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Visualizza</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Cronologia delle query</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">Cronologia delle query</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">Connessione: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">Esecuzione del comando: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">Apertura della nuova query: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">Non è possibile connettersi perché non sono state fornite informazioni sul server</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">Non è stato possibile aprire l'URL a causa dell'errore {0}</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">Verrà eseguita la connessione al server {0}</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">Connettersi?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">&amp;&amp;Apri</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">Connessione del file di query</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">Sono in corso una o più attività. Uscire comunque?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">Le funzionalità in anteprima consentono di migliorare l'esperienza in Azure Data Studio offrendo accesso completo a nuove funzionalità e miglioramenti. Per altre informazioni sulle funzionalità in anteprima, vedere [qui] ({0}). Abilitare le funzionalità in anteprima?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">Sì (scelta consigliata)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">Non visualizzare più questo messaggio</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">Attiva/Disattiva cronologia delle query</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Elimina</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">Cancella tutta la cronologia</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">Apri query</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Esegui query</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">Attiva/Disattiva acquisizione della cronologia delle query</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">Sospendi acquisizione della cronologia delle query</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">Avvia acquisizione della cronologia delle query</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">Non ci sono query da visualizzare.</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">Cronologia delle query</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Errore</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Avviso</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">Informazioni</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">Ignora</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">Il salvataggio dei risultati in un formato diverso è disabilitato per questo provider di dati.</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">Non è possibile serializzare i dati perché non è stato registrato alcun provider</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">La serializzazione non è riuscita e si verificato un errore sconosciuto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">Per interagire con adminservice, è richiesta la connessione</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Non ci sono gestori registrati</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">Seleziona un file</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">Per interagire con il servizio valutazione è necessaria una connessione</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Non ci sono gestori registrati</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">Messaggi e griglia dei risultati</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">Controlla la famiglia di caratteri.</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">Controlla lo spessore del carattere.</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">Controlla le dimensioni del carattere in pixel.</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">Controlla la spaziatura tra le lettere in pixel.</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">Controlla l'altezza delle righe in pixel</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">Controlla la spaziatura interna celle in pixel</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">Ridimensiona automaticamente la larghezza delle colonne sui risultati iniziali. Potrebbero verificarsi problemi di prestazioni con un numero elevato di colonne o celle di grandi dimensioni</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">Larghezza massima in pixel per colonne con ridimensionamento automatico</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Visualizza</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">Connessioni di database</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">connessioni a origine dati</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">gruppi di origine dati</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">Configurazione di avvio</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">È true se all'avvio di Azure Data Studio deve essere visualizzata la visualizzazione Server (impostazione predefinita); è false se deve essere visualizzata l'ultima visualizzazione aperta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Disconnetti</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aggiorna</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">Funzionalità di anteprima</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">Abilita le funzionalità di anteprima non rilasciate</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">Mostra la finestra di dialogo della connessione all'avvio</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">Notifica API obsolete</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">Abilita/disabilita la notifica di utilizzo di API obsolete</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">Problemi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} attività in corso</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Visualizza</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">Attività</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Attività</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">Numero massimo di connessioni usate di recente da archiviare nell'elenco delle connessioni.</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">Motore SQL predefinito da usare. Stabilisce il provider del linguaggio predefinito nei file con estensione sql e il valore predefinito da usare quando si crea una nuova connessione.</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">Prova ad analizzare il contenuto degli appunti quando si apre la finestra di dialogo di connessione o si esegue un'operazione Incolla.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">Tavolozza dei colori del gruppo di server usata nel viewlet Esplora oggetti.</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">Espande automaticamente i gruppi di server nel viewlet di Esplora oggetti.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(Anteprima) Usare il nuovo albero del server asincrono per la visualizzazione Server e la finestra di dialogo di connessione con il supporto di nuove funzionalità come i filtri dinamici dei nodi.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">Identificatore del tipo di account</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(Facoltativa) Icona usata per rappresentare l'account nell'interfaccia utente. Percorso di file o configurazione che supporta i temi</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Percorso dell'icona quando viene usato un tema chiaro</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Percorso dell'icona quando viene usato un tema scuro</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">Aggiunge come contributo le icone al provider di account.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">Mostra riquadro Modifica dati SQL all'avvio</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Valore minimo dell'asse Y</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Valore massimo dell'asse Y</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Etichetta per l'asse Y</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">Valore minimo dell'asse X</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">Valore massimo dell'asse X</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">Etichetta per l'asse X</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visualizzatore risorse</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">Indica la proprietà dati di un set di dati per un grafico.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">Per ogni colonna in un set di risultati mostra il valore nella riga 0 sotto forma di numero seguito dal nome della colonna. Ad esempio '1 Attivi', '3 Disabilitati', dove 'Attivi' è il nome della colonna e 1 è il valore presente a riga 1 cella 1</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">Visualizza i risultati in una tabella semplice</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">Visualizza un'immagine, ad esempio una restituita da una query R che usa ggplot2</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">Indica se il formato previsto è JPEG, PNG o di altro tipo.</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">Indica se viene codificato come hex, base64 o in un altro formato.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gestisci</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Dashboard</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">Webview che verrà visualizzata in questa scheda.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">controlhost che verrà visualizzato in questa scheda.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">Elenco dei widget che verranno visualizzati in questa scheda.</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">L'elenco dei widget deve trovarsi all'interno del contenitore dei widget per l'estensione.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">Elenco dei widget o delle webview che verranno visualizzati in questa scheda.</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">i widget o le webview devono trovarsi nel contenitore dei widget per l'estensione.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">Identificatore univoco per questo contenitore.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">Contenitore che verrà visualizzato nella scheda.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">Aggiunge come contributo uno o più container di dashboard che gli utenti possono aggiungere al proprio dashboard.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">Nel container di dashboard non è stato specificato alcun ID per l'estensione.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">Nel container di dashboard non è stato specificato alcun contenitore per l'estensione.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Per ogni spazio è necessario definire un solo container di dashboard.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">Nel container di dashboard è stato definito un tipo di contenitore sconosciuto per l'estensione.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificatore univoco per questa sezione di spostamento. Verrà passato all'estensione per eventuali richieste.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Facoltativa) Icona usata per rappresentare la sezione di spostamento nell'interfaccia utente. Percorso di file o configurazione che supporta i temi</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Percorso dell'icona quando viene usato un tema chiaro</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Percorso dell'icona quando viene usato un tema scuro</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">Titolo della sezione di spostamento da mostrare all'utente.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">Contenitore che verrà visualizzato in questa sezione di spostamento.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">Elenco di container di dashboard che verrà visualizzato in questa sezione di spostamento.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">Nella sezione di spostamento non è stato specificato alcun titolo per l'estensione.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">Nella sezione di spostamento non è stato specificato alcun contenitore per l'estensione.</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Per ogni spazio è necessario definire un solo container di dashboard.</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">Un elemento NAV_SECTION all'interno di un altro elemento NAV_SECTION non è un contenitore valido per l'estensione.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">Visualizzazione basata su modello che verrà visualizzata in questa scheda.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Backup</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Ripristina</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Ripristina</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">Apri nel portale di Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">disconnesso</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">Non è possibile eseguire l'espansione perché il provider di connessione richiesto '{0}' non è stato trovato</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">Annullato dall'utente</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">Finestra di dialogo del firewall annullata</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">Per interagire con JobManagementService, è richiesta la connessione</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Non ci sono gestori registrati</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">Si è verificato un errore durante il caricamento del visualizzatore file.</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">Errore del visualizzatore file</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">ID comune del provider</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">Nome visualizzato del provider</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">Alias del kernel del notebook per il provider</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">Percorso dell'icona per il tipo di server</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">Opzioni per la connessione</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificatore univoco per questa scheda. Verrà passato all'estensione per eventuali richieste.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">Titolo della scheda da mostrare all'utente.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">Descrizione di questa scheda che verrà mostrata all'utente.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Condizione che deve essere vera per mostrare questo elemento</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">Definisce i tipi di connessione con cui è compatibile questa scheda. Se non viene impostato, il valore predefinito è 'MSSQL'</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">Contenitore che verrà visualizzato in questa scheda.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">Indica se questa scheda deve essere sempre visualizzata oppure solo quando viene aggiunta dall'utente.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">Indica se questa scheda deve essere usata come scheda iniziale per un tipo di connessione.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">Identificatore univoco del gruppo a cui appartiene questa scheda, valore per il gruppo home: home.</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Facoltativo) Icona usata per rappresentare questa scheda nell'interfaccia utente. Percorso di file o configurazione che supporta i temi</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Percorso dell'icona quando viene usato un tema chiaro</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Percorso dell'icona quando viene usato un tema scuro</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">Aggiunge come contributo una o più schede che gli utenti possono aggiungere al proprio dashboard.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">Non è stato specificato alcun titolo per l'estensione.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">Non è stata specificata alcuna descrizione da mostrare.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">Non è stato specificato alcun contenitore per l'estensione.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">Per ogni spazio è necessario definire un solo container di dashboard</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">Identificatore univoco per questo gruppo di schede.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">Titolo del gruppo di schede.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">Fornisce uno o più gruppi di schede che gli utenti possono aggiungere al proprio dashboard.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">Nessun ID specificato per il gruppo di schede.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">Nessun titolo specificato per il gruppo di schede.</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">Amministrazione</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">Monitoraggio</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">Prestazioni</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">Sicurezza</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">Risoluzione dei problemi</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Impostazioni</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">scheda database</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">Database</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">riuscito</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">non riuscito</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">Errore di connessione</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">La connessione non è riuscita a causa di un errore di Kerberos.</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">Le informazioni sulla configurazione di Kerberos sono disponibili all'indirizzo {0}</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">Se si è già eseguita la connessione, può essere necessario eseguire di nuovo kinit.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Chiudi</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">Aggiunta dell'account...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">L'aggiornamento dell'account è stato annullato dall'utente</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">Risultati query</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor di query</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nuova query</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor di query</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">Se è impostata su true, le intestazioni di colonna vengono incluse quando si salvano i risultati in formato CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">Delimitatore personalizzato da usare tra i valori quando si salvano i risultati in formato CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">Caratteri usati per delimitare le righe quando si salvano i risultati in formato CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">Carattere usato per racchiudere i campi di testo quando si salvano i risultati in formato CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">Codifica di file usata quando si salvano i risultati in formato CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">Quando è true, l'output XML verrà formattato quando si salvano i risultati in formato XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">Codifica di file usata quando si salvano i risultati in formato XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">Abilita lo streaming dei risultati. Contiene alcuni problemi minori relativi a oggetti visivi</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">Opzioni di configurazione per la copia di risultati dalla Visualizzazione risultati</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">Opzioni di configurazione per la copia di risultati su più righe dalla visualizzazione risultati</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(Sperimentale) Usare una tabella ottimizzata per la visualizzazione dei risultati. Alcune funzionalità potrebbero mancare e sono in lavorazione.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">Indicare se visualizzare il tempo di esecuzione per singoli batch</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">Messaggi con ritorno a capo automatico</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">Tipo di grafico predefinito da usare quando si apre il visualizzatore grafico dai risultati di una query</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">La colorazione delle schede verrà disabilitata</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">Al bordo superiore di ogni scheda verrà applicato il colore del gruppo di server pertinente</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">Il colore di sfondo di ogni scheda dell'editor sarà uguale a quello del gruppo di server pertinente</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">Controlla come colorare le schede in base al gruppo di server della connessione attiva</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">Controlla se visualizzare le informazioni sulla connessione per una scheda nel titolo.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">Richiede di salvare i file SQL generati</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">Imposta il tasto di scelta rapida workbench.action.query.shortcut{0} in modo da eseguire il testo del tasto di scelta rapida come una chiamata di procedura. L'eventuale testo selezionato nell'editor di query verrà passato come parametro</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">Specifica i modelli di visualizzazione</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">Specifica i modelli di sessione</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Filtri profiler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Genera script come CREATE</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Genera script come DROP</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Genera script come SELECT TOP 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Genera script come EXECUTE</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Genera script come ALTER</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Modifica dati</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Genera script come SELECT TOP 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Take 10</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Genera script come CREATE</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Genera script come EXECUTE</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Genera script come ALTER</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Genera script come DROP</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aggiorna</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">Commit della riga non riuscito: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">Esecuzione della query iniziata a </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">Esecuzione della query "{0}" avviata</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">Riga {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">Annullamento della query non riuscito: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">Aggiornamento della cella non riuscito: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">Non è stato passato alcun URI durante la creazione di un gestore di notebook</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">Il provider di notebook non esiste</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Editor di notebook</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nuovo notebook</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nuovo notebook</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">Imposta area di lavoro e apri</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">Kernel SQL: arresta l'esecuzione di Notebook quando si verifica un errore in una cella.</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(Anteprima) mostrare tutti i kernel per il provider di notebook corrente.</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">Consentire ai notebook di eseguire i comandi di Azure Data Studio.</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">Abilitare il doppio clic per modificare le celle di testo nei notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">Impostare la modalità di visualizzazione RTF per impostazione predefinita per le celle di testo</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(Anteprima) Salvare il nome della connessione nei metadati del notebook.</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">Controlla l'altezza della riga usata nell'anteprima Markdown del notebook. Questo numero è relativo alle dimensioni del carattere.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Visualizza</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">Cerca nei notebook</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">Consente di configurare i criteri GLOB per escludere file e cartelle nelle ricerche full-text e in Quick Open. Eredita tutti i criteri GLOB dall'impostazione `#files.exclude#`. Per altre informazioni sui criteri GLOB, fare clic [qui](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">Criterio GLOB da usare per trovare percorsi file. Impostare su True o False per abilitare o disabilitare il criterio.</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">Controllo aggiuntivo sugli elementi di pari livello di un file corrispondente. Usare $(basename) come variabile del nome file corrispondente.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">Questa impostazione è deprecata. Verrà ora eseguito il fallback a "search.usePCRE2".</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">Deprecata. Per il supporto della funzionalità avanzate delle espressioni regex provare a usare "search.usePCRE2".</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">Se abilitato, il processo searchService verrà mantenuto attivo invece di essere arrestato dopo un'ora di inattività. In questo modo la cache di ricerca dei file rimarrà in memoria.</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Controlla se utilizzare i file `.gitignore` e `.ignore` durante la ricerca di file.</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Controlla se usare i file `.gitignore` e `.ignore` globali durante la ricerca di file.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">Indica se includere i risultati di una ricerca di simboli globale nei risultati dei file per Quick Open.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">Indica se includere i risultati di file aperti di recente nel file dei risultati per Quick Open.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">Le voci della cronologia sono ordinate per pertinenza in base al valore di filtro usato. Le voci più pertinenti vengono visualizzate per prime.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">Le voci della cronologia sono ordinate in base alla data. Le voci aperte più di recente vengono visualizzate per prime.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">Controlla l'ordinamento della cronologia dell'editor in Quick Open quando viene applicato il filtro.</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">Controlla se seguire i collegamenti simbolici durante la ricerca.</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">Esegue la ricera senza fare distinzione tra maiuscole/minuscole se il criterio è tutto minuscolo, in caso contrario esegue la ricerca facendo distinzione tra maiuscole/minuscole.</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">Controlla se il viewlet di ricerca deve leggere o modificare gli appunti di ricerca condivisi in macOS.</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">Controlla se la ricerca verrà mostrata come visualizzazione nella barra laterale o come pannello nell'area pannelli per ottenere più spazio orizzontale.</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">Questa impostazione è deprecata. Usare il menu di scelta rapida della visualizzazione di ricerca.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">I file con meno di 10 risultati vengono espansi. Gli altri vengono compressi.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">Controlla se i risultati della ricerca verranno compressi o espansi.</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">Controlla se aprire Anteprima sostituzione quando si seleziona o si sostituisce una corrispondenza.</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">Controlla se visualizzare i numeri di riga per i risultati della ricerca.</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">Indica se usare il motore regex PCRE2 nella ricerca di testo. In questo modo è possibile usare alcune funzionalità avanzate di regex, come lookahead e backreference. Non sono però supportate tutte le funzionalità di PCRE2, ma solo quelle supportate anche da JavaScript.</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">Deprecata. PCRE2 verrà usato automaticamente se si usano funzionalità regex supportate solo da PCRE2.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">Posiziona la barra azioni a destra quando la visualizzazione di ricerca è stretta e subito dopo il contenuto quando la visualizzazione di ricerca è ampia.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">Posiziona sempre la barra azioni a destra.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">Controlla il posizionamento in righe della barra azioni nella visualizzazione di ricerca.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">Cerca in tutti i file durante la digitazione.</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">Abilita il seeding della ricerca a partire dalla parola più vicina al cursore quando non ci sono selezioni nell'editor attivo.</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">Aggiorna la query di ricerca dell'area di lavoro in base al testo selezionato dell'editor quando lo stato attivo si trova nella visualizzazione di ricerca. Si verifica in caso di clic o quando si attiva il comando `workbench.views.search.focus`.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">Se `#search.searchOnType#` è abilitato, controlla il timeout in millisecondi tra la digitazione di un carattere e l'avvio della ricerca. Non ha effetto quando `search.searchOnType` è disabilitato.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">Facendo doppio clic viene selezionata la parola sotto il cursore.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">Facendo doppio clic il risultato viene aperto nel gruppo di editor attivo.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">Facendo doppio clic il risultato viene aperto nel gruppo di editor laterale e viene creato un gruppo se non esiste ancora.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">Configura l'effetto del doppio clic su un risultato nell'editor della ricerca.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">I risultati vengono visualizzati in ordine alfabetico in base ai nomi di file e cartella.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">I risultati vengono visualizzati in ordine alfabetico in base ai nomi file ignorando l'ordine delle cartelle.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">I risultati vengono visualizzati in ordine alfabetico in base all'estensione del file.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">I risultati vengono visualizzati in ordine decrescente in base alla data dell'ultima modifica del file.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">I risultati vengono visualizzati in ordine decrescente in base al conteggio per file.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">I risultati vengono visualizzati in ordine crescente in base al conteggio per file.</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">Controlla l'ordinamento dei risultati della ricerca.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nuova query</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Esegui</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">Spiega</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">Effettivo</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Disconnetti</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Cambia connessione</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Connetti</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">Abilita SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">Disabilita SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">Seleziona database</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Non è stato possibile modificare il database</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">Non è stato possibile modificare il database {0}</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">Esporta come notebook</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Chiudi</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Azione</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">Copia dettagli</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">Aggiungi gruppo di server</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">Modifica gruppo di server</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">Estensione</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">Non è stato possibile creare la sessione di Esplora oggetti</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">Più errori:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Errore di aggiunta account</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">Errore della regola del firewall</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">Alcune delle estensioni caricate usano API obsolete. Per informazioni dettagliate, vedere la scheda Console della finestra Strumenti di sviluppo</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Non visualizzare più questo messaggio</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">Identificatore della visualizzazione. Usare questa impostazione per registrare un provider di dati tramite l'API `vscode.window.registerTreeDataProviderForView`, nonché per avviare l'attivazione dell'estensione tramite la registrazione dell'evento `onView:${id}` in `activationEvents`.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Nome leggibile della visualizzazione. Verrà visualizzato</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">Condizione che deve essere vera per mostrare questa visualizzazione</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">Aggiunge come contributo le visualizzazioni all'editor</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">Aggiunge come contributo le visualizzazioni al contenitore Esplora dati nella barra attività</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">Aggiunge come contributo le visualizzazioni al contenitore delle visualizzazioni aggiunto come contributo</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">Non è possibile registrare più visualizzazioni con stesso ID `{0}` nel contenitore di visualizzazioni `{1}`</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">Una visualizzazione con ID `{0}` è già registrata nel contenitore di visualizzazioni `{1}`</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">le visualizzazioni devono essere una matrice</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">la proprietà `{0}` è obbligatoria e deve essere di tipo `string`</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">la proprietà `{0}` può essere omessa o deve essere di tipo `string`</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">{0} è stato sostituito con {1} nelle impostazioni utente.</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">{0} è stato sostituito con {1} nelle impostazioni dell'area di lavoro.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gestisci</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Mostra dettagli</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">Altre informazioni</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">Cancella tutti gli account salvati</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">Attiva/Disattiva attività</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">Stato della connessione</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">Nome visibile dell'utente per il provider dell'albero</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">L'ID del provider deve essere lo stesso di quando si registra il provider di dati dell'albero e deve iniziare con 'connectionDialog/'</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">Visualizza i risultati di una query sotto forma di grafico nel dashboard</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">Esegue il mapping di 'nome colonna' al colore. Ad esempio, aggiungere 'column1': red se si vuole usare il colore rosso per questa colonna </target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">Indica la posizione preferita e la visibilità della legenda del grafico. Questi sono i nomi di colonna estratti dalla query e associati all'etichetta di ogni voce del grafico</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">Se dataDirection è impostato su horizontal e si imposta questa opzione su true, per la legenda viene usato il primo valore di ogni colonna.</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">Se dataDirection è impostato su vertical e si imposta questa opzione su true, per la legenda vengono usati i nomi delle colonne.</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">Definisce se i dati vengono letti da una colonna (vertical) o da una riga (horizontal). Per la serie temporale questa impostazione viene ignorata perché la direzione deve essere verticale.</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">Se è impostato showTopNData, vengono visualizzati solo i primi N dati del grafico.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usato nei dashboard</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostra azioni</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visualizzatore risorse</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">Identificatore della risorsa.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Nome leggibile della visualizzazione. Verrà visualizzato</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">Percorso dell'icona della risorsa.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">Fornisce una risorsa alla visualizzazione risorse</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">la proprietà `{0}` è obbligatoria e deve essere di tipo `string`</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">la proprietà `{0}` può essere omessa o deve essere di tipo `string`</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">Albero del visualizzatore risorse</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usato nei dashboard</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usato nei dashboard</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usato nei dashboard</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Condizione che deve essere vera per mostrare questo elemento</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">Indica se nascondere l'intestazione del widget. Il valore predefinito è false</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">Titolo del contenitore</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">Riga del componente nella griglia</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">rowspan del componente nella griglia. Il valore predefinito è 1. Usare '*' per impostare sul numero di righe della griglia.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">Colonna del componente nella griglia</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">colspan del componente nella griglia. Il valore predefinito è 1. Usare '*' per impostare sul numero di colonne della griglia.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificatore univoco per questa scheda. Verrà passato all'estensione per eventuali richieste.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">La scheda dell'estensione è sconosciuta o non è installata.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Abilita o disabilita il widget delle proprietà</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valori di proprietà da mostrare</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nome visualizzato della proprietà</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">Valore nell'oggetto informazioni database</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">Specifica i valori da ignorare</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">Modello di recupero</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">Ultimo backup del database</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">Ultimo backup del log</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">Livello di compatibilità</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Proprietario</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">Personalizza la pagina del dashboard del database</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Cerca</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">Personalizza le schede del dashboard del database</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Abilita o disabilita il widget delle proprietà</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valori di proprietà da mostrare</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nome visualizzato della proprietà</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">Valore nell'oggetto informazioni server</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Versione</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">Edizione</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">Nome del computer</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">Versione del sistema operativo</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Cerca</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">Personalizza la pagina del dashboard del server</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">Personalizza le schede del dashboard del server</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gestisci</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">la proprietà `icon` può essere omessa o deve essere una stringa o un valore letterale come `{dark, light}`</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">Aggiunge un widget in grado di eseguire una query su un server o un database e di visualizzare i risultati in vari modi, ovvero sotto forma di grafico, conteggio riepilogativo e altro ancora</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">Identificatore univoco usato per memorizzare nella cache i risultati dei dati analitici.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">Query SQL da eseguire. Dovrebbe restituire esattamente un solo set di risultati.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[Facoltativa] Percorso di un file contenente una query. Usare se 'query' non è impostato</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[Facoltativa] Intervallo di aggiornamento automatico in minuti. Se non è impostato, non verrà eseguito alcun aggiornamento automatico</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">Indica le azioni da usare</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Database di destinazione per l'azione. È possibile usare il formato '${columnName}' per specificare un nome di colonna basata sui dati.</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Server di destinazione per l'azione. È possibile usare il formato '${columnName}' per specificare un nome di colonna basata sui dati.</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Utente di destinazione per l'azione. È possibile usare il formato '${columnName}' per specificare un nome di colonna basata sui dati.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">Identificatore dei dati analitici</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">Aggiunge come contributo i dati analitici al pannello del dashboard.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Backup</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">Per usare il backup, è necessario abilitare le funzionalità di anteprima</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">Il comando di backup non è supportato per i database SQL di Azure.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">Il comando di backup non è supportato nel contesto server. Selezionare un database e riprovare.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Ripristina</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">Per usare il ripristino, è necessario abilitare le funzionalità di anteprima</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">Il comando di ripristino non è supportato per i database SQL di Azure.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Mostra elementi consigliati</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">Installa estensioni</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">Crea un'estensione...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">Connessione alla sessione di modifica dati non riuscita</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">Apri le estensioni del dashboard</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">Al momento non sono installate estensioni del dashboard. Passare a Gestione estensioni per esplorare le estensioni consigliate.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">Percorso selezionato</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">File di tipo</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Rimuovi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">Non è stato passato alcun profilo di connessione al riquadro a comparsa dei dati analitici</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">Errore nei dati analitici</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">Si è verificato un errore durante la lettura del file di query: </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">Si è verificato un errore durante l'analisi della configurazione dei dati analitici. Non è stato possibile trovare la matrice/stringa di query o il file di query</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Account Azure</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Tenant di Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">Mostra connessioni</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Connessioni</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">Non è disponibile alcuna cronologia attività da visualizzare.</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">Cronologia attività</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">Errore attività</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">Cancella elenco</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">L'elenco delle connessioni recenti è stato cancellato</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">Eliminare tutte le connessioni dall'elenco?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Elimina</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">Ottieni la stringa di connessione corrente</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">La stringa di connessione non è disponibile</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">Non sono disponibili connessioni attive</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aggiorna</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">Modifica connessione</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Disconnetti</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">Nuova connessione</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">Nuovo gruppo di server</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">Modifica gruppo di server</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">Mostra connessioni attive</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">Mostra tutte le connessioni</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Connessioni recenti</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">Elimina connessione</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">Elimina gruppo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Esegui</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">Modifica del metodo Dispose non riuscita. Errore: </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arresta</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">Mostra riquadro SQL</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">Chiudi riquadro SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">Non connesso</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">La sessione del profiler XEvent è stata arrestata in modo imprevisto nel server {0}.</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">Si è verificato un errore durante l'avvio della nuova sessione</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">Sono presenti eventi persi per la sessione del profiler XEvent per {0}.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Caricamento in corso</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Caricamento completato</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">Gruppi di server</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">Nome del gruppo di server</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">Il nome del gruppo è obbligatorio.</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">Descrizione gruppo</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">Colore del gruppo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Errore di aggiunta account</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">Elemento</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valore</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">Dettagli delle informazioni dettagliate</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">Proprietà</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valore</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">Dati analitici</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">Elementi</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">Dettagli elemento</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">Non è possibile avviare un OAuth automatico perché ne è già in corso uno.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">Ordina per evento</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">Ordina per colonna</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">Cancella tutto</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Applica</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">Filtri</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">Rimuovi questa clausola</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">Salva filtro</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">Carica filtro</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">Aggiungi una clausola</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">Campo</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">Operatore</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valore</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">È Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">Non è Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">Contiene</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">Non contiene</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">Inizia con</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">Non inizia con</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Salva in formato CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Salva in formato JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Salva in formato Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Salva in formato XML</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copia</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copia con intestazioni</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Seleziona tutto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">Definisce una proprietà da mostrare nel dashboard</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">Indica il valore da usare come etichetta per la proprietà</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">Indica il valore nell'oggetto per accedere al valore</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">Specifica i valori da ignorare</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">Valore predefinito da mostrare se l'impostazione viene ignorata o non viene indicato alcun valore</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">Versione per la definizione delle proprietà del dashboard</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">ID della versione</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">Condizione per usare questa versione</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">Campo da usare per il confronto</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">Indica l'operatore da usare per il confronto</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">Valore con cui confrontare il campo</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">Proprietà da mostrare per la pagina del database</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">Proprietà da mostrare per la pagina del server</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">Definisce se questo provider supporta il dashboard</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">ID provider, ad esempio MSSQL</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">Valori di proprietà da mostrare nel dashboard</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">Valore non valido</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2565,435 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">vuoto</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">Nascondi etichette di testo</target>
       </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">selezionare tutte le caselle di controllo nella colonna: {0}</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">Mostra etichette di testo</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">Non è stata registrata alcuna visualizzazione struttura ad albero con ID '{0}'.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">L'inizializzazione della sessione di modifica dati non è riuscita: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">Identificatore del provider di notebook.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">Indica le estensioni di file da registrare in questo provider di notebook</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">Indica i kernel che devono essere standard con questo provider di notebook</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">Aggiunge come contributo i provider di notebook.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">Nome del comando magic per la cella, ad esempio '%%sql'.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">Lingua da usare per la cella se questo comando magic è incluso nella cella</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">Destinazione di esecuzione facoltativa indicata da questo comando magic, ad esempio Spark rispetto a SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">Set facoltativo di kernel per cui è valida questa impostazione, ad esempio python3, pyspark, sql</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">Aggiunge come contributo la lingua del notebook.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">Con il tasto di scelta rapida F5 è richiesta la selezione di una cella di codice. Selezionare una cella di codice da eseguire.</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">Con Cancella risultati è richiesta la selezione di una cella di codice. Selezionare una cella di codice da eseguire.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">Numero massimo di righe:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">Seleziona visualizzazione</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">Seleziona sessione</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">Seleziona sessione:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">Seleziona visualizzazione:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Testo</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">Etichetta</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valore</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Dettagli</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">Tempo trascorso</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">Numero di righe</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} righe</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">Esecuzione della query...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">Stato esecuzione</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">Riepilogo selezioni</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">Media: {0}  Conteggio: {1}  Somma: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">Scegli linguaggio SQL</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">Cambia provider del linguaggio SQL</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">Versione del linguaggio SQL</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">Cambia provider del motore SQL</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">Esiste già una connessione che usa il motore {0}. Per cambiare, disconnettersi o cambiare connessione</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">Al momento non ci sono editor di testo attivi</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">Seleziona provider del linguaggio</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">Si è verificato un errore durante la visualizzazione del grafo Plotly: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Non è stato possibile trovare alcun renderer {0} per l'output. Include i tipi MIME seguenti: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(sicuro) </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Genera script come SELECT TOP 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Take 10</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Genera script come EXECUTE</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Genera script come ALTER</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Modifica dati</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Genera script come CREATE</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Genera script come DROP</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">È necessario passare a questo metodo un elemento NotebookProvider con providerId valido</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">È necessario passare a questo metodo un elemento NotebookProvider con providerId valido</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">non è stato trovato alcun provider di notebook</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">Non è stato trovato alcun gestore</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">Il gestore del notebook {0} non include un gestore di server. Non è possibile eseguirvi operazioni</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">Il gestore del notebook {0} non include un gestore di contenuti. Non è possibile eseguirvi operazioni</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">Il gestore del notebook {0} non include un gestore di sessioni. Non è possibile eseguirvi operazioni</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">Non è stato possibile recuperare il token dell'account di Azure per la connessione</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">Connessione non accettata</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">Annullare questa connessione?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">Chiudi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">Caricamento dei kernel...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">Modifica del kernel...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">Collega a </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">Kernel </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">Caricamento dei contesti...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Cambia connessione</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">Seleziona connessione</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">Nessun kernel</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">Cancella risultati</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">Attendibile</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">Non attendibile</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">Comprimi celle</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">Espandi celle</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">Nessuno</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Nuovo notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Trova stringa successiva</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Trova stringa precedente</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">Piano di query</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aggiorna</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">Passaggio {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">Deve essere un'opzione inclusa nell'elenco</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">Casella di selezione</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Connessione</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">Connessione</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">Tipo di connessione</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Connessioni recenti</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connessioni salvate</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">Dettagli connessione</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Connetti</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Connessioni recenti</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">Non ci sono connessioni recenti</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connessioni salvate</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">Non ci sono connessioni salvate</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">dati non disponibili</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">Albero del visualizzatore file</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">Seleziona/Deseleziona tutto</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">Da</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">Mostra filtro</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">A</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Seleziona tutto</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">Crea nuova regola firewall</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Cerca</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} risultati</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">{0} selezionati</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">Ordinamento crescente</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">Ordinamento decrescente</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">Cancella</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Annulla</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">L'indirizzo IP client non ha accesso al server. Accedere a un account Azure e creare una nuova regola del firewall per consentire l'accesso.</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">Altre informazioni sulle impostazioni del firewall</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">Regola del firewall</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">Aggiungi IP client personale </target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">Aggiungi intervallo di IP della sottorete personale</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">Opzioni del filtro</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">Tutti i file</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Caricamento</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">Non è stato possibile trovare i file di query nei percorsi seguenti:
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">Errore di caricamento...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">È necessario aggiornare le credenziali per questo account.</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">Attiva/Disattiva altro</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">Abilita il controllo automatico degli aggiornamenti. Azure Data Studio controlla periodicamente la disponibilità di aggiornamenti in modo automatico.</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">Abilitare questa opzione per scaricare e installare le nuove versioni di Azure Data Studio in background in Windows</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">Mostra le note sulla versione dopo un aggiornamento. Le note sulla versione vengono aperte in una nuova finestra del Web browser.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">Menu azione barra degli strumenti del dashboard</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">Menu del titolo della cella del notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">Menu del titolo del notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">Menu della barra degli strumenti del notebook</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">Menu azione titolo contenitore vista dataexplorer</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">Menu di scelta rapida della voce dataexplorer</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">Menu di scelta rapida elemento Esplora oggetti</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">Menu di scelta rapida dell'albero di visualizzazione della finestra di connessione</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">Menu di scelta rapida elemento griglia dati</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">Impostare i criteri di sicurezza per il download delle estensioni.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">I criteri di estensione non consentono l'installazione delle estensioni. Modificare i criteri per l'estensione e riprovare.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">L'installazione dell'estensione {0} da VSIX è stata completata. Ricaricare Azure Data Studio per abilitarla.</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">Ricaricare Azure Data Studio per completare la disinstallazione di questa estensione.</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">Ricaricare Azure Data Studio per abilitare l'estensione aggiornata.</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">Ricaricare Azure Data Studio per abilitare l'estensione in locale.</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">Ricaricare Azure Data Studio per abilitare l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">Ricaricare Azure Data Studio per disabilitare l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">Ricaricare Azure Data Studio per completare la disinstallazione dell’estensione {0}.</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">Ricaricare Azure Data Studio per abilitare l'estensione in {0}.</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">L'installazione dell'estensione {0} è stata completata. Ricaricare Azure Data Studio per abilitarla.</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">Ricaricare reload Azure Data Studio per completare la reinstallazione dell'estensione {0}.</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Marketplace</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">È necessario specificare il tipo di scenario per le estensioni consigliate.</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">Non è possibile installare l'estensione '{0}' perché non è compatibile con Azure Data Studio '{1}'.</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nuova query</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Nuova &amp;&amp;query</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Nuovo notebook</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">Controlla la memoria disponibile per Azure Data Studio dopo il riavvio durante il tentativo di aprire file di grandi dimensioni. Il risultato è uguale a quando si specifica `--max-memory=NEWSIZE` sulla riga di comando.</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">Cambiare la lingua dell'interfaccia utente di Azure Data Studio in {0} e riavviare?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">Per usare Azure Data Studio in {0}, Azure Data Studio deve essere riavviato.</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">Nuovo file SQL</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuovo notebook</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Installare l'estensione dal pacchetto VSIX</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">Deve essere un'opzione inclusa nell'elenco</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">Casella di selezione</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">Mostra notebook</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">Risultati della ricerca</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">Percorso di ricerca non trovato: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebook</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">La copia delle immagini non è supportata</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">Stato attivo su query corrente</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Esegui query</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">Esegui query corrente</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">Copia query con risultati</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">Copia della query e dei risultati completata.</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">Esegui query corrente con piano effettivo</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">Annulla query</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">Aggiorna cache IntelliSense</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">Attiva/Disattiva risultati della query</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">Alterna lo stato attivo tra la query e i risultati</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">Per consentire l'esecuzione del tasto di scelta rapida, è necessario specificare il parametro Editor</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">Analizza query</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">I comandi sono stati completati</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">Comando non riuscito: </target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">Connettersi a un server</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">Esiste già un gruppo di server con lo stesso nome.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">riuscito</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">non riuscito</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">in corso</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">non avviato</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">annullato</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">in fase di annullamento</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usato nei dashboard</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">Non è possibile visualizzare il grafico con i dati specificati</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usato nei dashboard</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usato nei dashboard</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usato nei dashboard</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">Errore durante l'apertura del collegamento: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">Errore durante l'esecuzione del comando '{0}': {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">La copia non è riuscita. Errore: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">Mostra grafico</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">Mostra tabella</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Fare doppio clic per modificare&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Aggiungere contenuto qui...&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">Si è verificato un errore durante l'aggiornamento del nodo '{0}': {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Fatto</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Genera script</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Avanti</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">Indietro</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">Le schede non sono inizializzate</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated"> è obbligatorio.</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">Input non valido. È previsto un valore numerico.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">Percorso del file di backup</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">Database di destinazione</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Ripristina</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Ripristina database</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Database</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">File di backup</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Ripristina database</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Origine</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">Ripristina da</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">Il percorso del file di backup è obbligatorio.</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">Immettere uno o più percorsi di file separati da virgole</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Database</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">Destinazione</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">Ripristina in</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">Piano di ripristino</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">Set di backup da ripristinare</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">Ripristina file di database come</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">Dettagli del file di ripristino del database</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">Nome file logico</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">Tipo di file</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">Nome file originale</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">Ripristina come</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">Opzioni di ripristino</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">Backup della parte finale del log</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">Connessioni server</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">Generale</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">File</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opzioni</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">Copia cella</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Fatto</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">Copia e apri</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">Codice utente</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">Sito Web</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">L'indice {0} non è valido.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">Descrizione del server (facoltativa)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">Proprietà avanzate</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Rimuovi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">nbformat v{0}.{1} non riconosciuto</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">Il formato di notebook di questo file non è valido</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">Il tipo di cella {0} è sconosciuto</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Il tipo di output {0} non è riconosciuto</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">I dati per {0} devono essere una stringa o una matrice di stringhe</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Il tipo di output {0} non è riconosciuto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Introduzione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Admin Pack di SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Admin Pack di SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">Admin Pack per SQL Server è una raccolta delle estensioni più usate per l'amministrazione di database per semplificare la gestione di SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Consente di scrivere ed eseguire script di PowerShell usando l'editor di query avanzato di Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">Virtualizzazione dei dati</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">Virtualizza i dati con SQL Server 2019 e crea tabelle esterne tramite procedure guidate interattive</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">È possibile connettersi, eseguire query e gestire database Postgres con Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">Il supporto per {0} è già installato.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">La finestra verrà ricaricata dopo l'installazione di supporto aggiuntivo per {0}.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">Installazione di supporto aggiuntivo per {0} in corso...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">Il supporto per {0} con ID {1} non è stato trovato.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nuova connessione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nuova query</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Nuovo notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Distribuisci un server</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Introduzione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">Nuovo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">Apri…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">Apri file…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">Apri cartella…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">Inizia la presentazione</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">Chiudi barra della presentazione</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">Visualizzare una presentazione di Azure Data Studio?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">Introduzione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">Apri la cartella {0} con percorso {1}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">Installa</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">Installa mappatura tastiera {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">Installa supporto aggiuntivo per {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Installato</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">Mappatura tastiera {0} è già installata</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">Il supporto {0} è già installato</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Dettagli</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">Colore di sfondo della pagina di benvenuto.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">Editor del profiler per il testo dell'evento. Di sola lettura</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">Non è stato possibile salvare i risultati. </target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">Scegli file di risultati</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (delimitato da virgole)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Cartella di lavoro di Excel</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">Testo normale</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">Salvataggio del file...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">I risultati sono stati salvati in {0}</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Apri file</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">Nascondi etichette di testo</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">Mostra etichette di testo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">editor del codice modelview per il modello di visualizzazione.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">Informazioni</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Avviso</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Errore</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Mostra dettagli</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copia</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Chiudi</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">Indietro</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">Nascondi dettagli</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">Account</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">Account collegati</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Chiudi</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">Non sono presenti account collegati. Aggiungere un account.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">Aggiungi un account</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">Nessun cloud abilitato. Passa a Impostazioni -&gt; Cerca configurazione dell'account Azure -&gt; Abilita almeno un cloud</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">Non è stato selezionato alcun provider di autenticazione. Riprovare.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">L'esecuzione non è riuscita a causa di un errore imprevisto: {0}	{1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">Tempo di esecuzione totale: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">L'esecuzione della query a riga {0} è stata avviata</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">Esecuzione del batch {0} avviata</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">Tempo di esecuzione del batch: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">La copia non è riuscita. Errore: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Avvia</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nuova connessione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nuova query</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Nuovo notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Apri file</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Apri file</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">Distribuisci</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">Nuova distribuzione…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">Recenti</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">Altro...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">Non ci sono cartelle recenti</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Guida</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">Attività iniziali</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentazione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">Segnala problema o invia richiesta di funzionalità</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">Repository GitHub</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">Note sulla versione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Mostra la pagina iniziale all'avvio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">Personalizza</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Estensioni</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">Download delle estensioni necessarie, tra cui il pacchetto di amministrazione di SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">Tasti di scelta rapida</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">Ricerca e personalizzazione dei comandi preferiti</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">Tema colori</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">Tutto quel che serve per configurare editor e codice nel modo desiderato</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">Informazioni</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">Trova ed esegui tutti i comandi</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">Accesso e ricerca rapida di comandi dal riquadro comandi ({0})</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">Novità della release più recente</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">Ogni mese nuovi post di blog che illustrano le nuove funzionalità</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Seguici su Twitter</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">È possibile tenersi aggiornati sull'utilizzo di Azure Data Studio nella community e parlare direttamente con i tecnici.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Connetti</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Disconnetti</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Avvia</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">Nuova sessione</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">Sospendi</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">Riprendi</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Arresta</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">Cancella dati</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">Cancellare i dati?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">Scorrimento automatico: attivato</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">Scorrimento automatico: disattivato</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">Attiva/Disattiva pannello compresso</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">Modifica colonne</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Trova la stringa successiva</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Trova la stringa precedente</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Avvia profiler</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">Filtro…</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">Cancella filtro</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">Cancellare i filtri?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">Eventi (filtrati): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">Eventi: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">Numero di eventi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">dati non disponibili</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">Risultati</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">Messaggi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">Non è stato restituito alcuno script durante la chiamata dello script di selezione sull'oggetto </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">Seleziona</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">Crea</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">Inserisci</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">Aggiorna</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Elimina</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">Non è stato restituito alcuno script durante la generazione dello script come {0} sull'oggetto {1}</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">Generazione dello script non riuscita</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">Non è stato restituito alcuno script durante la generazione dello script come {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">Colore di sfondo dell'intestazione tabella</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">Colore primo piano dell'intestazione tabella</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">Colore di sfondo dell'elenco o della tabella per l'elemento selezionato e con stato attivo quando l'elenco o la tabella è attiva</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">Colore del contorno di una cella.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">Sfondo della casella di input disabilitata.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">Primo piano della casella di input disabilitata.</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">Colore del contorno del pulsante con stato attivo.</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">Primo piano della casella di controllo disabilitato.</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">Colore di sfondo della tabella di SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">Colore di sfondo delle celle della tabella di SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">Colore di sfondo della tabella di SQL Agent al passaggio del mouse.</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">Colore di sfondo dell'intestazione di SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">Colore del bordo delle celle della tabella di SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">Colore dell'errore nei messaggi dei risultati.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">Nome del backup</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">Modello di recupero</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">Tipo di backup</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">File di backup</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">Algoritmo</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">Certificato o chiave asimmetrica</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">Supporti</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">Esegui il backup sul set di supporti esistente</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">Esegui il backup su un nuovo set di supporti</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">Accoda al set di backup esistente</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">Sovrascrivi tutti i set di backup esistenti</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">Nome del nuovo set di supporti</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">Descrizione del nuovo set di supporti</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">Esegui il checksum prima della scrittura sui supporti</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">Verifica il backup al termine</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">Continua in caso di errore</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">Scadenza</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">Imposta i giorni di mantenimento del backup</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">Backup di sola copia</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">Configurazione avanzata</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">Compressione</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">Imposta la compressione del backup</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">Crittografia</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">Log delle transazioni</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">Tronca il log delle transazioni</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">Esegui il backup della coda del log</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">Affidabilità</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">Il nome del supporto è obbligatorio</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">Non sono disponibili certificati o chiavi asimmetriche</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">Aggiungi un file</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">Rimuovi file</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">Input non valido. Il valore deve essere maggiore o uguale a 0.</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Backup</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">È supportato solo il backup su file</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">Il percorso del file di backup è obbligatorio</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">Il salvataggio dei risultati in un formato diverso è disabilitato per questo provider di dati.</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">Non è possibile serializzare i dati perché non è stato registrato alcun provider</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">La serializzazione non è riuscita e si verificato un errore sconosciuto</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">Non ci sono provider di dati registrati che possono fornire i dati della visualizzazione.</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">Colore di sfondo dell'intestazione tabella</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aggiorna</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">Colore primo piano dell'intestazione tabella</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Comprimi tutto</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">Colore di sfondo dell'elenco o della tabella per l'elemento selezionato e con stato attivo quando l'elenco o la tabella è attiva</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">Si è verificato un errore durante l'esecuzione del comando {1}: {0}. Il problema può dipendere dall'estensione che aggiunge come contributo {1}.</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">Colore del contorno di una cella.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">Sfondo della casella di input disabilitata.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">Primo piano della casella di input disabilitata.</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">Colore del contorno del pulsante con stato attivo.</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">Primo piano della casella di controllo disabilitato.</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">Colore di sfondo della tabella di SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">Colore di sfondo delle celle della tabella di SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">Colore di sfondo della tabella di SQL Agent al passaggio del mouse.</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">Colore di sfondo dell'intestazione di SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">Colore del bordo delle celle della tabella di SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">Colore dell'errore nei messaggi dei risultati.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">Selezionare la cella attiva e riprovare</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">Alcune delle estensioni caricate usano API obsolete. Per informazioni dettagliate, vedere la scheda Console della finestra Strumenti di sviluppo</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">Esegui cella</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">Annulla esecuzione</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">Si è verificato un errore durante l'ultima esecuzione. Fare clic per ripetere l'esecuzione</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Non visualizzare più questo messaggio</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">L'annullamento dell'attività non è riuscito.</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">Attiva/Disattiva altro</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Caricamento</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">Home page</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">Il contenuto della sezione "{0}" non è valido. Contattare il proprietario dell'estensione.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">Processi</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Avvisi</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">Proxy</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">Operatori</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">Proprietà server</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">Proprietà database</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">Seleziona/Deseleziona tutto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">Mostra filtro</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">Cancella</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Connessioni recenti</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Server</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">File di backup</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">Tutti i file</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">Cerca: digitare il termine di ricerca e premere INVIO per cercare oppure ESC per annullare</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Cerca</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Non è stato possibile modificare il database</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">Ultima occorrenza</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Abilitata</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">Ritardo tra le risposte (in sec)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">Nome della categoria</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">Indirizzo di posta elettronica</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Abilitata</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">Nome dell'account</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">Nome della credenziale</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrizione</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Abilitata</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">caricamento oggetti</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">caricamento database</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">caricamento oggetti completato.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">caricamento database completato.</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">Ricerca per nome di tipo (t:, v:, f: o sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">Cerca nei database</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">Non è possibile caricare gli oggetti</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">Non è possibile caricare i database</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">Caricamento delle proprietà</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">Caricamento delle proprietà completato</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">Non è possibile caricare le proprietà del dashboard</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">Caricamento di {0}</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">Caricamento di {0} completato</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">Aggiornamento automatico: disattivato</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">Ultimo aggiornamento: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">Non ci sono risultati da visualizzare</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Passaggi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Salva in formato CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Salva in formato JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Salva in formato Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Salva in formato XML</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">La codifica dei risultati non verrà salvata quando si esporta in JSON. Ricordarsi di salvare con la codifica desiderata dopo la creazione del file.</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">Il salvataggio nel file non è supportato dall'origine dati di supporto</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copia</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copia con intestazioni</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Seleziona tutto</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">Ingrandisci</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Ripristina</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Grafico</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">Visualizzatore</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">Con il tasto di scelta rapida F5 è richiesta la selezione di una cella di codice. Selezionare una cella di codice da eseguire.</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">Con Cancella risultati è richiesta la selezione di una cella di codice. Selezionare una cella di codice da eseguire.</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">ID passaggio</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Fatto</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">Nome del passaggio</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">Messaggio</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Genera script</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Avanti</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">Indietro</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">Le schede non sono inizializzate</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Trova</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">Non è stata registrata alcuna visualizzazione struttura ad albero con ID '{0}'.</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Trova</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">È necessario passare a questo metodo un elemento NotebookProvider con providerId valido</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Corrispondenza precedente</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">non è stato trovato alcun provider di notebook</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Corrispondenza successiva</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">Non è stato trovato alcun gestore</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">Il gestore del notebook {0} non include un gestore di server. Non è possibile eseguirvi operazioni</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">Il gestore del notebook {0} non include un gestore di contenuti. Non è possibile eseguirvi operazioni</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">Il gestore del notebook {0} non include un gestore di sessioni. Non è possibile eseguirvi operazioni</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">È necessario passare a questo metodo un elemento NotebookProvider con providerId valido</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gestisci</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Mostra dettagli</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">Altre informazioni</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">Cancella tutti gli account salvati</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">Funzionalità di anteprima</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">Abilita le funzionalità di anteprima non rilasciate</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">Mostra la finestra di dialogo della connessione all'avvio</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">Notifica API obsolete</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">Abilita/disabilita la notifica di utilizzo di API obsolete</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">Connessione alla sessione di modifica dati non riuscita</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">Non connesso</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">La sessione del profiler XEvent è stata arrestata in modo imprevisto nel server {0}.</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">Si è verificato un errore durante l'avvio della nuova sessione</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">Sono presenti eventi persi per la sessione del profiler XEvent per {0}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostra azioni</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visualizzatore risorse</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">Informazioni</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Avviso</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Errore</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Mostra dettagli</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copia</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">Chiudi</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">La ricerca ha restituito un numero elevato di risultati. Verranno evidenziate solo le prime 999 corrispondenze.</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">Indietro</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} di {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Nessun risultato</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">Nascondi dettagli</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">A barre orizzontali</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">A barre</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">A linee</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">A torta</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">A dispersione</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">Serie temporale</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Immagine</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">Conteggio</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">Tabella</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">Ad anello</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">Non è stato possibile recuperare le righe per il set di dati da rappresentare nel grafico.</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">Il tipo di grafico: '{0}' non è supportato.</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">Parametri</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated"> è obbligatorio.</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">Input non valido. È previsto un valore numerico.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">Connesso a</target>
-      </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
-        <target state="translated">Disconnesso</target>
-      </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">Connessioni non salvate</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">L'indice {0} non è valido.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">Sfoglia (anteprima)</target>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">vuoto</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">Digitare qui per filtrare l'elenco</target>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">selezionare tutte le caselle di controllo nella colonna: {0}</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">Filtra connessioni</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">Applicazione filtro</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">Rimozione filtro</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">Filtro applicato</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">Filtro rimosso</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connessioni salvate</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Connessioni salvate</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">Albero del visualizzatore connessioni</target>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostra azioni</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Questa estensione è consigliata da Azure Data Studio.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Caricamento</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Caricamento completato</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Non visualizzare più questo messaggio</target>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">Valore non valido</target>
       </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio include estensioni consigliate.</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio include estensioni consigliate per la visualizzazione dei dati.
-Una volta installato, è possibile selezionare l'icona del visualizzatore per visualizzare i risultati della query.</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">Installa tutto</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Mostra elementi consigliati</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">È necessario specificare il tipo di scenario per le estensioni consigliate.</target>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}. {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">Questa pagina delle funzionalità è in anteprima. Le funzionalità in anteprima introducono nuove funzionalità che stanno per diventare una parte permanente del prodotto. Sono stabili, ma richiedono ulteriori miglioramenti per l'accessibilità. Apprezziamo il feedback iniziale degli utenti mentre sono in fase di sviluppo.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Caricamento in corso</target>
       </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">Anteprima</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">Crea una connessione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">Connettersi a un'istanza di database tramite la finestra di dialogo di connessione.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">Esegui una query</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">Interagire con i dati tramite un editor di query.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">Crea un notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">Creare un nuovo notebook usando un editor di notebook nativo.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Distribuisci un server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">Crea una nuova istanza di un servizio dati relazionale nella piattaforma scelta.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">Risorse</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">Cronologia</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">Posizione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">Mostra di più</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Mostra la pagina iniziale all'avvio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">Collegamenti utili</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">Attività iniziali</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Scopri le funzionalità offerte da Azure Data Studio e impara a sfruttarle al meglio.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentazione</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">Visitare il centro documentazione per guide di avvio rapido, guide pratiche e riferimenti per PowerShell, API e così via.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Panoramica di Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Introduzione ai notebook di Azure Data Studio | Dati esposti</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Estensioni</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">Mostra tutto</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">Altre informazioni </target>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Caricamento completato</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">Data di creazione: </target>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">editor del codice modelview per il modello di visualizzazione.</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Errore del notebook: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">Non è stato possibile trovare il componente per il tipo {0}</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">Errore del processo: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">La modifica dei tipi di editor per file non salvati non è supportata</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">Aggiunta</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Genera script come SELECT TOP 1000</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">Esecuzioni recenti</target>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Take 10</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">Esecuzioni precedenti</target>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Genera script come EXECUTE</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Genera script come ALTER</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Modifica dati</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Genera script come CREATE</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Genera script come DROP</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">Non è stato restituito alcuno script durante la chiamata dello script di selezione sull'oggetto </target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">Seleziona</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">Crea</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">Inserisci</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Elimina</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">Non è stato restituito alcuno script durante la generazione dello script come {0} sull'oggetto {1}</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">Generazione dello script non riuscita</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">Non è stato restituito alcuno script durante la generazione dello script come {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
+        <target state="translated">disconnesso</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
+        <target state="translated">Estensione</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">Colore di sfondo della scheda attiva per le schede verticali</target>
+      </trans-unit>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">Colore per i bordi nel dashboard</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">Colore del titolo del widget del dashboard</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">Colore per il sottotesto del widget del dashboard</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">Colore per i valori delle proprietà visualizzati nel componente del contenitore delle proprietà</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">Colore per i nomi proprietà visualizzati nel componente del contenitore delle proprietà</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">Colore ombra overflow barra degli strumenti</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">Identificatore del tipo di account</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(Facoltativa) Icona usata per rappresentare l'account nell'interfaccia utente. Percorso di file o configurazione che supporta i temi</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Percorso dell'icona quando viene usato un tema chiaro</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Percorso dell'icona quando viene usato un tema scuro</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">Aggiunge come contributo le icone al provider di account.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">Visualizza regole applicabili</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">Visualizza regole applicabili per {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">Richiama valutazione</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">Richiama valutazione per {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">Esporta come script</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">Visualizza tutte le regole e altre informazioni su GitHub</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">Crea report HTML</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">Il report è stato salvato. Aprirlo?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Apri</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Una volta installato, è possibile selezionare l'icona del visualizzatore per vi
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">Il database {0} è totalmente conforme alle procedure consigliate. Ottimo lavoro!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Grafico</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">Operazione</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">Oggetto</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">Costo stimato</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">Costo sottoalbero stimato</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">Righe effettive</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">Righe stimate</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">Esecuzioni effettive</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">Costo CPU stimato</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">Costo IO stimato</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">In parallelo</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">Riassociazioni effettive</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">Riassociazioni stimate</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">Ripristini effettivi</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">Ripristini stimati</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">Partizionato</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">Operazioni più frequenti</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">Non sono state trovate connessioni.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">Aggiungi connessione</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">Aggiungi un account...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Predefinito&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Caricamento...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">Gruppo di server</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Predefinito&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">Aggiungi nuovo gruppo...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;Non salvare&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} è obbligatorio.</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0} verrà tagliato.</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">Memorizza password</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">Account</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">Aggiorna credenziali dell'account</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Tenant di Azure AD</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">Nome (facoltativo)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">Avanzate...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">È necessario selezionare un account</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Database</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">File e filegroup</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">Completo</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">Differenziale</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">Log delle transazioni</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">Disco</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">Usa l'impostazione predefinita del server</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">Comprimi il backup</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">Non comprimere il backup</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">Certificato del server</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">Chiave asimmetrica</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">Non è stata aperta alcuna cartella contenente notebook/libri. </target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">Apri notebook</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">Il set di risultati contiene solo un subset di tutte le corrispondenze. Eseguire una ricerca più specifica per ridurre il numero di risultati.</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">Ricerca in corso - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">Non sono stati trovati risultati in '{0}' escludendo '{1}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">Non sono stati trovati risultati in '{0}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">Non sono stati trovati risultati escludendo '{0}' - </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">Non sono stati trovati risultati. Rivedere le impostazioni relative alle esclusioni configurate e verificare i file gitignore -</target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">Cerca di nuovo</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Annulla ricerca</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">Cerca di nuovo in tutti i file</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">Apri impostazioni</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">La ricerca ha restituito {0} risultati in {1} file</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">Attiva/Disattiva Comprimi ed espandi</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Annulla ricerca</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">Espandi tutto</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Comprimi tutto</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">Cancella risultati della ricerca</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Connessioni</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">È possibile connettersi, eseguire query e gestire le connessioni da SQL Server, Azure e altro ancora.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Avanti</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">Iniziare a creare il proprio notebook o la propria raccolta di notebook in un'unica posizione.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Estensioni</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Estendere le funzionalità di Azure Data Studio installando le estensioni sviluppate da Microsoft e dalla community di terze parti.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Impostazioni</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">Personalizzare Azure Data Studio in base alle proprie preferenze. È possibile configurare impostazioni come il salvataggio automatico e le dimensioni delle schede, personalizzare i tasti di scelta rapida e scegliere il tema colori preferito.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">Pagina iniziale</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">Individuare le funzionalità principali, i file aperti di recente e le estensioni consigliate nella pagina iniziale. Per altre informazioni su come iniziare a usare Azure Data Studio, vedere i video e la documentazione.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">Fine</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">Presentazione iniziale</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">Nascondi presentazione iniziale</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">Altre informazioni</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Guida</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">Elimina riga</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">Ripristina la riga corrente</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Una volta installato, è possibile selezionare l'icona del visualizzatore per vi
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">Pannello dei messaggi</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copia</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">Copia tutto</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">Apri nel portale di Azure</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Caricamento</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">Nome del backup</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Caricamento completato</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">Modello di recupero</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">Tipo di backup</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">File di backup</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">Algoritmo</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">Certificato o chiave asimmetrica</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">Supporti</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">Esegui il backup sul set di supporti esistente</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">Esegui il backup su un nuovo set di supporti</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">Accoda al set di backup esistente</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">Sovrascrivi tutti i set di backup esistenti</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">Nome del nuovo set di supporti</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">Descrizione del nuovo set di supporti</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">Esegui il checksum prima della scrittura sui supporti</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">Verifica il backup al termine</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">Continua in caso di errore</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">Scadenza</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">Imposta i giorni di mantenimento del backup</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">Backup di sola copia</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">Configurazione avanzata</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">Compressione</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">Imposta la compressione del backup</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">Crittografia</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">Log delle transazioni</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">Tronca il log delle transazioni</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">Esegui il backup della coda del log</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">Affidabilità</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">Il nome del supporto è obbligatorio</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">Non sono disponibili certificati o chiavi asimmetriche</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">Aggiungi un file</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">Rimuovi file</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">Input non valido. Il valore deve essere maggiore o uguale a 0.</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Backup</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">È supportato solo il backup su file</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">Il percorso del file di backup è obbligatorio</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">Fare clic su</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ Codice</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">o</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ Testo</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">per aggiungere una cella di testo o codice</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Backup</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">STDIN:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">Per usare il backup, è necessario abilitare le funzionalità di anteprima</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">Il comando Backup non è supportato all'esterno di un contesto di database. Selezionare un database e riprovare.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">Il comando di backup non è supportato per i database SQL di Azure.</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Backup</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">Espandi contenuto cella codice</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Database</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">Comprimi contenuto cella di codice</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">File e filegroup</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">Completo</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">Differenziale</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">Log delle transazioni</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">Disco</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">Usa l'impostazione predefinita del server</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">Comprimi il backup</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">Non comprimere il backup</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">Certificato del server</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">Chiave asimmetrica</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">Showplan XML</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">Griglia dei risultati</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Aggiungi cella</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Cella di codice</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Cella di testo</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">Sposta cella in basso</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">Sposta cella in alto</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Elimina</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Aggiungi cella</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Cella di codice</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Cella di testo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">Errore del kernel SQL</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">Per eseguire le celle del notebook, è necessario scegliere una connessione</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">Visualizzazione delle prime {0} righe.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Ultima esecuzione</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Prossima esecuzione</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Abilitata</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Stato</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Categoria</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">Eseguibile</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">Pianificazione</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Risultati ultima esecuzione</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Esecuzioni precedenti</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Non sono disponibili passaggi per questo processo.</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Errore: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">Non è stato possibile trovare il componente per il tipo {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Trova</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Trova</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Risultato precedente</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Risultato successivo</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Chiudi</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">La ricerca ha restituito un numero elevato di risultati. Verranno evidenziate solo le prime 999 corrispondenze.</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} di {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Nessun risultato</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">Schema</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Esegui query</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Non è stato possibile trovare alcun renderer {0} per l'output. Include i tipi MIME seguenti: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">sicuro </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">Non è stato possibile trovare alcun componente per il selettore {0}</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">Si è verificato un errore durante il rendering del componente: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Caricamento...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Caricamento...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Modifica</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">Esci</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Aggiorna</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostra azioni</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">Elimina widget</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">Fare clic per rimuovere</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">Fare clic per aggiungere</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">Apri funzionalità installate</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">Comprimi widget</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">Espandi widget</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} è un contenitore sconosciuto.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Database di destinazione</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Ultima esecuzione</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Prossima esecuzione</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Stato</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Risultati ultima esecuzione</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Esecuzioni precedenti</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Non sono disponibili passaggi per questo processo.</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Errore: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Errore del notebook: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">Errore di caricamento...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostra azioni</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">Non sono stati trovati elementi corrispondenti</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">Elenco di ricerca filtrato per 1 elemento</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">Elenco di ricerca filtrato per {0} elementi</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">Non riuscito</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">Riuscito</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">Riprova</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">Annullato</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">In corso</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">Stato sconosciuto</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">In esecuzione</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">In attesa del thread</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">Tra tentativi</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">Inattivo</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">Sospeso</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[Obsoleto]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sì</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">No</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">Non pianificato</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">Mai eseguito</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">Grassetto</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">Corsivo</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">Sottolineato</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">Evidenziazione</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Codice</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">Collegamento</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">Elenco</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">Elenco ordinato</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Immagine</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Disattivazione anteprima Markdown</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">Intestazione</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">Intestazione 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">Intestazione 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">Intestazione 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">Paragrafo</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">Inserire il collegamento</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">Inserisci immagine</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">Visualizzazione RTF</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">Doppia visualizzazione</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Visualizzazione Markdown</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">Crea dati analitici</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">Non è possibile creare i dati analitici perché l'editor attivo non è un editor SQL</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">Widget personale</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">Configura grafico</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">Copia come immagine</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">Non è stato possibile trovare il grafico da salvare</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">Salva come immagine</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">Grafico salvato nel percorso: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Una volta installato, è possibile selezionare l'icona del visualizzatore per vi
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Grafico</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">A barre orizzontali</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">A barre</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">A linee</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">A torta</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">A dispersione</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">Serie temporale</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Immagine</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">Conteggio</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">Tabella</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">Ad anello</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">Non è stato possibile recuperare le righe per il set di dati da rappresentare nel grafico.</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">Il tipo di grafico: '{0}' non è supportato.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Grafici predefiniti</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">Numero massimo di righe per i grafici da visualizzare. Avviso: l'aumento di questo valore può influire sulle prestazioni.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">Chiudi</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">Esiste già un gruppo di server con lo stesso nome.</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">Serie {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">La tabella non contiene un'immagine valida</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">È stato superato il numero massimo di righe per i grafici predefiniti. Vengono usate solo {0} prime righe. Per configurare il valore, è possibile aprire le impostazioni utente e cercare: 'builtinCharts.maxRowCount'.</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Non visualizzare più questo messaggio</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">Connessione: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">Esecuzione del comando: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">Apertura della nuova query: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">Non è possibile connettersi perché non sono state fornite informazioni sul server</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">Non è stato possibile aprire l'URL a causa dell'errore {0}</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">Verrà eseguita la connessione al server {0}</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">Connettersi?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">&amp;&amp;Apri</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">Connessione del file di query</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">{0} è stato sostituito con {1} nelle impostazioni utente.</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">{0} è stato sostituito con {1} nelle impostazioni dell'area di lavoro.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">Numero massimo di connessioni usate di recente da archiviare nell'elenco delle connessioni.</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">Motore SQL predefinito da usare. Stabilisce il provider del linguaggio predefinito nei file con estensione sql e il valore predefinito da usare quando si crea una nuova connessione.</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">Prova ad analizzare il contenuto degli appunti quando si apre la finestra di dialogo di connessione o si esegue un'operazione Incolla.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">Stato della connessione</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">ID comune del provider</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">Nome visualizzato del provider</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">Alias del kernel del notebook per il provider</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">Percorso dell'icona per il tipo di server</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">Opzioni per la connessione</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">Nome visibile dell'utente per il provider dell'albero</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">L'ID del provider deve essere lo stesso di quando si registra il provider di dati dell'albero e deve iniziare con 'connectionDialog/'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">Identificatore univoco per questo contenitore.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">Contenitore che verrà visualizzato nella scheda.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">Aggiunge come contributo uno o più container di dashboard che gli utenti possono aggiungere al proprio dashboard.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">Nel container di dashboard non è stato specificato alcun ID per l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">Nel container di dashboard non è stato specificato alcun contenitore per l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Per ogni spazio è necessario definire un solo container di dashboard.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">Nel container di dashboard è stato definito un tipo di contenitore sconosciuto per l'estensione.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">controlhost che verrà visualizzato in questa scheda.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">Il contenuto della sezione "{0}" non è valido. Contattare il proprietario dell'estensione.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">Elenco dei widget o delle webview che verranno visualizzati in questa scheda.</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">i widget o le webview devono trovarsi nel contenitore dei widget per l'estensione.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">Visualizzazione basata su modello che verrà visualizzata in questa scheda.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificatore univoco per questa sezione di spostamento. Verrà passato all'estensione per eventuali richieste.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Facoltativa) Icona usata per rappresentare la sezione di spostamento nell'interfaccia utente. Percorso di file o configurazione che supporta i temi</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Percorso dell'icona quando viene usato un tema chiaro</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Percorso dell'icona quando viene usato un tema scuro</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">Titolo della sezione di spostamento da mostrare all'utente.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">Contenitore che verrà visualizzato in questa sezione di spostamento.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">Elenco di container di dashboard che verrà visualizzato in questa sezione di spostamento.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">Nella sezione di spostamento non è stato specificato alcun titolo per l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">Nella sezione di spostamento non è stato specificato alcun contenitore per l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Per ogni spazio è necessario definire un solo container di dashboard.</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">Un elemento NAV_SECTION all'interno di un altro elemento NAV_SECTION non è un contenitore valido per l'estensione.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">Webview che verrà visualizzata in questa scheda.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">Elenco dei widget che verranno visualizzati in questa scheda.</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">L'elenco dei widget deve trovarsi all'interno del contenitore dei widget per l'estensione.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Modifica</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">Esci</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostra azioni</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">Elimina widget</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">Fare clic per rimuovere</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">Fare clic per aggiungere</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">Apri funzionalità installate</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">Comprimi widget</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">Espandi widget</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} è un contenitore sconosciuto.</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Una volta installato, è possibile selezionare l'icona del visualizzatore per vi
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">Crea dati analitici</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificatore univoco per questa scheda. Verrà passato all'estensione per eventuali richieste.</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">Non è possibile creare i dati analitici perché l'editor attivo non è un editor SQL</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">Titolo della scheda da mostrare all'utente.</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">Widget personale</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">Descrizione di questa scheda che verrà mostrata all'utente.</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">Configura grafico</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Condizione che deve essere vera per mostrare questo elemento</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">Copia come immagine</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">Definisce i tipi di connessione con cui è compatibile questa scheda. Se non viene impostato, il valore predefinito è 'MSSQL'</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">Non è stato possibile trovare il grafico da salvare</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">Contenitore che verrà visualizzato in questa scheda.</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">Salva come immagine</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">Indica se questa scheda deve essere sempre visualizzata oppure solo quando viene aggiunta dall'utente.</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">Indica se questa scheda deve essere usata come scheda iniziale per un tipo di connessione.</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">Grafico salvato nel percorso: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">Identificatore univoco del gruppo a cui appartiene questa scheda, valore per il gruppo home: home.</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Facoltativo) Icona usata per rappresentare questa scheda nell'interfaccia utente. Percorso di file o configurazione che supporta i temi</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Percorso dell'icona quando viene usato un tema chiaro</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Percorso dell'icona quando viene usato un tema scuro</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">Aggiunge come contributo una o più schede che gli utenti possono aggiungere al proprio dashboard.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">Non è stato specificato alcun titolo per l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">Non è stata specificata alcuna descrizione da mostrare.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">Non è stato specificato alcun contenitore per l'estensione.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">Per ogni spazio è necessario definire un solo container di dashboard</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">Identificatore univoco per questo gruppo di schede.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">Titolo del gruppo di schede.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">Fornisce uno o più gruppi di schede che gli utenti possono aggiungere al proprio dashboard.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">Nessun ID specificato per il gruppo di schede.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">Nessun titolo specificato per il gruppo di schede.</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">Amministrazione</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">Monitoraggio</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">Prestazioni</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">Sicurezza</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">Risoluzione dei problemi</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Impostazioni</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">scheda database</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">Database</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">Aggiungi codice</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gestisci</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">Aggiungi testo</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Dashboard</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">Crea file</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gestisci</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">Non è stato possibile visualizzare il contenuto: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">la proprietà `icon` può essere omessa o deve essere una stringa o un valore letterale come `{dark, light}`</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Aggiungi cella</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">Definisce una proprietà da mostrare nel dashboard</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Cella di codice</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">Indica il valore da usare come etichetta per la proprietà</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Cella di testo</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">Indica il valore nell'oggetto per accedere al valore</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">Esegui tutti</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">Specifica i valori da ignorare</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">Cella</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">Valore predefinito da mostrare se l'impostazione viene ignorata o non viene indicato alcun valore</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Codice</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">Versione per la definizione delle proprietà del dashboard</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Testo</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">ID della versione</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">Esegui celle</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">Condizione per usare questa versione</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; Indietro</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">Campo da usare per il confronto</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">Avanti &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">Indica l'operatore da usare per il confronto</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">la cella con URI {0} non è stata trovata in questo modello</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">Valore con cui confrontare il campo</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">Comando Esegui celle non riuscito. Per altre informazioni, vedere l'errore nell'output della cella attualmente selezionata.</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">Proprietà da mostrare per la pagina del database</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">Proprietà da mostrare per la pagina del server</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">Definisce se questo provider supporta il dashboard</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">ID provider, ad esempio MSSQL</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">Valori di proprietà da mostrare nel dashboard</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Condizione che deve essere vera per mostrare questo elemento</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">Indica se nascondere l'intestazione del widget. Il valore predefinito è false</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">Titolo del contenitore</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">Riga del componente nella griglia</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">rowspan del componente nella griglia. Il valore predefinito è 1. Usare '*' per impostare sul numero di righe della griglia.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">Colonna del componente nella griglia</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">colspan del componente nella griglia. Il valore predefinito è 1. Usare '*' per impostare sul numero di colonne della griglia.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificatore univoco per questa scheda. Verrà passato all'estensione per eventuali richieste.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">La scheda dell'estensione è sconosciuta o non è installata.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">Proprietà database</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Abilita o disabilita il widget delle proprietà</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valori di proprietà da mostrare</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nome visualizzato della proprietà</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">Valore nell'oggetto informazioni database</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">Specifica i valori da ignorare</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">Modello di recupero</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">Ultimo backup del database</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">Ultimo backup del log</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">Livello di compatibilità</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Proprietario</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">Personalizza la pagina del dashboard del database</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Cerca</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">Personalizza le schede del dashboard del database</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">Proprietà server</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Abilita o disabilita il widget delle proprietà</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valori di proprietà da mostrare</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nome visualizzato della proprietà</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">Valore nell'oggetto informazioni server</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versione</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">Edizione</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">Nome del computer</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">Versione del sistema operativo</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Cerca</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">Personalizza la pagina del dashboard del server</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">Personalizza le schede del dashboard del server</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">Home page</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Non è stato possibile modificare il database</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostra azioni</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">Non sono stati trovati elementi corrispondenti</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">Elenco di ricerca filtrato per 1 elemento</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">Elenco di ricerca filtrato per {0} elementi</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">Schema</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">caricamento oggetti</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">caricamento database</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">caricamento oggetti completato.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">caricamento database completato.</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">Ricerca per nome di tipo (t:, v:, f: o sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">Cerca nei database</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">Non è possibile caricare gli oggetti</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">Non è possibile caricare i database</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Esegui query</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">Caricamento di {0}</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">Caricamento di {0} completato</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">Aggiornamento automatico: disattivato</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">Ultimo aggiornamento: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">Non ci sono risultati da visualizzare</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">Aggiunge un widget in grado di eseguire una query su un server o un database e di visualizzare i risultati in vari modi, ovvero sotto forma di grafico, conteggio riepilogativo e altro ancora</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">Identificatore univoco usato per memorizzare nella cache i risultati dei dati analitici.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">Query SQL da eseguire. Dovrebbe restituire esattamente un solo set di risultati.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[Facoltativa] Percorso di un file contenente una query. Usare se 'query' non è impostato</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[Facoltativa] Intervallo di aggiornamento automatico in minuti. Se non è impostato, non verrà eseguito alcun aggiornamento automatico</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">Indica le azioni da usare</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Database di destinazione per l'azione. È possibile usare il formato '${columnName}' per specificare un nome di colonna basata sui dati.</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Server di destinazione per l'azione. È possibile usare il formato '${columnName}' per specificare un nome di colonna basata sui dati.</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Utente di destinazione per l'azione. È possibile usare il formato '${columnName}' per specificare un nome di colonna basata sui dati.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">Identificatore dei dati analitici</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">Aggiunge come contributo i dati analitici al pannello del dashboard.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">Non è possibile visualizzare il grafico con i dati specificati</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">Visualizza i risultati di una query sotto forma di grafico nel dashboard</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">Esegue il mapping di 'nome colonna' al colore. Ad esempio, aggiungere 'column1': red se si vuole usare il colore rosso per questa colonna </target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">Indica la posizione preferita e la visibilità della legenda del grafico. Questi sono i nomi di colonna estratti dalla query e associati all'etichetta di ogni voce del grafico</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">Se dataDirection è impostato su horizontal e si imposta questa opzione su true, per la legenda viene usato il primo valore di ogni colonna.</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">Se dataDirection è impostato su vertical e si imposta questa opzione su true, per la legenda vengono usati i nomi delle colonne.</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">Definisce se i dati vengono letti da una colonna (vertical) o da una riga (horizontal). Per la serie temporale questa impostazione viene ignorata perché la direzione deve essere verticale.</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">Se è impostato showTopNData, vengono visualizzati solo i primi N dati del grafico.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Valore minimo dell'asse Y</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Valore massimo dell'asse Y</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Etichetta per l'asse Y</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">Valore minimo dell'asse X</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">Valore massimo dell'asse X</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">Etichetta per l'asse X</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">Indica la proprietà dati di un set di dati per un grafico.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">Per ogni colonna in un set di risultati mostra il valore nella riga 0 sotto forma di numero seguito dal nome della colonna. Ad esempio '1 Attivi', '3 Disabilitati', dove 'Attivi' è il nome della colonna e 1 è il valore presente a riga 1 cella 1</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">Visualizza un'immagine, ad esempio una restituita da una query R che usa ggplot2</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">Indica se il formato previsto è JPEG, PNG o di altro tipo.</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">Indica se viene codificato come hex, base64 o in un altro formato.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">Visualizza i risultati in una tabella semplice</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">Caricamento delle proprietà</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">Caricamento delle proprietà completato</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">Non è possibile caricare le proprietà del dashboard</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">Connessioni di database</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">connessioni a origine dati</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">gruppi di origine dati</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">Le connessioni salvate vengono ordinate in base alle date aggiunte.</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">Le connessioni salvate vengono ordinate in base ai rispettivi nomi visualizzati in ordine alfabetico.</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">Controllare l'ordinamento delle connessioni salvate e dei gruppi di connessioni.</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">Configurazione di avvio</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">È true se all'avvio di Azure Data Studio deve essere visualizzata la visualizzazione Server (impostazione predefinita); è false se deve essere visualizzata l'ultima visualizzazione aperta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">Identificatore della visualizzazione. Usare questa impostazione per registrare un provider di dati tramite l'API `vscode.window.registerTreeDataProviderForView`, nonché per avviare l'attivazione dell'estensione tramite la registrazione dell'evento `onView:${id}` in `activationEvents`.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Nome leggibile della visualizzazione. Verrà visualizzato</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">Condizione che deve essere vera per mostrare questa visualizzazione</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">Aggiunge come contributo le visualizzazioni all'editor</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">Aggiunge come contributo le visualizzazioni al contenitore Esplora dati nella barra attività</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">Aggiunge come contributo le visualizzazioni al contenitore delle visualizzazioni aggiunto come contributo</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">Non è possibile registrare più visualizzazioni con stesso ID `{0}` nel contenitore di visualizzazioni `{1}`</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">Una visualizzazione con ID `{0}` è già registrata nel contenitore di visualizzazioni `{1}`</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">le visualizzazioni devono essere una matrice</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">la proprietà `{0}` è obbligatoria e deve essere di tipo `string`</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">la proprietà `{0}` può essere omessa o deve essere di tipo `string`</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Connessioni</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">Mostra connessioni</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Disconnetti</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">Mostra riquadro Modifica dati SQL all'avvio</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Esegui</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">Modifica del metodo Dispose non riuscita. Errore: </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Arresta</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">Mostra riquadro SQL</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">Chiudi riquadro SQL</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">Numero massimo di righe:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">Elimina riga</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">Ripristina la riga corrente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Salva in formato CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Salva in formato JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Salva in formato Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Salva in formato XML</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copia</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copia con intestazioni</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Seleziona tutto</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">Schede del dashboard ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Titolo</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrizione</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">Dati analitici dashboard ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">Quando</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">Recupera informazioni sull'estensione dalla raccolta</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">ID estensione</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">L'estensione '{0}' non è stata trovata.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Mostra elementi consigliati</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">Installa estensioni</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">Crea un'estensione...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Non visualizzare più questo messaggio</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio include estensioni consigliate.</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio include estensioni consigliate per la visualizzazione dei dati.
+Una volta installato, è possibile selezionare l'icona del visualizzatore per visualizzare i risultati della query.</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">Installa tutto</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Mostra elementi consigliati</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">È necessario specificare il tipo di scenario per le estensioni consigliate.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Questa estensione è consigliata da Azure Data Studio.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">Processi</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Avvisi</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">Proxy</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">Operatori</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">Ultima occorrenza</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Abilitata</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">Ritardo tra le risposte (in sec)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">Nome della categoria</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Errore: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">Visualizza regole applicabili</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">ID passaggio</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">Visualizza regole applicabili per {0}</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">Nome del passaggio</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">Richiama valutazione</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">Richiama valutazione per {0}</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">Esporta come script</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">Visualizza tutte le regole e altre informazioni su GitHub</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">Crea report HTML</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">Il report è stato salvato. Aprirlo?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Apri</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Annulla</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">Messaggio</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">Dati</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Connessione</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor di query</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Dashboard</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Passaggi</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">Schede del dashboard ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">Titolo</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrizione</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">Dati analitici dashboard ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">Quando</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Ultima esecuzione</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Prossima esecuzione</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Abilitata</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Stato</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Categoria</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">Eseguibile</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">Pianificazione</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Risultati ultima esecuzione</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Esecuzioni precedenti</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Non sono disponibili passaggi per questo processo.</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Errore: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">La tabella non contiene un'immagine valida</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">Data di creazione: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Errore del notebook: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">Errore del processo: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">Aggiunta</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">Esecuzioni recenti</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">Esecuzioni precedenti</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">Altro</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Modifica</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Database di destinazione</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Chiudi</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Ultima esecuzione</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">Converti cella</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Prossima esecuzione</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">Esegui celle sopra</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Stato</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">Esegui celle sotto</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Risultati ultima esecuzione</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">Inserisci codice sopra</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Esecuzioni precedenti</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">Inserisci codice sotto</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Non sono disponibili passaggi per questo processo.</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">Inserisci testo sopra</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Errore: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">Inserisci testo sotto</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">Comprimi cella</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">Espandi cella</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">Crea cella parametri</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">Rimuovi cella parametri</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">Cancella risultato</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Errore del notebook: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">Si è verificato un errore durante l'avvio della sessione del notebook</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">Il server non è stato avviato per motivi sconosciuti</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">Indirizzo di posta elettronica</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">Il kernel {0} non è stato trovato. Verrà usato il kernel predefinito.</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Abilitata</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">Serie {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">Nome dell'account</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Chiudi</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">Nome della credenziale</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="it">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated">N. parametri inseriti
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrizione</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">Selezionare una connessione per eseguire le celle per questo kernel</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">Non è stato possibile eliminare la cella.</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">Non è stato possibile modificare il kernel. Verrà usato il kernel {0}. Errore: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">Non è stato possibile modificare il kernel a causa dell'errore: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">La modifica del contesto non è riuscita: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">Non è stato possibile avviare la sessione: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">Si è verificato un errore della sessione client durante la chiusura del notebook: {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">Non è possibile trovare il gestore di notebook per il provider {0}</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Abilitata</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Errore: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">Altro</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Modifica</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Chiudi</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">Converti cella</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">Esegui celle sopra</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">Esegui celle sotto</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">Inserisci codice sopra</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">Inserisci codice sotto</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">Inserisci testo sopra</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">Inserisci testo sotto</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">Comprimi cella</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">Espandi cella</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">Crea cella parametri</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">Rimuovi cella parametri</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">Cancella risultato</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Aggiungi cella</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Cella di codice</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Cella di testo</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">Sposta cella in basso</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">Sposta cella in alto</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Elimina</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Aggiungi cella</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Cella di codice</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Cella di testo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">Parametri</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">Selezionare la cella attiva e riprovare</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">Esegui cella</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">Annulla esecuzione</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">Si è verificato un errore durante l'ultima esecuzione. Fare clic per ripetere l'esecuzione</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">Espandi contenuto cella codice</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">Comprimi contenuto cella di codice</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">Grassetto</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">Corsivo</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">Sottolineato</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">Evidenziazione</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Codice</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">Collegamento</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">Elenco</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">Elenco ordinato</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Immagine</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Disattivazione anteprima Markdown</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">Intestazione</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">Intestazione 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">Intestazione 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">Intestazione 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">Paragrafo</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">Inserire il collegamento</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">Inserisci immagine</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">Visualizzazione RTF</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Doppia visualizzazione</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Visualizzazione Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Non è stato possibile trovare alcun renderer {0} per l'output. Include i tipi MIME seguenti: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">sicuro </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">Non è stato possibile trovare alcun componente per il selettore {0}</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">Si è verificato un errore durante il rendering del componente: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">Fare clic su</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ Codice</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">o</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ Testo</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">per aggiungere una cella di testo o codice</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">Aggiungere cella di codice</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">Aggiungi una cella di testo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">STDIN:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Fare doppio clic per modificare&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Aggiungere contenuto qui...&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Trova</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Trova</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Corrispondenza precedente</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Corrispondenza successiva</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Chiudi</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">La ricerca ha restituito un numero elevato di risultati. Verranno evidenziate solo le prime 999 corrispondenze.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} di {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Nessun risultato</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">Aggiungi codice</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">Aggiungi testo</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">Crea file</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">Non è stato possibile visualizzare il contenuto: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Aggiungi cella</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Cella di codice</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Cella di testo</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">Esegui tutti</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">Cella</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Codice</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Testo</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">Esegui celle</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; Indietro</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">Avanti &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">la cella con URI {0} non è stata trovata in questo modello</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Comando Esegui celle non riuscito. Per altre informazioni, vedere l'errore nell'output della cella attualmente selezionata.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuovo notebook</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuovo notebook</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">Imposta area di lavoro e apri</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">Kernel SQL: arresta l'esecuzione di Notebook quando si verifica un errore in una cella.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(Anteprima) mostrare tutti i kernel per il provider di notebook corrente.</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">Consentire ai notebook di eseguire i comandi di Azure Data Studio.</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">Abilitare il doppio clic per modificare le celle di testo nei notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">Il testo viene visualizzato come testo RTF, noto anche come WYSIWYG.</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">Markdown visualizzato a sinistra, con un'anteprima del testo di cui è stato eseguito il rendering a destra.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">Il testo viene visualizzato come Markdown.</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">Modalità di modifica predefinita usata per le celle di testo</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(Anteprima) Salvare il nome della connessione nei metadati del notebook.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">Controlla l'altezza della riga usata nell'anteprima Markdown del notebook. Questo numero è relativo alle dimensioni del carattere.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(Anteprima) Visualizzare il notebook di cui è eseguito il rendering nell'editor diff.</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">Numero massimo di modifiche archiviate nella cronologia di annullamento per l'editor di testo RTF del notebook.</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">Cerca nei notebook</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">Consente di configurare i criteri GLOB per escludere file e cartelle nelle ricerche full-text e in Quick Open. Eredita tutti i criteri GLOB dall'impostazione `#files.exclude#`. Per altre informazioni sui criteri GLOB, fare clic [qui](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">Criterio GLOB da usare per trovare percorsi file. Impostare su True o False per abilitare o disabilitare il criterio.</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">Controllo aggiuntivo sugli elementi di pari livello di un file corrispondente. Usare $(basename) come variabile del nome file corrispondente.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">Questa impostazione è deprecata. Verrà ora eseguito il fallback a "search.usePCRE2".</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">Deprecata. Per il supporto della funzionalità avanzate delle espressioni regex provare a usare "search.usePCRE2".</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">Se abilitato, il processo searchService verrà mantenuto attivo invece di essere arrestato dopo un'ora di inattività. In questo modo la cache di ricerca dei file rimarrà in memoria.</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Controlla se utilizzare i file `.gitignore` e `.ignore` durante la ricerca di file.</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Controlla se usare i file `.gitignore` e `.ignore` globali durante la ricerca di file.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">Indica se includere i risultati di una ricerca di simboli globale nei risultati dei file per Quick Open.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">Indica se includere i risultati di file aperti di recente nel file dei risultati per Quick Open.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">Le voci della cronologia sono ordinate per pertinenza in base al valore di filtro usato. Le voci più pertinenti vengono visualizzate per prime.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">Le voci della cronologia sono ordinate in base alla data. Le voci aperte più di recente vengono visualizzate per prime.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">Controlla l'ordinamento della cronologia dell'editor in Quick Open quando viene applicato il filtro.</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">Controlla se seguire i collegamenti simbolici durante la ricerca.</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">Esegue la ricera senza fare distinzione tra maiuscole/minuscole se il criterio è tutto minuscolo, in caso contrario esegue la ricerca facendo distinzione tra maiuscole/minuscole.</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">Controlla se il viewlet di ricerca deve leggere o modificare gli appunti di ricerca condivisi in macOS.</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">Controlla se la ricerca verrà mostrata come visualizzazione nella barra laterale o come pannello nell'area pannelli per ottenere più spazio orizzontale.</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">Questa impostazione è deprecata. Usare il menu di scelta rapida della visualizzazione di ricerca.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">I file con meno di 10 risultati vengono espansi. Gli altri vengono compressi.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">Controlla se i risultati della ricerca verranno compressi o espansi.</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">Controlla se aprire Anteprima sostituzione quando si seleziona o si sostituisce una corrispondenza.</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">Controlla se visualizzare i numeri di riga per i risultati della ricerca.</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">Indica se usare il motore regex PCRE2 nella ricerca di testo. In questo modo è possibile usare alcune funzionalità avanzate di regex, come lookahead e backreference. Non sono però supportate tutte le funzionalità di PCRE2, ma solo quelle supportate anche da JavaScript.</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">Deprecata. PCRE2 verrà usato automaticamente se si usano funzionalità regex supportate solo da PCRE2.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">Posiziona la barra azioni a destra quando la visualizzazione di ricerca è stretta e subito dopo il contenuto quando la visualizzazione di ricerca è ampia.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">Posiziona sempre la barra azioni a destra.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">Controlla il posizionamento in righe della barra azioni nella visualizzazione di ricerca.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">Cerca in tutti i file durante la digitazione.</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">Abilita il seeding della ricerca a partire dalla parola più vicina al cursore quando non ci sono selezioni nell'editor attivo.</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">Aggiorna la query di ricerca dell'area di lavoro in base al testo selezionato dell'editor quando lo stato attivo si trova nella visualizzazione di ricerca. Si verifica in caso di clic o quando si attiva il comando `workbench.views.search.focus`.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">Se `#search.searchOnType#` è abilitato, controlla il timeout in millisecondi tra la digitazione di un carattere e l'avvio della ricerca. Non ha effetto quando `search.searchOnType` è disabilitato.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">Facendo doppio clic viene selezionata la parola sotto il cursore.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">Facendo doppio clic il risultato viene aperto nel gruppo di editor attivo.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">Facendo doppio clic il risultato viene aperto nel gruppo di editor laterale e viene creato un gruppo se non esiste ancora.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">Configura l'effetto del doppio clic su un risultato nell'editor della ricerca.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">I risultati vengono visualizzati in ordine alfabetico in base ai nomi di file e cartella.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">I risultati vengono visualizzati in ordine alfabetico in base ai nomi file ignorando l'ordine delle cartelle.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">I risultati vengono visualizzati in ordine alfabetico in base all'estensione del file.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">I risultati vengono visualizzati in ordine decrescente in base alla data dell'ultima modifica del file.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">I risultati vengono visualizzati in ordine decrescente in base al conteggio per file.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">I risultati vengono visualizzati in ordine crescente in base al conteggio per file.</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">Controlla l'ordinamento dei risultati della ricerca.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">Caricamento dei kernel...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">Modifica del kernel...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">Collega a </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">Kernel </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">Caricamento dei contesti...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Cambia connessione</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">Seleziona connessione</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">Nessun kernel</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Questo notebook non può essere eseguito con parametri perché il kernel non è supportato. Usare i kernel e il formato supportati. [Altre informazioni] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Il notebook non può essere eseguito con parametri finché non viene aggiunta una cella di parametri. [Altre informazioni] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Il notebook non può essere eseguito con parametri finché non vengono aggiunti parametri alla cella dei parametri. [Altre informazioni] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">Cancella risultati</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">Attendibile</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">Non attendibile</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">Comprimi celle</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">Espandi celle</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">Esegui con parametri</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">Nessuno</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Nuovo notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Trova stringa successiva</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Trova stringa precedente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">Risultati della ricerca</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">Percorso di ricerca non trovato: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">Non è stata aperta alcuna cartella contenente notebook/libri. </target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">Apri notebook</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">Il set di risultati contiene solo un subset di tutte le corrispondenze. Eseguire una ricerca più specifica per ridurre il numero di risultati.</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">Ricerca in corso - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">Non sono stati trovati risultati in '{0}' escludendo '{1}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">Non sono stati trovati risultati in '{0}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">Non sono stati trovati risultati escludendo '{0}' - </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">Non sono stati trovati risultati. Rivedere le impostazioni relative alle esclusioni configurate e verificare i file gitignore -</target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">Cerca di nuovo</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">Cerca di nuovo in tutti i file</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">Apri impostazioni</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">La ricerca ha restituito {0} risultati in {1} file</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">Attiva/Disattiva Comprimi ed espandi</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">Annulla ricerca</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">Espandi tutto</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Comprimi tutto</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">Cancella risultati della ricerca</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">Cerca: digitare il termine di ricerca e premere INVIO per cercare oppure ESC per annullare</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Cerca</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">la cella con URI {0} non è stata trovata in questo modello</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Comando Esegui celle non riuscito. Per altre informazioni, vedere l'errore nell'output della cella attualmente selezionata.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">Eseguire questa cella per visualizzare gli output.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">Questa vista è vuota. Aggiungere una cella a questa vista facendo clic sul pulsante Inserisci celle.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">La copia non è riuscita. Errore: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">Mostra grafico</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">Mostra tabella</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Non è stato possibile trovare alcun renderer {0} per l'output. Include i tipi MIME seguenti: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(sicuro) </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">Si è verificato un errore durante la visualizzazione del grafo Plotly: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">Non sono state trovate connessioni.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">Aggiungi connessione</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">Tavolozza dei colori del gruppo di server usata nel viewlet Esplora oggetti.</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">Espande automaticamente i gruppi di server nel viewlet di Esplora oggetti.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(Anteprima) Usare il nuovo albero del server asincrono per la visualizzazione Server e la finestra di dialogo di connessione con il supporto di nuove funzionalità come i filtri dinamici dei nodi.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">Dati</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Connessione</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Editor di query</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Dashboard</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Grafici predefiniti</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">Specifica i modelli di visualizzazione</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">Specifica i modelli di sessione</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Filtri profiler</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Connetti</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Disconnetti</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Avvia</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">Nuova sessione</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">Sospendi</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">Riprendi</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Arresta</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">Cancella dati</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">Cancellare i dati?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">Scorrimento automatico: attivato</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">Scorrimento automatico: disattivato</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">Attiva/Disattiva pannello compresso</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">Modifica colonne</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Trova la stringa successiva</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Trova la stringa precedente</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Avvia profiler</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">Filtro…</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">Cancella filtro</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">Cancellare i filtri?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">Seleziona visualizzazione</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">Seleziona sessione</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">Seleziona sessione:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">Seleziona visualizzazione:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Testo</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">Etichetta</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valore</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Dettagli</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Trova</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Trova</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Risultato precedente</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Risultato successivo</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Chiudi</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">La ricerca ha restituito un numero elevato di risultati. Verranno evidenziate solo le prime 999 corrispondenze.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} di {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Nessun risultato</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">Editor del profiler per il testo dell'evento. Di sola lettura</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">Eventi (filtrati): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">Eventi: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">Numero di eventi</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Salva in formato CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Salva in formato JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Salva in formato Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Salva in formato XML</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">La codifica dei risultati non verrà salvata quando si esporta in JSON. Ricordarsi di salvare con la codifica desiderata dopo la creazione del file.</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">Il salvataggio nel file non è supportato dall'origine dati di supporto</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copia</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copia con intestazioni</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Seleziona tutto</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">Ingrandisci</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Ripristina</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Grafico</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">Visualizzatore</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">Scegli linguaggio SQL</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">Cambia provider del linguaggio SQL</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">Versione del linguaggio SQL</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">Cambia provider del motore SQL</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">Esiste già una connessione che usa il motore {0}. Per cambiare, disconnettersi o cambiare connessione</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">Al momento non ci sono editor di testo attivi</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">Seleziona provider del linguaggio</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">Showplan XML</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">Griglia dei risultati</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">È stato superato il numero massimo di righe per il filtraggio o l'ordinamento. Per aggiornarlo, è possibile passare alle impostazioni utente e modificare l'impostazione 'queryEditor.results.inMemoryDataProcessingThreshold'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">Stato attivo su query corrente</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Esegui query</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">Esegui query corrente</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">Copia query con risultati</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">Copia della query e dei risultati completata.</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">Esegui query corrente con piano effettivo</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">Annulla query</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">Aggiorna cache IntelliSense</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">Attiva/Disattiva risultati della query</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">Alterna lo stato attivo tra la query e i risultati</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">Per consentire l'esecuzione del tasto di scelta rapida, è necessario specificare il parametro Editor</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">Analizza query</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">I comandi sono stati completati</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">Comando non riuscito: </target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">Connettersi a un server</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">Pannello dei messaggi</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copia</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">Copia tutto</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">Risultati query</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nuova query</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Editor di query</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">Se è impostata su true, le intestazioni di colonna vengono incluse quando si salvano i risultati in formato CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">Delimitatore personalizzato da usare tra i valori quando si salvano i risultati in formato CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">Caratteri usati per delimitare le righe quando si salvano i risultati in formato CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">Carattere usato per racchiudere i campi di testo quando si salvano i risultati in formato CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">Codifica di file usata quando si salvano i risultati in formato CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">Quando è true, l'output XML verrà formattato quando si salvano i risultati in formato XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">Codifica di file usata quando si salvano i risultati in formato XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">Abilita lo streaming dei risultati. Contiene alcuni problemi minori relativi a oggetti visivi</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">Opzioni di configurazione per la copia di risultati dalla Visualizzazione risultati</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">Opzioni di configurazione per la copia di risultati su più righe dalla visualizzazione risultati</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(Sperimentale) Usare una tabella ottimizzata per la visualizzazione dei risultati. Alcune funzionalità potrebbero mancare e sono in lavorazione.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">Controlla il numero massimo di righe consentite per l'applicazione di filtri e ordinamento in memoria. Se il numero viene superato, l'ordinamento e il filtro verranno disabilitati. Avviso: l'aumento di questo valore può influire sulle prestazioni.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">Indica se aprire il file in Azure Data Studio dopo il salvataggio del risultato.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">Indicare se visualizzare il tempo di esecuzione per singoli batch</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">Messaggi con ritorno a capo automatico</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">Tipo di grafico predefinito da usare quando si apre il visualizzatore grafico dai risultati di una query</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">La colorazione delle schede verrà disabilitata</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">Al bordo superiore di ogni scheda verrà applicato il colore del gruppo di server pertinente</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">Il colore di sfondo di ogni scheda dell'editor sarà uguale a quello del gruppo di server pertinente</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">Controlla come colorare le schede in base al gruppo di server della connessione attiva</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">Controlla se visualizzare le informazioni sulla connessione per una scheda nel titolo.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">Richiede di salvare i file SQL generati</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">Impostare l'associazione dei tasti workbench.action.query.shortcut{0} per eseguire il testo del collegamento come chiamata di routine o esecuzione di query. Il testo selezionato nell'editor di query verrà passato come parametro alla fine della query oppure è possibile fare riferimento a esso con {arg}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nuova query</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Esegui</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">Spiega</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">Effettivo</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Disconnetti</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Cambia connessione</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Connetti</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">Abilita SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">Disabilita SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Seleziona database</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Non è stato possibile modificare il database</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">Non è stato possibile modificare il database: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">Esporta come notebook</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">Risultati</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">Messaggi</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">Tempo trascorso</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">Numero di righe</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} righe</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">Esecuzione della query...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">Stato esecuzione</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">Riepilogo selezioni</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">Media: {0}  Conteggio: {1}  Somma: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">Messaggi e griglia dei risultati</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">Controlla la famiglia di caratteri.</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">Controlla lo spessore del carattere.</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">Controlla le dimensioni del carattere in pixel.</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">Controlla la spaziatura tra le lettere in pixel.</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">Controlla l'altezza delle righe in pixel</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">Controlla la spaziatura interna celle in pixel</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">Ridimensiona automaticamente la larghezza delle colonne sui risultati iniziali. Potrebbero verificarsi problemi di prestazioni con un numero elevato di colonne o celle di grandi dimensioni</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">Larghezza massima in pixel per colonne con ridimensionamento automatico</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">Attiva/Disattiva cronologia delle query</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Elimina</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Cancella tutta la cronologia</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">Apri query</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Esegui query</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">Attiva/Disattiva acquisizione della cronologia delle query</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Sospendi acquisizione della cronologia delle query</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Avvia acquisizione della cronologia delle query</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">riuscito</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">non riuscito</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">Non ci sono query da visualizzare.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">Cronologia delle query</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">Cronologia query</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">Indica se l'acquisizione della cronologia delle query è abilitata. Se è false, le query eseguite non verranno acquisite.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Cancella tutta la cronologia</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Sospendi acquisizione della cronologia delle query</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Avvia acquisizione della cronologia delle query</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Visualizza</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Cronologia delle query</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">Cronologia delle query</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">Piano di query</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">Operazione</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">Oggetto</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">Costo stimato</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">Costo sottoalbero stimato</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">Righe effettive</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">Righe stimate</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">Esecuzioni effettive</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">Costo CPU stimato</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">Costo IO stimato</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">In parallelo</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">Riassociazioni effettive</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">Riassociazioni stimate</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">Ripristini effettivi</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">Ripristini stimati</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">Partizionato</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">Operazioni più frequenti</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visualizzatore risorse</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">Errore durante l'apertura del collegamento: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">Errore durante l'esecuzione del comando '{0}': {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">Albero del visualizzatore risorse</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">Identificatore della risorsa.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Nome leggibile della visualizzazione. Verrà visualizzato</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">Percorso dell'icona della risorsa.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">Fornisce una risorsa alla visualizzazione risorse</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">la proprietà `{0}` è obbligatoria e deve essere di tipo `string`</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">la proprietà `{0}` può essere omessa o deve essere di tipo `string`</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Ripristina</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Ripristina</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">Per usare il ripristino, è necessario abilitare le funzionalità di anteprima</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">Il comando Ripristina non è supportato all'esterno di un contesto del server. Selezionare un server o un database e riprovare.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">Il comando di ripristino non è supportato per i database SQL di Azure.</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Ripristina</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Genera script come CREATE</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Genera script come DROP</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Genera script come SELECT TOP 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Genera script come EXECUTE</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Genera script come ALTER</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Modifica dati</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Genera script come SELECT TOP 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Take 10</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Genera script come CREATE</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Genera script come EXECUTE</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Genera script come ALTER</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Genera script come DROP</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">Si è verificato un errore durante l'aggiornamento del nodo '{0}': {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} attività in corso</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Visualizza</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">Attività</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Attività</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">Attiva/Disattiva attività</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">riuscito</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">non riuscito</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">in corso</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">non avviato</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">annullato</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">in fase di annullamento</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">Non è disponibile alcuna cronologia attività da visualizzare.</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">Cronologia attività</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">Errore attività</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">Impossibile annullare l'attività.</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">Non ci sono provider di dati registrati che possono fornire i dati della visualizzazione.</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Comprimi tutto</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">Si è verificato un errore durante l'esecuzione del comando {1}: {0}. Il problema può dipendere dall'estensione che aggiunge come contributo {1}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Chiudi</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">Le funzionalità in anteprima consentono di migliorare l'esperienza in Azure Data Studio offrendo accesso completo a nuove funzionalità e miglioramenti. Per altre informazioni sulle funzionalità in anteprima, vedere [qui] ({0}). Abilitare le funzionalità in anteprima?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">Sì (scelta consigliata)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">Non visualizzare più questo messaggio</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">Questa pagina delle funzionalità è in anteprima. Le funzionalità in anteprima introducono nuove funzionalità che stanno per diventare una parte permanente del prodotto. Sono stabili, ma richiedono ulteriori miglioramenti per l'accessibilità. Apprezziamo il feedback iniziale degli utenti mentre sono in fase di sviluppo.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">Anteprima</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">Crea una connessione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">Connettersi a un'istanza di database tramite la finestra di dialogo di connessione.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">Esegui una query</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">Interagire con i dati tramite un editor di query.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">Crea un notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">Creare un nuovo notebook usando un editor di notebook nativo.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Distribuisci un server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">Crea una nuova istanza di un servizio dati relazionale nella piattaforma scelta.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">Risorse</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">Cronologia</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">Posizione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">Mostra di più</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Mostra la pagina iniziale all'avvio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">Collegamenti utili</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">Attività iniziali</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Scopri le funzionalità offerte da Azure Data Studio e impara a sfruttarle al meglio.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentazione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">Visitare il centro documentazione per guide di avvio rapido, guide pratiche e riferimenti per PowerShell, API e così via.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">Video</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Panoramica di Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Introduzione ai notebook di Azure Data Studio | Dati esposti</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Estensioni</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">Mostra tutto</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">Altre informazioni </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Connessioni</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">È possibile connettersi, eseguire query e gestire le connessioni da SQL Server, Azure e altro ancora.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Avanti</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">Iniziare a creare il proprio notebook o la propria raccolta di notebook in un'unica posizione.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Estensioni</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Estendere le funzionalità di Azure Data Studio installando le estensioni sviluppate da Microsoft e dalla community di terze parti.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Impostazioni</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">Personalizzare Azure Data Studio in base alle proprie preferenze. È possibile configurare impostazioni come il salvataggio automatico e le dimensioni delle schede, personalizzare i tasti di scelta rapida e scegliere il tema colori preferito.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">Pagina iniziale</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">Individuare le funzionalità principali, i file aperti di recente e le estensioni consigliate nella pagina iniziale. Per altre informazioni su come iniziare a usare Azure Data Studio, vedere i video e la documentazione.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">Fine</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">Presentazione iniziale</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">Nascondi presentazione iniziale</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">Altre informazioni</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Guida</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Introduzione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Admin Pack di SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Admin Pack di SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">Admin Pack per SQL Server è una raccolta delle estensioni più usate per l'amministrazione di database per semplificare la gestione di SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server Agent</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">Importazione di SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server Dacpac</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Consente di scrivere ed eseguire script di PowerShell usando l'editor di query avanzato di Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">Virtualizzazione dei dati</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">Virtualizza i dati con SQL Server 2019 e crea tabelle esterne tramite procedure guidate interattive</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">È possibile connettersi, eseguire query e gestire database Postgres con Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">Il supporto per {0} è già installato.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">La finestra verrà ricaricata dopo l'installazione di supporto aggiuntivo per {0}.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">Installazione di supporto aggiuntivo per {0} in corso...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">Il supporto per {0} con ID {1} non è stato trovato.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nuova connessione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nuova query</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Nuovo notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Distribuisci un server</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Introduzione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">Nuovo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">Apri…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">Apri file…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">Apri cartella…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">Inizia la presentazione</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">Chiudi barra della presentazione</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">Visualizzare una presentazione di Azure Data Studio?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">Introduzione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">Apri la cartella {0} con percorso {1}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Installa</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">Installa mappatura tastiera {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">Installa supporto aggiuntivo per {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">Installato</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">Mappatura tastiera {0} è già installata</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">Il supporto {0} è già installato</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Dettagli</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">Colore di sfondo della pagina di benvenuto.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Avvia</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nuova connessione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nuova query</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Nuovo notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Apri file</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Apri file</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">Distribuisci</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">Nuova distribuzione…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Recenti</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">Altro...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">Non ci sono cartelle recenti</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Guida</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">Attività iniziali</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentazione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">Segnala problema o invia richiesta di funzionalità</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">Repository GitHub</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">Note sulla versione</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Mostra la pagina iniziale all'avvio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">Personalizza</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Estensioni</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">Download delle estensioni necessarie, tra cui il pacchetto di amministrazione di SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">Tasti di scelta rapida</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">Ricerca e personalizzazione dei comandi preferiti</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">Tema colori</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">Tutto quel che serve per configurare editor e codice nel modo desiderato</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">Informazioni</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">Trova ed esegui tutti i comandi</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">Accesso e ricerca rapida di comandi dal riquadro comandi ({0})</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">Novità della release più recente</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">Ogni mese nuovi post di blog che illustrano le nuove funzionalità</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Seguici su Twitter</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">È possibile tenersi aggiornati sull'utilizzo di Azure Data Studio nella community e parlare direttamente con i tecnici.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">Account</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">Account collegati</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Chiudi</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">Non sono presenti account collegati. Aggiungere un account.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">Aggiungi un account</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">Nessun cloud abilitato. Passa a Impostazioni -&gt; Cerca configurazione dell'account Azure -&gt; Abilita almeno un cloud</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">Non è stato selezionato alcun provider di autenticazione. Riprovare.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Errore di aggiunta account</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">È necessario aggiornare le credenziali per questo account.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Chiudi</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">Aggiunta dell'account...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">L'aggiornamento dell'account è stato annullato dall'utente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Account Azure</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Tenant di Azure</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">Copia e apri</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">Codice utente</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">Sito Web</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">Non è possibile avviare un OAuth automatico perché ne è già in corso uno.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">Per interagire con adminservice, è richiesta la connessione</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Non ci sono gestori registrati</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">Per interagire con il servizio valutazione è necessaria una connessione</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Non ci sono gestori registrati</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">Proprietà avanzate</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Rimuovi</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">Descrizione del server (facoltativa)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">Cancella elenco</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">L'elenco delle connessioni recenti è stato cancellato</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">Eliminare tutte le connessioni dall'elenco?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Elimina</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">Ottieni la stringa di connessione corrente</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">La stringa di connessione non è disponibile</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">Non sono disponibili connessioni attive</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Sfoglia</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">Digitare qui per filtrare l'elenco</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">Filtra connessioni</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">Applicazione filtro</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">Rimozione filtro</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">Filtro applicato</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">Filtro rimosso</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Connessioni salvate</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Connessioni salvate</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">Albero del visualizzatore connessioni</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">Errore di connessione</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">La connessione non è riuscita a causa di un errore di Kerberos.</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">Le informazioni sulla configurazione di Kerberos sono disponibili all'indirizzo {0}</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">Se si è già eseguita la connessione, può essere necessario eseguire di nuovo kinit.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Connessione</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">Connessione</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">Tipo di connessione</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Recenti</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">Dettagli connessione</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Connetti</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Connessioni recenti</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">Non ci sono connessioni recenti</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">Non è stato possibile recuperare il token dell'account di Azure per la connessione</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">Connessione non accettata</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">Annullare questa connessione?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">Aggiungi un account...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Predefinito&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Caricamento...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">Gruppo di server</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Predefinito&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">Aggiungi nuovo gruppo...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;Non salvare&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} è obbligatorio.</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0} verrà tagliato.</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">Memorizza password</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">Account</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">Aggiorna credenziali dell'account</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Tenant di Azure AD</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">Nome (facoltativo)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">Avanzate...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">È necessario selezionare un account</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">Connesso a</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">Disconnesso</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">Connessioni non salvate</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">Apri le estensioni del dashboard</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">Al momento non sono installate estensioni del dashboard. Passare a Gestione estensioni per esplorare le estensioni consigliate.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">Passaggio {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Fatto</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">L'inizializzazione della sessione di modifica dati non è riuscita: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Chiudi</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Azione</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">Copia dettagli</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Errore</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Avviso</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">Informazioni</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">Ignora</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">Percorso selezionato</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">File di tipo</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Rimuovi</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">Seleziona un file</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">Albero del visualizzatore file</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">Si è verificato un errore durante il caricamento del visualizzatore file.</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">Errore del visualizzatore file</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">Tutti i file</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">Copia cella</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">Non è stato passato alcun profilo di connessione al riquadro a comparsa dei dati analitici</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">Errore nei dati analitici</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">Si è verificato un errore durante la lettura del file di query: </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">Si è verificato un errore durante l'analisi della configurazione dei dati analitici. Non è stato possibile trovare la matrice/stringa di query o il file di query</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">Elemento</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valore</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">Dettagli delle informazioni dettagliate</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">Proprietà</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valore</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">Dati analitici</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">Elementi</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">Dettagli elemento</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">Non è stato possibile trovare i file di query nei percorsi seguenti:
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">Non riuscito</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">Riuscito</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">Riprova</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">Annullato</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">In corso</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">Stato sconosciuto</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">In esecuzione</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">In attesa del thread</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">Tra tentativi</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">Inattivo</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">Sospeso</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[Obsoleto]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">Non pianificato</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">Mai eseguito</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">Per interagire con JobManagementService, è richiesta la connessione</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Non ci sono gestori registrati</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Errore: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">Si è verificato un errore durante l'avvio della sessione del notebook</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">Il server non è stato avviato per motivi sconosciuti</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">Il kernel {0} non è stato trovato. Verrà usato il kernel predefinito.</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="it">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Errore: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="it">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="it">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">La modifica dei tipi di editor per file non salvati non è supportata</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated">N. parametri inseriti
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">Selezionare una connessione per eseguire le celle per questo kernel</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">Non è stato possibile eliminare la cella.</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">Non è stato possibile modificare il kernel. Verrà usato il kernel {0}. Errore: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">Non è stato possibile modificare il kernel a causa dell'errore: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">La modifica del contesto non è riuscita: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">Non è stato possibile avviare la sessione: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">Si è verificato un errore della sessione client durante la chiusura del notebook: {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">Non è possibile trovare il gestore di notebook per il provider {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">Non è stato passato alcun URI durante la creazione di un gestore di notebook</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">Il provider di notebook non esiste</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">Una vista con il nome {0} esiste già in questo notebook.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">Errore del kernel SQL</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">Per eseguire le celle del notebook, è necessario scegliere una connessione</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">Visualizzazione delle prime {0} righe.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">RTF</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Doppia visualizzazione</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">nbformat v{0}.{1} non riconosciuto</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">Il formato di notebook di questo file non è valido</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">Il tipo di cella {0} è sconosciuto</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Il tipo di output {0} non è riconosciuto</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">I dati per {0} devono essere una stringa o una matrice di stringhe</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Il tipo di output {0} non è riconosciuto</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">Identificatore del provider di notebook.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">Indica le estensioni di file da registrare in questo provider di notebook</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">Indica i kernel che devono essere standard con questo provider di notebook</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">Aggiunge come contributo i provider di notebook.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">Nome del comando magic per la cella, ad esempio '%%sql'.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">Lingua da usare per la cella se questo comando magic è incluso nella cella</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">Destinazione di esecuzione facoltativa indicata da questo comando magic, ad esempio Spark rispetto a SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">Set facoltativo di kernel per cui è valida questa impostazione, ad esempio python3, pyspark, sql</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">Aggiunge come contributo la lingua del notebook.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Caricamento...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Aggiorna</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">Modifica connessione</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Disconnetti</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">Nuova connessione</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">Nuovo gruppo di server</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">Modifica gruppo di server</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">Mostra connessioni attive</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">Mostra tutte le connessioni</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">Elimina connessione</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">Elimina gruppo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">Non è stato possibile creare la sessione di Esplora oggetti</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">Più errori:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">Non è possibile eseguire l'espansione perché il provider di connessione richiesto '{0}' non è stato trovato</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">Annullato dall'utente</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">Finestra di dialogo del firewall annullata</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Caricamento...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Connessioni recenti</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Server</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">Ordina per evento</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">Ordina per colonna</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">Cancella tutto</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Applica</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">Filtri</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">Rimuovi questa clausola</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">Salva filtro</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">Carica filtro</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">Aggiungi una clausola</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">Campo</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">Operatore</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valore</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">È Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">Non è Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">Contiene</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">Non contiene</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">Inizia con</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">Non inizia con</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">Commit della riga non riuscito: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">Esecuzione della query iniziata a </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">Esecuzione della query "{0}" avviata</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">Riga {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">Annullamento della query non riuscito: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">Aggiornamento della cella non riuscito: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">L'esecuzione non è riuscita a causa di un errore imprevisto: {0}	{1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">Tempo di esecuzione totale: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">L'esecuzione della query a riga {0} è stata avviata</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">Esecuzione del batch {0} avviata</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">Tempo di esecuzione del batch: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">La copia non è riuscita. Errore: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">Non è stato possibile salvare i risultati. </target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">Scegli file di risultati</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (delimitato da virgole)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Cartella di lavoro di Excel</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">Testo normale</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">Salvataggio del file...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">I risultati sono stati salvati in {0}</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Apri file</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">Da</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">A</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">Crea nuova regola firewall</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">L'indirizzo IP client non ha accesso al server. Accedere a un account Azure e creare una nuova regola del firewall per consentire l'accesso.</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">Altre informazioni sulle impostazioni del firewall</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">Regola del firewall</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">Aggiungi IP client personale </target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">Aggiungi intervallo di IP della sottorete personale</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Errore di aggiunta account</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">Errore della regola del firewall</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">Percorso del file di backup</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">Database di destinazione</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Ripristina</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Ripristina database</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Database</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">File di backup</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Ripristina database</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Origine</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">Ripristina da</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">Il percorso del file di backup è obbligatorio.</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">Immettere uno o più percorsi di file separati da virgole</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Database</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">Destinazione</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">Ripristina in</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">Piano di ripristino</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">Set di backup da ripristinare</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">Ripristina file di database come</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">Dettagli del file di ripristino del database</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">Nome file logico</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">Tipo di file</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">Nome file originale</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">Ripristina come</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">Opzioni di ripristino</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">Backup della parte finale del log</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">Connessioni server</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">Generale</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">File</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Opzioni</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">File di backup</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">Tutti i file</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">Gruppi di server</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Annulla</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">Nome del gruppo di server</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">Il nome del gruppo è obbligatorio.</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">Descrizione gruppo</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">Colore del gruppo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">Aggiungi gruppo di server</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">Modifica gruppo di server</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">Sono in corso una o più attività. Uscire comunque?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sì</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">No</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="it">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">Attività iniziali</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">Mostra introduzione</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Introduzione</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ja/admin-tool-ext-win.ja.xlf
+++ b/resources/xlf/ja/admin-tool-ext-win.ja.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/ja/agent.ja.xlf
+++ b/resources/xlf/ja/agent.ja.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">新しいスケジュール</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">キャンセル</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">スケジュール名</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">スケジュール</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">プロキシの作成</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">プロキシの編集</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">全般</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">プロキシ名</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">資格情報名</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">説明</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">サブシステム</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">オペレーティング システム (CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">レプリケーション スナップショット</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">レプリケーション トランザクション ログ リーダー</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">レプリケーション ディストリビューター</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">レプリケーション マージ</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">レプリケーション キュー リーダー</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">SQL Server Analysis Services クエリ</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">SQL Server Analysis Services コマンド</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">SQL Server Integration Services パッケージ</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">次のサブシステムに対してアクティブ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">ジョブ スケジュール</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">利用可能なスケジュール:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">説明</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">演算子の作成</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">演算子の編集</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">全般</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">通知</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">有効</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">電子メール名</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">ポケットベル電子メール名</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">月曜日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">火曜日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">水曜日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">木曜日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">金曜日  </target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">土曜日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">日曜日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">始業時刻</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">終業時刻</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">ポケットベルの受信スケジュール</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">アラートの一覧</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">アラート名</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">電子メール</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">ポケットベル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">全般</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">ジョブ スケジュール</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">ステップ</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">スケジュール</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">アラート</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">利用可能なスケジュール:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">通知</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">ジョブの名前を空白にすることはできません。</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">名前</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">所有者</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">ID</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">カテゴリ</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">説明</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">有効</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">ジョブ ステップの一覧</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">ステップ</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">種類</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">成功時</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">失敗時</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">新しいステップ</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">ステップの編集</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">ステップの削除</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">ステップを上に移動</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">ステップを下に移動</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">ステップの開始</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">ジョブ完了時に実行するアクション</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">電子メール</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">ページ</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">Windows アプリケーション イベント ログに書き込む</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">自動的にジョブを削除</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">スケジュールの一覧</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">スケジュールを選択</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">スケジュール名</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">アラート一覧</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">新しいアラート</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">アラート名</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">有効</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">種類</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">新しいジョブ</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">ジョブの編集</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">送信する付加的な通知メッセージ</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">応答間の遅延</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">遅延 (分)</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">演算子の作成</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">演算子の編集</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">全般</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">通知</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">有効</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">電子メール名</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">ポケットベル電子メール名</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">月曜日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">火曜日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">水曜日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">木曜日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">金曜日  </target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">土曜日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">日曜日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">始業時刻</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">終業時刻</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">ポケットベルの受信スケジュール</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">アラートの一覧</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">アラート名</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">電子メール</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">ポケットベル</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">プロキシの更新に失敗しました '{0}'</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">全般</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">プロキシ '{0}' が正常に更新されました</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">ステップ</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">プロキシ '{0}' が正常に作成されました</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">スケジュール</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">アラート</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">通知</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">ジョブの名前を空白にすることはできません。</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">所有者</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">カテゴリ</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">説明</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">有効</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">ジョブ ステップの一覧</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">ステップ</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">種類</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">成功時</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">失敗時</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">新しいステップ</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">ステップの編集</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">ステップの削除</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">ステップを上に移動</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">ステップを下に移動</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">ステップの開始</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">ジョブ完了時に実行するアクション</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">電子メール</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">ページ</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">Windows アプリケーション イベント ログに書き込む</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">自動的にジョブを削除</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">スケジュールの一覧</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">スケジュールを選択</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">スケジュールの削除</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">アラート一覧</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">新しいアラート</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">アラート名</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">有効</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">種類</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">新しいジョブ</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">ジョブの編集</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">ステップの更新に失敗しました '{0}'</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">ジョブ名を指定する必要があります</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">ステップ名を指定する必要があります</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">ステップの更新に失敗しました '{0}'</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">ジョブ名を指定する必要があります</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">ステップ名を指定する必要があります</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">この機能は開発中です。最新の変更内容を試す場合には、最新のインサイダー ビルドをご確認ください。</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">テンプレートが正常に更新されました</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">テンプレートの更新エラー</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">ノートブックは、スケジュールする前に保存する必要があります。保存してから、もう一度スケジュールを再試行してください。</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">新しい接続の追加</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">接続の選択</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">有効な接続を選択してください。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">この機能は開発中です。最新の変更内容を試す場合には、最新のインサイダー ビルドをご確認ください。</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">プロキシの作成</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">プロキシの編集</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">全般</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">プロキシ名</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">資格情報名</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">説明</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">サブシステム</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">オペレーティング システム (CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">レプリケーション スナップショット</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">レプリケーション トランザクション ログ リーダー</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">レプリケーション ディストリビューター</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">レプリケーション マージ</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">レプリケーション キュー リーダー</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">SQL Server Analysis Services クエリ</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">SQL Server Analysis Services コマンド</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">SQL Server Integration Services パッケージ</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">プロキシの更新に失敗しました '{0}'</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">プロキシ '{0}' が正常に更新されました</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">プロキシ '{0}' が正常に作成されました</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">新しいノートブック ジョブ</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">ノートブック ジョブの編集</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">全般</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">ノートブックの詳細</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">ノートブックのパス</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">記憶域のデータベース</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">実行データベース</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">データベースの選択</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">ジョブの詳細</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">所有者</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">スケジュールの一覧</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">スケジュールの選択</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">スケジュールの削除</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">説明</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">PC からスケジュールするノートブックを選択する</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">すべてのノートブック ジョブのメタデータと結果を格納するデータベースを選択します</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">ノートブックのクエリを実行するデータベースを選択します</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">ノートブックが完了した場合</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">ノートブックが失敗した場合</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">ノートブックが成功した場合</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">ノートブック名を指定する必要があります</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">テンプレート パスを指定する必要があります</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">無効なノートブック パス</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">ストレージ データベースの選択</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">実行データベースの選択</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">同様の名前のジョブが既に存在しています。</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">ノートブックの更新に失敗しました '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">ノートブックの作成に失敗しました '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">ノートブック '{0}' が正常に更新されました</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">ノートブック '{0}' が正常に作成されました</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ja/azurecore.ja.xlf
+++ b/resources/xlf/ja/azurecore.ja.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">アカウント {0} ({1}) サブスクリプション {2} ({3}) テナント {4} のリソース グループの取り込みでエラーが発生しました: {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">アカウント {0} ({1}) サブスクリプション {2} ({3}) テナント {4} の場所の取り込みでエラーが発生しました: {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">無効なクエリ</target>
@@ -379,7 +383,7 @@
         <target state="translated">SQL Server - Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
         <target state="translated">Azure Arc 対応 PostgreSQL Hyperscale</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
@@ -411,7 +415,7 @@
         <target state="translated">Azure 認証で不明なエラーが発生しました</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">ID '{0}' の指定されたテナントが見つかりません。</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,7 +423,7 @@
         <target state="translated">認証で何かが失敗したか、またはトークンがシステムから削除されています。アカウントを Azure Data Studio にもう一度追加してください。</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">トークンの取得がエラーで失敗しました。開発者ツールを開いてエラーを表示してください</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">アカウント {0} の資格情報を取得できませんでした。アカウント ダイアログに移動して、アカウントを更新してください。</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">このアカウントからの要求は抑えられています。再試行するには、より小さいサブスクリプション数を選択してください。</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">Azure リソースの読み込み中にエラーが発生しました: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Azure Data Explorer クラスター</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ja/big-data-cluster.ja.xlf
+++ b/resources/xlf/ja/big-data-cluster.ja.xlf
@@ -60,6 +60,126 @@
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">HDFS、Spark、コントローラーなどの SQL Server ビッグ データ クラスター エンドポイントに対する SSL 検証エラーを無視する (true の場合)</target>
       </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">SQL Server ビッグ データ クラスター</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">SQL Server ビッグ データ クラスターを使用すると、Kubernetes で実行されている SQL Server、Spark、および HDFS のコンテナーのスケーラブルなクラスターをデプロイできます。</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">バージョン</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">デプロイ ターゲット</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">新しい Azure Kubernetes Service クラスター</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">既存の Azure Kubernetes Service クラスター</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">既存の Kubernetes クラスター (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">既存の Azure Red Hat OpenShift クラスター</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">既存の OpenShift クラスター</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">SQL Server ビッグ データ クラスターの設定</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">クラスター名</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">コントローラーのユーザー名</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">パスワード</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">パスワードの確認</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Azure の設定</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">サブスクリプション ID</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">既定の Azure サブスクリプションを使用する</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">リソース グループ名</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">リージョン</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">AKS クラスター名</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">VM サイズ</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">VM 数</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">ストレージ クラス名</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">データの容量 (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">ログの容量 (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">{0}、{1}、{2} に同意します。</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Microsoft プライバシー ステートメント</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">azdata ライセンス条項</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">SQL Server ライセンス条項</target>
+      </trans-unit>
     </body>
   </file>
   <file original="extensions/big-data-cluster/dist/bigDataCluster/utils" source-language="en" datatype="plaintext" target-language="ja">

--- a/resources/xlf/ja/cms.ja.xlf
+++ b/resources/xlf/ja/cms.ja.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">読み込み中...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">保存されたサーバー {0} の読み込み中に予期しないエラーが発生しました。</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">読み込み中...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">中央管理サーバー グループには、既に {0} という名前の登録済みサーバーがあります</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Azure SQL Database サーバーは、Central Management Servers として使用できません</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Azure SQL サーバーは、Central Management Servers として使用できません</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/ja/dacpac.ja.xlf
+++ b/resources/xlf/ja/dacpac.ja.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="ja">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">データ層アプリケーション パッケージ</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">既定で、.DACPAC と .BACPAC ファイルが保存されるフォルダーの完全パス</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">ターゲット サーバー</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">ソース サーバー</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">ソース データベース</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">ターゲット データベース</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">ファイルの場所</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">ファイルの選択</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">設定の概要</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">バージョン</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">設定</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">値</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">データベース名</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開く</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">既存のデータベースのアップグレード</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">新しいデータベース</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">リストされている {0} のデプロイ操作によってデータが失われる可能性があります。デプロイで生じる問題に備えて、バックアップまたはスナップショットが使用可能であることを確認してください。</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">データ損失の可能性にかかわらず続行します</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">リストされているデプロイ アクションによってデータ損失は生じません。</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">保存</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">ファイルの場所</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">バージョン (形式は x.x.x.x。x は数字)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開く</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">データ層アプリケーションの .dacpac ファイルを SQL Server インスタンスにデプロイします [Dacpac のデプロイ]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">データベースのスキーマとデータを論理 .bacpac ファイル形式にエクスポートします [Bacpac のエクスポート]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">データベース名</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">既存のデータベースのアップグレード</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">新しいデータベース</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">ターゲット データベース</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">ターゲット サーバー</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">ソース サーバー</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">ソース データベース</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">バージョン</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">設定</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">値</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">既定</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">データ層アプリケーション ウィザード</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">スクリプトの生成</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">ウィザードを閉じた後、タスク ビューでスクリプト生成の状態を表示できます。完了すると、生成されたスクリプトが開きます。</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">既定</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">デプロイ プランの操作</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">SQL Server のインスタンスに同じ名前のデータベースが既に存在します。</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">未定義の名前</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">ファイル名の末尾をピリオドにすることはできません</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">ファイル名を空白にすることはできません</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">ファイル文字が無効です</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">このファイル名は Windows による使用のために予約されています。別の名前を選んで再実行してください</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">予約済みのファイル名です。別の名前を選択して、もう一度お試しください</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">ファイル名の末尾を空白にすることはできません</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">ファイル名が 255 文字を超えています</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">デプロイ計画の生成に失敗しました '{0}'</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">デプロイ スクリプトの生成に失敗しました '{0}'</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">{0} 操作に失敗しました '{1}'</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">ウィザードを閉じた後、タスク ビューでスクリプト生成の状態を表示できます。完了すると、生成されたスクリプトが開きます。</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ja/import.ja.xlf
+++ b/resources/xlf/ja/import.ja.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="ja">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">フラット ファイル インポートの構成</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[省略可能] コンソールへのデバッグ出力をログに記録し ([表示] -&gt; [出力])、ドロップダウンから適切な出力チャネルを選択します</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">{0} が開始されました</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">{0} の開始中</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">{0}を開始できませんでした: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">{0} を {1} にインストールしています</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">{0} サービスをインストールしています</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">{0} がインストールされました</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">{0} をダウンロードしています</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">{0} をダウンロードしています</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">{0} のダウンロードが完了しました</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">{0} を抽出しました ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">フィードバックの送信</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">サービス コンポーネントを開始できませんでした</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">データベースが含まれるサーバー</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">テーブルが作成されているデータベース</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">ファイルの場所が無効です。別の入力ファイルをお試しください</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">参照</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開く</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">インポートするファイルの場所</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">新しいテーブル名</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">テーブル スキーマ</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">データのインポート</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">次へ</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">列名</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">データ型</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">主キー</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">Null を許容</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">この操作によって、最初の 50 行までのプレビューを下に生成するために入力ファイル構造が分析されました。</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">この操作は失敗しました。別の入力ファイルをお試しください。</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">最新の情報に更新</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">情報のインポート</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ テーブルにデータを正常に挿入しました。</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">この操作によって、最初の 50 行までのプレビューを下に生成するために入力ファイル構造が分析されました。</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">この操作は失敗しました。別の入力ファイルをお試しください。</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">最新の情報に更新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">データのインポート</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">次へ</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">列名</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">データ型</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">主キー</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">Null を許容</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">データベースが含まれるサーバー</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">テーブルが作成されているデータベース</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">参照</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開く</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">インポートするファイルの場所</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">新しいテーブル名</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">テーブル スキーマ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">このウィザードを使用する前に、サーバーに接続してください。</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">SQL Server Import 拡張機能は、この種類の接続をサポートしていません</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">新しいファイルのインポート</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">フィードバックの送信</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">サービス コンポーネントを開始できませんでした</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">サービスが開始しました</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">サービスを開始しています</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">インポート サービス {0} を開始できませんでした</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">{0} サービスを {1} にインストールしています</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">サービスをインストールしています</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">インストール済み</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">{0} をダウンロードしています</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">サービスをダウンロードしています</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">完了</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ja/notebook.ja.xlf
+++ b/resources/xlf/ja/notebook.ja.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">ノートブックで使用される、以前から存在する Python インストールのローカル パス。</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">Python の更新を確認するメッセージを表示しません。</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">すべてのノートブックが閉じられた後、サーバーをシャットダウンするまでの待機時間 (分)。(シャットダウンしない場合は ”0” を入力してください)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Notebook エディターの既定の設定をオーバーライドします。設定には、背景色、現在の線の色、境界線が含まれます</target>
@@ -49,6 +57,10 @@
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
         <target state="translated">ユーザーによって現在のワークスペースにピン留めされているノートブック</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,24 +151,24 @@
         <target state="translated">Jupyter ブック</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">ブックの保存</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Jupyter ブックの保存</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="translated">信頼ブック</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Jupyter ブックの信頼</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">ブックの検索</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Jupyter ブックの検索</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
         <target state="translated">ノートブック</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="translated">指定されたブック</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">提供されている Jupyter ブック</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
@@ -174,17 +186,29 @@
         <source xml:lang="en">Close Jupyter Book</source>
         <target state="translated">Jupyter ブックを閉じる</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="translated">Jupyter Notebook を閉じる</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">ノートブックを閉じる</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">ノートブックの削除</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">ノートブックの追加</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">マークダウン ファイルの追加</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
         <target state="translated">ブックで公開する</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="translated">ブックの作成 (プレビュー)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Jupyter ブックの作成</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
@@ -263,8 +287,8 @@
         <target state="translated">フォルダーの選択</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="translated">ブックの選択</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Jupyter ブックの選択</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
@@ -283,40 +307,40 @@
         <target state="translated">外部リンクを開く</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="translated">ブックはワークスペースで信頼されるようになりました。</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">Jupyter ブックはワークスペースで信頼されるようになりました。</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="translated">ブックはこのワークスペースで既に信頼されています。</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">Jupyter ブックはこのワークスペースで既に信頼されています。</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="translated">ブックはこのワークスペースで信頼されなくなりました</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">Jupyter ブックはこのワークスペースで信頼されなくなりました</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="translated">ブックは既にこのワークスペースで信頼されていません。</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">Jupyter ブックは既にこのワークスペースで信頼されていません。</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="translated">ブック {0} はワークスペースにピン留めされました。</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">Jupyter ブック {0} はワークスペースにピン留めされました。</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="translated">ブック {0} はこのワークスペースにピン留めされなくなりました</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Jupyter ブック {0} はもうこのワークスペースにピン留めされていません</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="translated">指定されたブックに目次ファイルが見つかりませんでした。</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">指定された Jupyter ブックに目次ファイルが見つかりませんでした。</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="translated">ビューレットに現在選択されているブックがありません。</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">ビューレットに現在選択されている Jupyter ブックがありません。</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="translated">ブック セクションの選択</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Jupyter ブックのセクションを選択</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
@@ -339,12 +363,12 @@
         <target state="translated">構成ファイルが見つかりません</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="translated">ブック {0} を開けませんでした: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Jupyter ブック {0} を開くことができませんでした: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="translated">ブック {0} の読み取りに失敗しました: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">Jupyter ブック {0} を読み取ることができませんでした: {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
@@ -363,8 +387,8 @@
         <target state="translated">リンク {0} を開けませんでした。{1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="translated">ブック {0} を閉じられませんでした: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Jupyter ブック {0} を閉じることができませんでした: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
@@ -373,12 +397,16 @@
  データの損失を防ぐために、ファイルの名前が {2} に変更されました。</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="translated">ブック {0} の編集中にエラーが発生しました: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Jupyter ブック {0} の編集中にエラーが発生しました: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="translated">編集するブックまたはセクションの選択中にエラーが発生しました: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">編集する Jupyter ブックまたはセクションの選択中にエラーが発生しました: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">{1} にセクション {0} が見つかりませんでした。</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
@@ -393,8 +421,8 @@
         <target state="translated">場所</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="translated">リモート ブックの追加</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">リモート Jupyter ブックの追加</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
@@ -409,8 +437,8 @@
         <target state="translated">リリース</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="translated">ブック</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter ブック</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
@@ -421,8 +449,8 @@
         <target state="translated">言語</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="translated">指定されたリンクで現在利用可能なブックがありません</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">指定されたリンクで現在利用可能な Jupyter ブックがありません</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
@@ -445,44 +473,44 @@
         <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="translated">リモート ブックのダウンロードが進行中です</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">リモート Jupyter ブックのダウンロードが進行中です</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="translated">リモート ブックのダウンロードが完了しました</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">リモート Jupyter ブックのダウンロードが完了しました</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="translated">リモート ブックのダウンロード中にエラーが発生しました</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">リモート Jupyter ブックのダウンロード中にエラーが発生しました</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="translated">リモート ブックの圧縮解除中にエラーが発生しました</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">リモート Jupyter ブックの圧縮解除中にエラーが発生しました</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="translated">リモート ブック ディレクトリの作成中にエラーが発生しました</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">リモート Jupyter ブック ディレクトリの作成中にエラーが発生しました</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="translated">リモート ブックをダウンロードしています</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">リモート Jupyter ブックのダウンロード</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
         <target state="translated">リソースが見つかりません。</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="translated">ブックが見つかりません</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">Jupyter ブックが見つかりません</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
         <target state="translated">リリースが見つかりません</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="translated">選択したブックは無効です</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">選択した Jupyter ブックは無効です</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
@@ -492,21 +520,21 @@
         <source xml:lang="en">Downloading to {0}</source>
         <target state="translated">{0} にダウンロードしています</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="translated">新しいグループ</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">新しい Jupyter ブック (プレビュー)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="translated">グループは、ノートブックを整理するために使用されます。</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Jupyter　ブックは、ノートブックを整理するために使用されます。</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="translated">場所の参照...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">詳細情報。</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="translated">コンテンツ フォルダーの選択</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">コンテンツ フォルダー</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
@@ -524,7 +552,7 @@
         <source xml:lang="en">Save location</source>
         <target state="translated">保存場所</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
         <target state="translated">コンテンツ フォルダー (省略可能)</target>
       </trans-unit>
@@ -533,8 +561,44 @@
         <target state="translated">コンテンツ フォルダーのパスが存在しません</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="translated">保存場所のパスが存在しません</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">保存場所のパスが存在しません。</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">アクセスしようとしているときにエラーが発生しました: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">新しいノートブック (プレビュー)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">新しいマークダウン (プレビュー)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">ファイル拡張子</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">ファイルは既に存在します。このファイルを上書きしますか?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">タイトル</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">ファイル名</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">保存場所のパスが無効です。</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">移動先のフォルダーにファイル {0} が既に存在します</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">別の Python のインストールが現在進行中です。完了するのを待っています。</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">更新のために、アクティブな Python ノートブック セッションがシャットダウンされます。今すぐ続行しますか?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">Python {0} が Azure Data Studio で利用できるようになりました。現在の Python バージョン (3.6.6) は、2021 年 12 月にサポートされなくなります。今すぐ Python {0} に更新しますか?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">Python {0} がインストールされ、Python 3.6.6 が置換されます。一部のパッケージは、新しいバージョンとの互換性がなくなったか、再インストールが必要になる可能性があります。すべての pip パッケージの再インストールを支援するためにノートブックが作成されます。今すぐ更新を続行しますか?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">Notebook 依存関係のインストールに失敗しました。エラー: {0}</target>
@@ -603,6 +679,18 @@
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
         <target state="translated">Python ユーザー パスの取得時にエラーが発生しました: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">今後このメッセージを表示しない</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">このハンドラーではアクション {0} はサポートされていません</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">HTTP リンクと HTTPS リンクのみがサポートされているため、リンク {0} を開くことができません</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">HTTP、HTTPS、およびファイル リンクのみがサポートされているため、リンク {0} を開けません</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/ja/profiler.ja.xlf
+++ b/resources/xlf/ja/profiler.ja.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/ja/resource-deployment.ja.xlf
+++ b/resources/xlf/ja/resource-deployment.ja.xlf
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">Docker を使用して SQL Server コンテナー イメージを実行する</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">SQL Server ビッグ データ クラスター</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">SQL Server ビッグ データ クラスターを使用すると、Kubernetes で実行されている SQL Server、Spark、および HDFS のコンテナーのスケーラブルなクラスターをデプロイできます。</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">バージョン</target>
@@ -45,34 +37,6 @@
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
         <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">デプロイ ターゲット</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">新しい Azure Kubernetes Service クラスター</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">既存の Azure Kubernetes Service クラスター</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">既存の Kubernetes クラスター (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="translated">既存の Azure Red Hat OpenShift クラスター</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="translated">既存の OpenShift クラスター</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">ポート</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">SQL Server ビッグ データ クラスターの設定</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">クラスター名</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">コントローラーのユーザー名</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">パスワード</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">パスワードの確認</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Azure の設定</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">サブスクリプション ID</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">既定の Azure サブスクリプションを使用する</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">リソース グループ名</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">リージョン</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">AKS クラスター名</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">VM サイズ</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">VM 数</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">ストレージ クラス名</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">データの容量 (GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">ログの容量 (GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">SQL Server on Windows</target>
@@ -170,21 +70,9 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">SQL Server on Windows を実行し、開始するバージョンを選択します。</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">{0}、{1}、{2} に同意します。</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
         <target state="translated">Microsoft のプライバシーに関する声明</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">azdata ライセンス条項</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">SQL Server ライセンス条項</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
@@ -485,6 +373,22 @@
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
         <target state="translated">EULA に同意して選択</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">このリソースを展開するには、'{0}' の拡張機能が必要です。今すぐインストールしますか?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">インストール</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">拡張機能 '{0}' をインストールしています...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">不明な拡張機能 '{0}'</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
@@ -1096,10 +1000,6 @@
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">拡張機能を読み込めませんでした: {0}。package.json のリソースの種類の定義でエラーが検出されました。詳しくは、デバッグ コンソールを確認してください。</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">リソースの種類: {0} が定義されていません</target>
@@ -2222,13 +2122,13 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Deployment pre-requisites</source>
         <target state="translated">デプロイの前提条件</target>
       </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="translated">進めるには、エンド ユーザー使用許諾契約 (EULA) の条件に同意する必要があります。</target>
-      </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
         <target state="translated">一部のツールがまだ検出されていません。それらがインストールされており、実行中で検出可能であることを確認してください</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">進めるには、エンド ユーザー使用許諾契約 (EULA) の条件に同意する必要があります。</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
@@ -2378,6 +2278,10 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Azure Data CLI</source>
         <target state="translated">Azure Data CLI</target>
       </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">このリソースをデプロイするには、Azure Data CLI 拡張機能をインストールする必要があります。拡張機能ギャラリーを使用してインストールしてから、もう一度お試しください。</target>
+      </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
         <target state="translated">バージョン情報の取得でエラーが発生しました。詳細については、出力チャネル '{0}' を参照してください</target>
@@ -2385,46 +2289,6 @@ Select a different subscription containing at least one server</source>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
         <target state="translated">バージョン情報の取得でエラーが発生しました。{0}無効な出力を受け取りました。バージョン取得コマンドの出力: '{1}'</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="translated">以前にダウンロードされた Azdata.msi が存在する場合にそれを削除しています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="translated">Azdata.msi をダウンロードして、azdata cli をインストールしています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="translated">インストール ログを表示しています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="translated">azdata-cli に brew リポジトリを利用しています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="translated">azdata-cli インストール用に brew リポジトリを更新しています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="translated">azdata をインストールしています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="translated">リポジトリ情報を更新しています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="translated">azdata インストールに必要なパッケージを取得しています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="translated">azdata の署名キーをダウンロードしてインストールしています...</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="translated">azdata リポジトリ情報を追加しています...</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ja/schema-compare.ja.xlf
+++ b/resources/xlf/ja/schema-compare.ja.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">ソース</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">ターゲット</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">ファイル</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">データ層アプリケーション ファイル (.dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">データベース</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">種類</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">サーバー</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">データベース</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">Schema Compare</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">別のソース スキーマが選択されました。比較を表示して比較しますか?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">別のターゲット スキーマが選択されました。比較を表示して比較しますか?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">異なるソース スキーマとターゲット スキーマが選択されています。比較を表示して比較しますか?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">ソース ファイル</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">ターゲット ファイル</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">ソース データベース</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">ターゲット データベース</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">ソース サーバー</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">ターゲット サーバー</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">既定</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開く</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">ソース ファイルの選択</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">ターゲット ファイルの選択</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">リセット</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">オブジェクトの種類を含める</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">詳細の比較</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">ターゲットを更新しますか?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">比較を更新するには、[比較] を押します。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">ターゲットに変更をデプロイするスクリプトを生成します</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">スクリプトに変更はありません</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">ターゲットに変更を適用する</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">適用する変更はありません</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">対象の依存関係を計算するために、包含/除外操作に少し時間がかかる場合があることにご注意ください</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">削除</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">変更</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">追加</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">ソースとターゲットの比較</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">比較を初期化します。しばらく時間がかかる場合があります。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">2 つのスキーマを比較するには、最初にソース スキーマとターゲット スキーマを選択し、[比較] を押します。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">スキーマの違いは見つかりませんでした。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">種類</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">ソース名</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">包含</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">アクション</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">ターゲット名</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">ターゲットがデータベースの場合にスクリプトの生成が有効になります</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">ターゲットがデータベースの場合に適用が有効になります</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">{0} を除外することはできません。対象の依存関係が存在します ({1} など)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">{0} を含めることはできません。対象外の依存関係が存在します ({1} など)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">{0} を除外することはできません。対象の依存関係が存在します</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">{0} を含めることはできません。対象外の依存関係が存在します</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">比較</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">スクリプトの生成</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">オプション​​</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">適用</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">方向の切り替え</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">ソースとターゲットの切り替え</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">ソースの選択</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">ターゲットの選択</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">.scmp ファイルを開く</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">.scmp ファイルに保存されたソース、ターゲット、およびオプションを読み込みます</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">.scmp ファイルを保存</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">ソース、ターゲット、オプション、および除外された要素を保存します</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">保存</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">{0} に接続しますか?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">接続の選択</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,8 +663,8 @@
         <target state="translated">データベース ロール</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
-        <target state="translated">DatabaseTriggers</target>
+        <source xml:lang="en">Database Triggers</source>
+        <target state="translated">データベース トリガー</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
         <source xml:lang="en">Defaults</source>
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">外部ファイル形式</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">外部ストリーム</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">外部ストリーミング ジョブ</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">外部テーブル</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">ファイル グループ</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">ファイル</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">署名</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">ストアド プロシージャ</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">対称キー</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">データベースに公開するときに、テーブルの列の順序の違いを無視するか、更新するかを指定します。</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">ソース</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">ターゲット</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">ファイル</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">データ層アプリケーション ファイル (.dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">データベース</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">種類</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">サーバー</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">データベース</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">アクティブな接続がありません</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Schema Compare</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">別のソース スキーマが選択されました。比較を表示して比較しますか?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">別のターゲット スキーマが選択されました。比較を表示して比較しますか?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">異なるソース スキーマとターゲット スキーマが選択されています。比較を表示して比較しますか?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開く</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">既定</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">詳細の比較</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">ターゲットを更新しますか?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">比較を更新するには、[比較] を押します。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">ターゲットに変更をデプロイするスクリプトを生成します</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">スクリプトに変更はありません</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">ターゲットに変更を適用する</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">適用する変更はありません</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">削除</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">変更</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">追加</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Schema Compare</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">ソース</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">ターゲット</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">比較を初期化します。しばらく時間がかかる場合があります。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">2 つのスキーマを比較するには、最初にソース スキーマとターゲット スキーマを選択し、[比較] を押します。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">スキーマの違いは見つかりませんでした。</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">Schema Compare に失敗しました: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">種類</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">ソース名</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">包含</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">アクション</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">ターゲット名</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">ターゲットがデータベースの場合にスクリプトの生成が有効になります</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">ターゲットがデータベースの場合に適用が有効になります</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">比較</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">比較</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">scmp を保存できませんでした: '{0}'</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">スキーマ比較を取り消すことができませんでした: '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">スクリプトの生成</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">スクリプトを生成できませんでした: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">オプション​​</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">オプション​​</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">適用</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">Schema Compare を適用できませんでした '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">方向の切り替え</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">ソースとターゲットの切り替え</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">ソースの選択</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">ターゲットの選択</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">.scmp ファイルを開く</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">.scmp ファイルに保存されたソース、ターゲット、およびオプションを読み込みます</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開く</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">scmp を開くことができませんでした: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">.scmp ファイルを保存</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">ソース、ターゲット、オプション、および除外された要素を保存します</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">保存</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">scmp を保存できませんでした: '{0}'</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ja/sql.ja.xlf
+++ b/resources/xlf/ja/sql.ja.xlf
@@ -1,2251 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">イメージのコピーはサポートされていません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">はじめに</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">「はじめに」を表示する</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">はじめに(&amp;&amp;S)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">クエリ履歴</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">Query History キャプチャが有効かどうか。false の場合、実行されたクエリはキャプチャされません。</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">表示</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">Query History (&amp;&amp;Q)</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">Query History</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">接続中: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">実行中のコマンド: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">新しいクエリを開いています: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">サーバー情報が提供されていないため接続できません</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">エラー {0} により URL を開くことができませんでした</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">これにより、サーバー {0} に接続されます</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">接続しますか?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">開く(&amp;&amp;O)</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">クエリ ファイルへの接続中</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">1 つ以上のタスクを実行中です。終了してもよろしいですか?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">プレビュー機能により、新機能と機能改善にフル アクセスできることで、Azure Data Studio のエクスペリエンスが拡張されます。プレビュー機能の詳細については、[ここ] ({0}) を参照してください。プレビュー機能を有効にしますか?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">はい (推奨)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">いいえ、今後は表示しない</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">Query History の切り替え</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">削除</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">すべての履歴をクリア</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">クエリを開く</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">クエリの実行</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">Query History キャプチャの切り替え</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">Query History キャプチャの一時停止</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">Query History キャプチャの開始</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">表示するクエリがありません。</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">Query History</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">エラー</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">警告</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">情報</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">無視する</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">このデータ プロバイダーに対して無効になっている別の形式で結果を保存しています。</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">プロバイダーが登録されていないため、データをシリアル化できません</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">不明なエラーにより、シリアル化に失敗しました</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">管理サービスとの対話には接続が必須です</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">登録されているハンドラーがありません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">ファイルの選択</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">評価サービスとの対話には接続が必要です</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">登録されているハンドラーがありません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">結果グリッドとメッセージ</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">フォント ファミリを制御します。</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">フォントの太さを制御します。</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">フォント サイズ (ピクセル単位) を制御します。</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">文字間隔 (ピクセル単位) を制御します。</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">ピクセル単位で行の高さを制御する</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">セルの埋め込みをピクセル単位で制御します</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">最初の結果について、列の幅を自動サイズ設定します。多数の列がある場合や、大きいセルがある場合、パフォーマンスの問題が発生する可能性があります</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">自動サイズ設定される列の最大幅 (ピクセル単位)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">表示</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">データベース接続</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">データ ソース接続</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">データソース グループ</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">起動の構成</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">Azure Data Studio の起動時にサーバー ビューを表示する場合には true (既定)。最後に開いたビューを表示する場合には false</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">切断</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">最新の情報に更新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">プレビュー機能</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">未リリースのプレビュー機能を有効にする</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">起動時に接続ダイアログを表示</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">古い API 通知</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">古い API 使用状況通知を有効または無効にする</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">問題</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} 個のタスクが進行中です</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">表示</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">タスク</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">タスク(&amp;&amp;T)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">接続リストに格納する最近使用された接続の最大数。</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">使用する既定の SQL エンジン。.sql ファイル内の既定の言語プロバイダーが駆動され、新しい接続が作成されるときに既定で使用されます。</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">接続ダイアログが開いたり、解析が実行されたりするときにクリップボードの内容の解析を試行します。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">オブジェクト エクスプローラー ビューレットで使用するサーバー グループ カラー パレット。</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">オブジェクト エクスプローラー ビューレットの自動展開サーバー グループ。</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(プレビュー) 動的ノード フィルターなどの新機能をサポートする、新しい非同期サーバー ツリーをサーバー ビューおよび接続ダイアログに使用します。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">アカウントの種類の識別子</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(省略可能) UI の accpunt を表すために使用するアイコン。ファイル パスまたはテーマを設定可能な構成のいずれかです</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">明るいテーマを使用した場合のアイコンのパス</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">暗いテーマを使用した場合のアイコンのパス</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">アカウント プロバイダーにアイコンを提供します。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">起動時にデータ SQL の編集ペインを表示する</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Y 軸の最小値</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Y 軸の最大値</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Y 軸のラベル</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">X 軸の最小値</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">X 軸の最大値</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">X 軸のラベル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">リソース ビューアー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">グラフのデータ セットのデータ プロパティを示します。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">結果セットの各列について、行 0 の値をカウントとして表示し、その後に列名が続きます。たとえば、'1 正常'、'3 異常' をサポートします。ここで、'正常' は列名、1 は行 1 セル 1 の値です。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">単純なテーブルに結果を表示する</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">イメージを表示します。例: ggplot2 を使用して R クエリによって返されたイメージ</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">必要な形式は何ですか。JPEG、PNG、またはその他の形式ですか?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">これは 16 進数、base64 または、他の形式でエンコードされていますか？</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">ダッシュボード</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">このタブに表示される Web ビュー。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">このタブに表示される controlhost。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">このタブに表示されるウィジェットのリスト。</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">拡張には、ウィジェット コンテナー内にウィジェットのリストが必要です。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">このタブに表示されるウィジェットまたは Web ビューのリスト。</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">ウィジェットや Web ビューが拡張機能用のウィジェット コンテナー内に必要です。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">このコンテナーの一意の識別子。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">タブに表示されるコンテナー。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">単一または複数のダッシュ ボード コンテナーを提供し、ユーザーが自分のダッシュボードに追加できるようにします。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">ダッシュボード コンテナーに、拡張用に指定された ID はありません。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">ダッシュボード コンテナーに、拡張用に指定されたコンテナーはありません。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">空間ごとにダッシュボード コンテナーを 1 つだけ定義する必要があります。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">拡張用にダッシュボード コンテナーで定義されているコンテナーの種類が不明です。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">このナビゲーション セクションの一意の識別子。すべての要求で拡張機能に渡されます。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(省略可能) UI でこのナビゲーション セクションを表すために使用されるアイコン。ファイル パスまたはテーマを設定可能な構成のいずれかです</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">明るいテーマを使用した場合のアイコンのパス</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">暗いテーマを使用した場合のアイコンのパス</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">ユーザーに表示するナビゲーション セクションのタイトル。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">このナビゲーション セクションに表示されるコンテナー。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">このナビゲーション セクションに表示されるダッシュボード コンテナーのリスト。</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">ナビゲーション セクションに、拡張用に指定されたタイトルはありません。</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">ナビゲーション セクションに、拡張用に指定されたコンテナーはありません。</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">空間ごとにダッシュボード コンテナーを 1 つだけ定義する必要があります。</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION 内の NAV_SECTION は拡張用に無効なコンテナーです。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">このタブに表示されるモデルに基づくビュー。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">バックアップ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">復元</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">復元</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">Azure Portal で開きます</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">切断されました</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">必要な接続プロバイダー '{0}' が見つからないため、展開できません</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">ユーザーによる取り消し</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">ファイアウォール ダイアログが取り消されました</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">JobManagementService と対話するには接続が必須です</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">登録されているハンドラーがありません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">ファイル ブラウザーの読み込み中にエラーが発生しました。</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">ファイル ブラウザーのエラー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">プロバイダーの共通 ID</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">プロバイダーの表示名</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">プロバイダーの Notebook カーネル別名</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">サーバーの種類のアイコン パス</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">接続のオプション</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">このタブの一意の識別子。すべての要求で拡張機能に渡されます。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">ユーザーを表示するタブのタイトル。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">ユーザーに表示されるこのタブの説明。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">この項目を表示するために true にする必要がある条件</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">このタブと互換性のある接続の種類を定義します。設定されていない場合、既定値は 'MSSQL' に設定されます</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">このタブに表示されるコンテナー。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">このタブを常に表示するか、またはユーザーが追加したときにのみ表示するかどうか。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">このタブを接続の種類の [ホーム] タブとして使用するかどうか。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">このタブが属しているグループの一意識別子。ホーム グループの値: home。</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(省略可能) UI でこのタブを表すために使用されるアイコン。ファイル パスまたはテーマを設定可能な構成のいずれかです</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">明るいテーマを使用した場合のアイコンのパス</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">暗いテーマを使用した場合のアイコンのパス</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">ユーザーがダッシュボードに追加する 1 つまたは、複数のタブを提供します。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">拡張機能にタイトルが指定されていません。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">表示するよう指定された説明はありません。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">拡張機能にコンテナーが指定されていません。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">空間ごとにダッシュボード コンテナーを 1 つだけ定義する必要があります</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">このタブ グループの一意識別子。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">タブ グループのタイトル。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">ユーザーがダッシュボードに追加するための 1 つまたは複数のタブ グループを提供します。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">タブ グループの ID が指定されていません。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">タブ グループのタイトルが指定されていません。</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">監視中</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">パフォーマンス</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">セキュリティ</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">トラブルシューティング</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">設定</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">データベース タブ</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">データベース</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">成功</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">失敗</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">接続エラー</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">接続は、Kerberos エラーのため失敗しました。</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">Kerberos を構成するためのヘルプを {0} で確認できます</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">以前に接続した場合は、kinit を再実行しなければならない場合があります。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">閉じる</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">アカウントを追加しています...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">ユーザーがアカウントの更新をキャンセルしました</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">クエリ結果</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">クエリ エディター</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">新しいクエリ</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">クエリ エディター</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">true の場合、CSV として結果を保存する際に列ヘッダーが組み込まれます</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">CSV として保存するときに値の間に使用するカスタム区切り記号</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">結果を CSV として保存するときに行を区切るために使用する文字</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">結果を CSV として保存するときにテキスト フィールドを囲むために使用する文字</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">結果を CSV として保存するときに使用するファイル エンコード</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">true の場合、XML として結果を保存すると XML 出力がフォーマットされます</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">結果を XML として保存するときに使用されるファイル エンコード</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">結果のストリーミングを有効にします。視覚上の小さな問題がいくつかあります</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">結果を結果ビューからコピーするための構成オプション</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">複数行の結果を結果ビューからコピーするための構成オプション</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(試験的) 結果の最適化されたテーブルを使用します。一部の機能がなく、準備中の場合があります。</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">各バッチの実行時間を表示するかどうか</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">メッセージを右端で折り返す</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">クエリ結果からグラフ ビューアーを開くときに使用する既定のグラフの種類</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">タブの色指定は無効になります</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">各エディター タブの上部境界線は、関連するサーバー グループと同じ色になります</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">各エディター タブの背景色は、関連するサーバー グループと同じになります</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">アクティブな接続のサーバー グループに基づいてタブに色を付ける方法を制御します</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">タイトルにタブの接続情報を表示するかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">生成された SQL ファイルを保存するかをプロンプトで確認する</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">ショートカット テキストをプロシージャ呼び出しとして実行するにはキーバインド workbench.action.query.shortcut{0} を設定します。クエリ エディターで選択したテキストはパラメーターとして渡されます</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">ビュー テンプレートを指定する</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">セッション テンプレートを指定する</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Profiler フィルター</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">作成としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">ドロップとしてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">上位 1000 を選択する</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">実行としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">変更としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">データの編集</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">上位 1000 を選択する</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">10 個</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">作成としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">実行としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">変更としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">ドロップとしてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">最新の情報に更新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">行のコミットに失敗しました: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">次の場所でクエリの実行を開始しました: </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">クエリ「{0}」の実行を開始しました</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">行 {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">失敗したクエリのキャンセル中: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">セルの更新が失敗しました: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">ノートブック マネージャーを作成するときに URI が渡されませんでした</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">ノートブック プロバイダーが存在しません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">ノートブック エディター</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新しいノートブック</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新しいノートブック</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">ワークスペースを設定して開く</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">SQL カーネル: セルでエラーが発生したときに Notebook の実行を停止します。</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(プレビュー) 現在のノートブック プロバイダーのすべてのカーネルを表示します。</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">ノートブックでの Azure Data Studio コマンドの実行を許可します。</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">ノートブックのテキスト セルのダブルクリックして編集を有効する</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">既定でテキスト セルにリッチ テキスト表示モードを設定する</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(プレビュー) ノートブック メタデータに接続名を保存します。</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">ノートブック マークダウン プレビューで使用される行の高さを制御します。この数値はフォント サイズを基準とします。</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">表示</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">ノートブックの検索</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">フルテキスト検索および Quick Open でファイルやフォルダーを除外するための glob パターンを構成します。'#files.exclude#' 設定からすべての glob パターンを継承します。glob パターンの詳細については、[こちら](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) を参照してください。</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">ファイル パスの照合基準となる glob パターン。これを true または false に設定すると、パターンがそれぞれ有効/無効になります。</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">一致するファイルの兄弟をさらにチェックします。一致するファイル名の変数として $(basename) を使用します。</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">この設定は推奨されず、現在 "search.usePCRE2" にフォール バックします。</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">推奨されません。高度な正規表現機能サポートのために "search.usePCRE2" の利用を検討してください。</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">有効にすると、searchService プロセスは 1 時間操作がない場合でもシャットダウンされず、アクティブな状態に保たれます。これにより、ファイル検索キャッシュがメモリに保持されます。</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">ファイルを検索するときに、`.gitignore` ファイルと `.ignore` ファイルを使用するかどうかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">ファイルを検索するときに、グローバルの `.gitignore` と `.ignore` ファイルを使用するかどうかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">グローバル シンボル検索の結果を、Quick Open の結果ファイルに含めるかどうか。</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">最近開いたファイルの結果を、Quick Open の結果ファイルに含めるかどうか。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">履歴エントリは、使用されるフィルター値に基づいて関連性によって並び替えられます。関連性の高いエントリが最初に表示されます。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">履歴エントリは、新しい順に並べ替えられます。最近開いたエントリが最初に表示されます。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">フィルター処理時に、 Quick Open におけるエディター履歴の並べ替え順序を制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">検索中にシンボリック リンクをたどるかどうかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">すべて小文字のパターンの場合、大文字と小文字を区別しないで検索し、そうでない場合は大文字と小文字を区別して検索します。</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">macOS で検索ビューが共有の検索クリップボードを読み取りまたは変更するかどうかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">検索をサイドバーのビューとして表示するか、より水平方向の空間をとるためにパネル領域のパネルとして表示するかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">この設定は非推奨です。代わりに検索ビューのコンテキスト メニューをお使いください。</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">結果が 10 件未満のファイルが展開されます。他のファイルは折りたたまれます。</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">検索結果を折りたたむか展開するかどうかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">一致項目を選択するか置換するときに、置換のプレビューを開くかどうかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">検索結果に行番号を表示するかどうかを制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">テキスト検索に PCRE2 正規表現エンジンを使用するかどうか。これにより、先読みや後方参照といった高度な正規表現機能を使用できるようになります。ただし、すべての PCRE2 機能がサポートされているわけではありません。JavaScript によってサポートされる機能のみが使用できます。</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">廃止されました。PCRE2 でのみサポートされている正規表現機能を使用すると、PCRE2 が自動的に使用されます。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">検索ビューが狭い場合はアクションバーを右に、検索ビューが広い場合はコンテンツの直後にアクションバーを配置します。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">アクションバーを常に右側に表示します。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">検索ビューの行内のアクションバーの位置を制御します。</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">入力中の文字列を全てのファイルから検索する。</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">アクティブなエディターで何も選択されていないときに、カーソルに最も近い語からのシード検索を有効にします。</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">検索ビューにフォーカスを置いたときに、ワークスペースの検索クエリが、エディターで選択されているテキストに更新されます。これは、クリックされたときか、'workbench.views.search.focus' コマンドがトリガーされたときに発生します。</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">'#search.searchOnType#' を有効にすると、文字が入力されてから検索が開始されるまでのタイムアウト (ミリ秒) が制御されます。'search.searchOnType' が無効になっている場合には影響しません。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">ダブルクリックすると、カーソルの下にある単語が選択されます。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">ダブルクリックすると、アクティブなエディター グループに結果が開きます。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">ダブルクリックすると、結果はエディター グループの横に開かれ、まだ存在しない場合は作成されます。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">検索エディターで結果をダブル クリックした場合の効果を構成します。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">結果はフォルダー名とファイル名でアルファベット順に並べ替えられます。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">結果はフォルダーの順序を無視したファイル名でアルファベット順に並べ替えられます。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">結果は、ファイル拡張子でアルファベット順に並べ替えられます。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">結果は、ファイルの最終更新日で降順に並べ替えられます。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">結果は、ファイルあたりの数で降順に並べ替えられます。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">結果は、ファイルごとのカウントで昇順に並べ替えられます。</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">検索結果の並べ替え順序を制御します。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">新しいクエリ</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">実行</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">説明</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">実際</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">切断</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">接続の変更</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">接続</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">SQLCMD を有効にする</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">SQLCMD を無効にする</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">データベースの選択</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">データベースを変更できませんでした</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">データベース {0} を変更できませんでした</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">ノートブックとしてエクスポート</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">閉じる</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">アクション</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">コピーの詳細</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">サーバー グループを追加する</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">サーバー グループの編集</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">拡張</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">オブジェクト エクスプローラー セッションを作成できませんでした</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">複数のエラー:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">アカウントの追加でのエラー</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">ファイアウォール規則のエラー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">読み込まれた拡張機能の一部は古い API を使用しています。[開発者ツール] ウィンドウの [コンソール] タブで詳細情報を確認してください。</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">今後表示しない</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">ビューの識別子。`vscode.window.registerTreeDataProviderForView` API を介してデータ プロバイダーを登録するには、これを使用します。また、`onView:${id}` イベントを `activationEvents` に登録することによって、拡張機能のアクティブ化をトリガーするためにも使用できます。</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">ビューの判読できる名前。これが表示されます</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">このビューを表示するために満たす必要がある条件</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">ビューをエディターに提供します</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">アクティビティ バーのデータ エクスプローラー コンテナーにビューを提供します</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">コントリビューション ビュー コンテナーにビューを提供します</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">ビュー コンテナー '{1}'に同じ ID '{0}' のビューを複数登録できません</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">ビュー ID `{0}` はビュー コンテナー `{1}` に既に登録されています</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">ビューは配列にする必要があります</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">プロパティ `{0}` は必須で、`string` 型でなければなりません</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">プロパティ `{0}` は省略するか、`string` 型にする必要があります</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">ユーザー設定の {0} は {1} に置き換えられました。</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">ワークスペース設定の {0} は {1} に置き換えられました。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">詳細の表示</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">詳細情報</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">保存されているすべてのアカウントのクリア</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">タスクの切り替え</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">接続状態</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">ツリー プロバイダーのユーザー表示名</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">プロバイダーの ID は、ツリー データ プロバイダーを登録するときと同じである必要があり、'connectionDialog/' で始まる必要があります</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">ダッシュボード上のグラフとしてクエリの結果を表示します</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">'列名' -&gt; 色をマップします。たとえば、「'column1': red」を追加して、この列で赤色が使用されるようにします </target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">グラフの凡例の優先される位置と表示範囲を示します。これはクエリに基づく列名で、各グラフ項目のラベルにマップされます</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">dataDirection が横の場合、true に設定すると凡例に最初の列値が使用されます。</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">dataDirection が縦の場合、true に設定すると凡例に列名が使用されます。</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">データを列 (縦) 方向から、または行 (横) 方向から読み取るかを定義します。時系列の場合、方向は縦にする必要があるため、これは無視されます。</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">showTopNData を設定すると、上位 N 個のデータのみがグラフに表示されます。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">アクションの表示</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">リソース ビューアー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">リソースの識別子。</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">ビューの判読できる名前。これが表示されます</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">リソース アイコンへのパス。</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">リソースをリソース ビューに提供します</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">プロパティ `{0}` は必須で、`string` 型でなければなりません</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">プロパティ `{0}` は省略するか、`string` 型にする必要があります</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">リソース ビューアー ツリー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">この項目を表示するために true にする必要がある条件</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">ウィジェットのヘッダーを非表示にするかどうか。既定値は false です。</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">コンテナーのタイトル</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">グリッド内のコンポーネントの行</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">グリッド内のコンポーネントの rowspan。既定値は 1 です。グリッド内の行数に設定するには '*' を使用します。</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">グリッド内のコンポーネントの列</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">グリッドのコンポーネントの colspan。既定値は 1 です。グリッドの列数に設定するには '*' を使用します。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">このタブの一意の識別子。すべての要求で拡張機能に渡されます。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">拡張機能タブが不明またはインストールされていません。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">プロパティ ウィジェットを有効または無効にする</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">表示するプロパティ値</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">プロパティの表示名</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">データベース情報オブジェクトの値</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">無視する特定の値を指定します</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">復旧モデル</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">前回のデータベース バックアップ</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">最終ログ バックアップ</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">互換性レベル</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">所有者</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">データベース ダッシュボード ページをカスタマイズする</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">検索</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">データベース ダッシュボード タブをカスタマイズする</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">プロパティ ウィジェットを有効または無効にする</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">表示するプロパティ値</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">プロパティの表示名</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">サーバー情報オブジェクトの値</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">バージョン</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">エディション</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">コンピューター名</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">OS バージョン</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">検索</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">サーバー ダッシュ ボード ページをカスタマイズします</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">サーバー ダッシュボードのタブをカスタマイズします</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">プロパティ `icon` は省略するか、文字列または `{dark, light}` などのリテラルにする必要があります</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">ウィジェットを追加します。そこでは、サーバーまたはデータベースのクエリを実行して、その結果をグラフや集計されたカウントなどの複数の方法で表示できます</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">分析情報の結果をキャッシュするために使用される一意識別子。</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">実行する SQL クエリ。返す結果セットは 1 つのみでなければなりません。</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[省略可能] クエリを含むファイルへのパス。'クエリ' が設定されていない場合に使用します</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[省略可能] 分単位の自動更新間隔。設定しないと、自動更新されません</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">使用するアクション</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">アクションのターゲット データベース。形式 '${ columnName }' を使用して、データ ドリブン列名を使用できます。</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">アクションのターゲット サーバー。形式 '${ columnName }' を使用して、データ ドリブン列名を使用できます。</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">アクションのターゲット ユーザー。形式 '${ columnName }' を使用して、データ ドリブン列名を使用できます。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">分析情報の識別子</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">ダッシュボード パレットに分析情報を提供します。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">バックアップ</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">バックアップを使用するにはプレビュー機能を有効にする必要があります</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL データベースでは、バックアップ コマンドはサポートされていません。</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">バックアップ コマンドは、サーバー コンテキストではサポートされていません。データベースを選択して、もう一度お試しください。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">復元</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">復元を使用するには、プレビュー機能を有効にする必要があります</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL データベースでは、復元コマンドはサポートされていません。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">推奨事項を表示</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">拡張機能のインストール</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">拡張機能の作成...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">編集データ セッションの接続に失敗しました</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">ダッシュボードの拡張機能を開く</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">まだダッシュボードの拡張機能がインストールされていません。拡張機能マネージャーに移動し、推奨される拡張機能をご確認ください。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">選択されたパス</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">ファイルの種類</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">破棄</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">分析情報ポップアップに渡された接続プロファイルはありませんでした</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">分析情報エラー</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">クエリ ファイルの読み取り中にエラーが発生しました: </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">分析情報の構成の解析中にエラーが発生しました。クエリ配列/文字列、またはクエリ ファイルが見つかりませんでした</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Azure アカウント</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Azure テナント</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">接続の表示</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">サーバー</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">接続</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">表示するタスク履歴がありません。</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">タスク履歴</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">タスク エラー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">リストのクリア</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">最近の接続履歴をクリアしました</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">一覧からすべての接続を削除してよろしいですか?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">削除</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">現在の接続文字列を取得する</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">接続文字列は使用できません</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">使用できるアクティブな接続がありません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">最新の情報に更新</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">接続の編集</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">切断</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">新しい接続</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">新しいサーバー グループ</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">サーバー グループの編集</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">アクティブな接続を表示</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">すべての接続を表示</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近の接続</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">接続の削除</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">グループの削除</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">実行</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">編集内容の破棄がエラーで失敗しました: </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">SQL ペインの表示</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">SQL ペインを閉じる</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">プロファイラー</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">未接続</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">サーバー {0} で XEvent Profiler セッションが予期せず停止しました。</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">新しいセッションを開始中にエラーが発生しました</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">{0} の XEvent Profiler セッションのイベントが失われました。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2257,743 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">サーバー グループ</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">テキスト ラベルの非表示</target>
       </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">サーバー グループ名</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">グループ名が必須です。</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">グループの説明</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">グループの色</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">テキスト ラベルの表示</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">アカウントの追加でのエラー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">アイテム</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">値</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">分析情報の詳細</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">プロパティ</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">値</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">分析情報</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">アイテム</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">アイテムの詳細</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">自動 OAuth を開始できません。自動 OAuth は既に進行中です。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">イベントで並べ替え</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">列で並べ替え</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">プロファイラー</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">すべてクリア</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">適用</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">フィルター</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">この句を削除する</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">フィルターを保存する</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">フィルターを読み込む</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">句を追加する</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">フィールド</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">演算子</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">値</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">Null である</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">Null でない</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">含む</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">含まない</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">次で始まる</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">次で始まらない</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">CSV として保存</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">JSON として保存</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Excel として保存</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">XML として保存</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">コピー</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">ヘッダー付きでコピー</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">すべて選択</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">ダッシュ ボードに表示するプロパティを定義します</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">プロパティのラベルとして使用する値</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">値にアクセスするためのオブジェクト内の値</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">無視される値を指定します</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">無視されるか値がない場合に表示される既定値です</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">ダッシュボードのプロパティを定義するためのフレーバー</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">フレーバーの ID</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">このフレーバーを使用する条件</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">比較するフィールド</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">比較に使用する演算子</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">フィールドを比較する値</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">データベース ページに表示するプロパティ</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">サーバー ページに表示するプロパティ</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">このプロバイダーがダッシュボードをサポートすることを定義します</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">プロバイダー ID (例: MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">ダッシュボードに表示するプロパティ値</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">無効な値</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}。{1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">読み込み中</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">読み込み完了</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">空白</target>
-      </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">列 {0} のすべてのチェック ボックスをオンにする</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">ID '{0}' のツリー ビューは登録されていません。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">編集データ セッションを初期化できませんでした: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">ノートブック プロバイダーの識別子。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">このノートブック プロバイダーにどのファイル拡張子を登録する必要があるか</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">このノートブック プロバイダーへの標準装備が必要なカーネル</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">ノートブック プロバイダーを提供します。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">'%%sql' などのセル マジックの名前。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">このセル マジックがセルに含まれる場合に使用されるセルの言語</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">Spark / SQL など、このマジックが示すオプションの実行対象</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">これが有効なカーネルのオプションのセット (python3、pyspark、sql など)</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">ノートブックの言語を提供します。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">F5 ショートカット キーでは、コード セルを選択する必要があります。実行するコード セルを選択してください。</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">結果をクリアするには、コード セルを選択する必要があります。実行するコード セルを選択してください。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">最大行数:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">ビューの選択</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">セッションの選択</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">セッションを選択:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">ビューを選択:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">テキスト</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">ラベル</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">値</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">詳細</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">経過時間</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">行数</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} 行</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">クエリを実行しています...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">実行状態</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">選択の要約</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">平均: {0}  数: {1}  合計: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">SQL 言語の選択</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">SQL 言語プロバイダーの変更</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">SQL 言語のフレーバー</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">SQL エンジン プロバイダーの変更</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">エンジン {0} を使用している接続が存在します。変更するには、切断するか、接続を変更してください</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">現時点でアクティブなテキスト エディターはありません</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">言語プロバイダーの選択</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">Plotly グラフの表示エラー: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">出力用の {0} レンダラーが見つかりませんでした。次の MIME の種類があります: {1}。</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(安全) </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">上位 1000 を選択する</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">10 個</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">実行としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">変更としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">データの編集</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">作成としてのスクリプト</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">ドロップとしてのスクリプト</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">有効な providerId を持つ NotebookProvider をこのメソッドに渡す必要があります</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">有効な providerId を持つ NotebookProvider をこのメソッドに渡す必要があります</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">ノートブック プロバイダーが見つかりません</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">マネージャーが見つかりません</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">ノートブック {0} の Notebook Manager にサーバー マネージャーがありません。それに対して操作を実行できません</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">ノートブック {0} の Notebook Manager にコンテンツ マネージャーがありません。それに対して操作を実行できません</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">ノートブック {0} の Notebook Manager にセッション マネージャーがありません。それに対して操作を実行できません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">接続用の Azure アカウント トークンの取得に失敗しました</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">接続が承認されていません</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">この接続をキャンセルしてもよろしいですか?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">閉じる</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">カーネルを読み込んでいます...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">カーネルを変更しています...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">接続先: </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">カーネル </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">コンテキストを読み込んでいます...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">接続の変更</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">接続を選択</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">カーネルなし</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">結果のクリア</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">信頼されています</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">信頼されていません</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">セルを折りたたむ</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">セルを展開する</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">なし</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新しいノートブック</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">次の文字列を検索</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">前の文字列を検索</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">クエリ プラン</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">最新の情報に更新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">ステップ {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">一覧からオプションを選択する必要があります</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">ボックスを選択</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">接続</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">接続しています</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">接続の種類</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近の接続</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存された接続</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">接続の詳細</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">接続</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近の接続</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">最近の接続はありません</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存された接続</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">保存された接続はありません</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">利用できるデータはありません</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">ファイル ブラウザー ツリー</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">すべて選択/選択解除</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">開始</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">フィルターの表示</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">終了</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">すべて選択</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">新しいファイアウォール規則の作成</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">検索</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} 件の結果</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">{0} 件選択済み</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">昇順で並べ替え</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">降順で並べ替え</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">クリア</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">キャンセル</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">このクライアント IP アドレスではサーバーにアクセスできません。アクセスできるようにするには、Azure アカウントにサインインし、新しいファイアウォール規則を作成します。</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">ファイアウォール設定の詳細情報</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">ファイアウォール規則</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">自分のクライアント IP アドレスを追加 </target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">自分のサブネット IP 範囲を追加</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">フィルター オプション</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">すべてのファイル</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">読み込み中</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">クエリ ファイルが、次のどのパスにも見つかりませんでした:
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">読み込みエラー...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">このアカウントの資格情報を更新する必要があります。</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">詳細の切り替え</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">自動更新チェックを有効にします。Azure Data Studio は、更新プログラムを自動的かつ定期的に確認します。</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">Windows で新しい Azure Data Studio バージョンをバックグラウンドでダウンロードしてインストールできるようにする</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">更新後にリリース ノートを表示します。リリース ノートが新しい Web ブラウザー ウィンドウで開きます。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">ダッシュボード ツールバーのアクション メニュー</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">ノートブックのセル タイトル メニュー</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">ノートブックのタイトル メニュー</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">ノートブックのツール バー メニュー</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">dataexplorer ビュー コンテナーのタイトル アクション メニュー</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">データエクスプローラー項目のコンテキスト メニュー</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">オブジェクト エクスプローラー項目のコンテキスト メニュー</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">接続ダイアログの閲覧ツリーのコンテキスト メニュー</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">データ グリッド項目のコンテキスト メニュー</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">拡張機能をダウンロードするためのセキュリティ ポリシーを設定します。</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">拡張機能のポリシーでは、拡張機能のインストールは許可されていません。拡張機能ポリシーを変更して、もう一度お試しください。</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">VSIX からの {0} 拡張機能のインストールが完了しました。有効にするには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">この拡張機能のアンインストールを完了するには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">更新された拡張機能を有効にするには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">この拡張機能をローカルで有効にするには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">この拡張機能を有効にするには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">更新された拡張機能を無効にするには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">拡張機能 {0}のアンインストールを完了するには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">この拡張機能を {0} で有効にするには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">拡張機能 {0} のインストールが完了しました。これを有効にするには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">拡張機能 {0}の再インストールを完了するには、Azure Data Studio を再度読み込んでください。</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">マーケット プレース</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">拡張機能の推奨事項のシナリオの種類を指定する必要があります。</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">Azure Data Studio '{1}' と互換性がないため、拡張機能 '{0}' をインストールできません。</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新しいクエリ</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">新しいクエリ(&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">新しいノートブック(&amp;N)</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">大きなファイルを開こうとすると再起動後に Azure Data Studio に対して使用できるメモリを制御します。コマンド ラインで '--max-memory=NEWSIZE' を指定する場合と同じ効果があります。</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">Azure Data Studio の UI 言語を {0} に変更して再起動しますか?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">{0}で Azure Data Studio を使用するには、Azure Data Studio を再起動する必要があります。</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">新しい SQL ファイル</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新しいノートブック</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">VSIX パッケージから拡張機能をインストールする</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">一覧からオプションを選択する必要があります</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">ボックスを選択</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">ノートブックの表示</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">検索結果</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">検索パスが見つかりません: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">ノートブック</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">イメージのコピーはサポートされていません</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">現在のクエリにフォーカスを移動する</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">クエリの実行</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">現在のクエリを実行</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">結果を含むクエリのコピー</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">クエリと結果が正常にコピーされました。</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">実際のプランで現在のクエリを実行</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">クエリのキャンセル</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">IntelliSense キャッシュの更新</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">クエリ結果の切り替え</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">クエリと結果の間のフォーカスの切り替え</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">ショートカットを実行するにはエディター パラメーターが必須です</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">クエリの解析</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">コマンドが正常に完了しました</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">コマンドが失敗しました: </target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">サーバーに接続してください</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">同じ名前のサーバー グループが既に存在します。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">成功</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">失敗</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">進行中</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">未開始</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">キャンセル済み</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">キャンセル中</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">指定されたデータでグラフを表示できません</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">ダッシュ ボードで使用されているウィジェット</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">リンクを開いているときにエラーが発生しました: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">コマンド '{0}' の実行でエラーが発生しました: {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">エラー {0} でコピーに失敗しました</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">グラフの表示</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">テーブルの表示</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;ダブルクリックして編集&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;ここにコンテンツを追加...&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">ノード '{0}' の更新でエラーが発生しました: {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">完了</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">スクリプトの生成</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">次へ</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">前へ</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">タブが初期化されていません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated"> が必須です。</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">無効な入力です。数値が必要です。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">バックアップ ファイルのパス</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">ターゲット データベース</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">復元</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">データベースの復元</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">データベース</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">バックアップ ファイル</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">データベースの復元</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">スクリプト</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">ソース</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">復元元</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">バックアップ ファイルのパスが必須です。</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">１つまたは複数のファイル パスをコンマで区切って入力してください。</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">データベース</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">ターゲット</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">復元先</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">復元計画</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">復元するバックアップ セット</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">データベース ファイルを名前を付けて復元</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">データベース ファイルの詳細を復元する</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">論理ファイル名</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">ファイルの種類</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">元のファイル名</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">復元ファイル名</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">復元オプション</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">ログ末尾のバックアップ</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">サーバーの接続</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">全般</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">ファイル</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">オプション​​</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">セルをコピー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">完了</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">コピーして開く</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">ユーザー コード</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">Web サイト</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">インデックス {0} が無効です。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">サーバーの説明 (省略可能)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">詳細プロパティ</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">破棄</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">認識されない nbformat v{0}.{1}</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">このファイルは有効なノートブック形式ではありません</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">セルの種類 {0} が不明</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">出力の種類 {0} を認識できません</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">{0} のデータは、文字列または文字列の配列である必要があります</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">出力の種類 {0} を認識できません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">ようこそ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 管理パック</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 管理パック</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">SQL Server の管理パックは、一般的なデータベース管理拡張機能のコレクションであり、SQL Server の管理に役立ちます</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Azure Data Studio のリッチ クエリ エディターを使用して PowerShell スクリプトを作成して実行します</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">データ仮想化</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">SQL Server 2019 を使用してデータを仮想化し、インタラクティブなウィザードを使用して外部テーブルを作成します</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">Azure Data Studio で Postgres データベースを接続、クエリ、および管理します</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">{0} のサポートは既にインストールされています。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">{0} に追加のサポートをインストールしたあと、ウィンドウが再度読み込まれます。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">{0} に追加のサポートをインストールしています...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">ID {1} のサポート {0} は見つかりませんでした。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">新しい接続</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">新しいクエリ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">新しいノートブック</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">サーバーのデプロイ</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">ようこそ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">新規</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">開く…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">ファイルを開く…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">フォルダーを開く</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">ツアーの開始</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">クイック ツアー バーを閉じる</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">Azure Data Studio のクイック ツアーを開始しますか?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">ようこそ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">パス {1} のフォルダー {0} を開く</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">インストール</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">{0} キーマップのインストール</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">{0} に追加のサポートをインストールする</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">インストール済み</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">{0} キーマップは既にインストールされています</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">{0} のサポートは既にインストールされています</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">詳細</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">ウェルカム ページの背景色。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">イベント テキストの Profiler エディター。読み取り専用</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">結果を保存できませんでした。 </target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">結果ファイルの選択</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (コンマ区切り)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Excel ブック</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">プレーン テキスト</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">ファイルを保存しています...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">結果が {0} に正常に保存されました </target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">ファイルを開く</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">テキスト ラベルの非表示</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">テキスト ラベルの表示</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">ビュー モデル用のモードビュー コード エディター。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">情報</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">警告</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">エラー</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">詳細の表示</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">コピー</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">閉じる</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">戻る</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">詳細を表示しない</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">アカウント</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">リンクされたアカウント</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">閉じる</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">リンクされているアカウントはありません。アカウントを追加してください。</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">アカウントを追加する</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">有効にされているクラウドがありません。[設定] -&gt; [Azure アカウント構成の検索] に移動し、 少なくとも 1 つのクラウドを有効にしてください</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">認証プロバイダーを選択していません。もう一度お試しください。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">予期しないエラーにより、実行が失敗しました: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">総実行時間: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">行 {0} でのクエリの実行が開始されました</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">バッチ {0} の実行を開始しました</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">バッチ実行時間: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">エラー {0} でコピーに失敗しました</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">開始</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">新しい接続</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">新しいクエリ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">新しいノートブック</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">ファイルを開く</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">ファイルを開く</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">デプロイ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">新しいデプロイ…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">最近</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">その他...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">最近使用したフォルダーなし</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">ヘルプ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">はじめに</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">ドキュメント</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">問題または機能要求を報告する</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">GitHub リポジトリ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">リリース ノート</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">起動時にウェルカム ページを表示する</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">カスタマイズ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">拡張</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">SQL Server 管理パックなど、必要な拡張機能をダウンロードする</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">キーボード ショートカット</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">お気に入りのコマンドを見つけてカスタマイズする</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">配色テーマ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">エディターとコードの外観を自由に設定します</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">詳細</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">すべてのコマンドの検索と実行</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">コマンド パレット ({0}) にすばやくアクセスしてコマンドを検索します</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">最新リリースの新機能を見る</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">毎月新機能を紹介する新しいブログ記事</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Twitter でフォローする</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">コミュニティがどのように Azure Data Studio を使用しているかについて、最新情報を把握し、エンジニアと直接話し合います。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">接続</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">切断</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">開始</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">新しいセッション</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">一時停止</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">再開</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">データのクリア</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">データをクリアしますか?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">自動スクロール: オン</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">自動スクロール: オフ</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">折りたたんだパネルを切り替える</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">列の編集</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">次の文字列を検索</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">前の文字列を検索</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Profiler を起動</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">フィルター...</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">フィルターのクリア</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">フィルターをクリアしますか?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">イベント (フィルター処理済み): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">イベント: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">イベント数</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">利用できるデータはありません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">結果</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">メッセージ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">オブジェクトに対するスクリプトの選択を呼び出したときに返されたスクリプトはありません </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">選択</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">作成</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">挿入</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">更新</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">削除</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">オブジェクト {1} に対する {0} としてスクリプトを作成したときに返されたスクリプトはありません</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">スクリプト作成に失敗しました</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">{0} としてスクリプトを作成したときに返されたスクリプトはありません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">テーブル ヘッダーの背景色</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">テーブル ヘッダーの前景色</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">リスト/テーブルがアクティブなときに選択した項目とフォーカスのある項目のリスト/テーブル背景色</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">セルの枠線の色。</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">入力ボックスの背景が無効にされました。</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">入力ボックスの前景が無効にされました。</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">フォーカスしたときのボタンの外枠の色。</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">チェック ボックスの前景が無効にされました。</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">SQL Agent のテーブル背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">SQL エージェントのテーブル セル背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">SQL Agent のテーブル ホバー背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">SQL Agent の見出し背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">SQL Agent のテーブル セル枠線色。</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">結果メッセージのエラー色。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">バックアップ名</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">復旧モデル</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">バックアップの種類</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">バックアップ ファイル</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">アルゴリズム</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">証明書または非対称キー</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">メディア</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">既存のメディア セットにバックアップ</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">新しいメディア セットにバックアップ</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">既存のバックアップ セットに追加</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">既存のすべてのバックアップ セットを上書きする</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">新しいメディア セット名</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">新しいメディア セットの説明</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">メディアに書き込む前にチェックサムを行う</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">完了時にバックアップを検証する</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">エラー時に続行</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">有効期限</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">バックアップ保持日数の設定</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">コピーのみのバックアップ</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">高度な構成</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">圧縮</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">バックアップの圧縮の設定</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">暗号化</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">トランザクション ログ</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">トランザクション ログの切り捨て</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">ログ末尾のバックアップ</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">信頼性</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">メディア名が必須です</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">使用可能な証明書または非対称キーがありません</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">ファイルを追加</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">ファイルを削除</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">入力が無効です。値は 0 以上でなければなりません。</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">スクリプト</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">バックアップ</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">ファイルへのバックアップのみがサポートされています</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">バックアップ ファイルのパスが必須です</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">このデータ プロバイダーに対して無効になっている別の形式で結果を保存しています。</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">プロバイダーが登録されていないため、データをシリアル化できません</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">不明なエラーにより、シリアル化に失敗しました</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">ビュー データを提供できるデータ プロバイダーが登録されていません。</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">テーブル ヘッダーの背景色</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">最新の情報に更新</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">テーブル ヘッダーの前景色</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">すべて折りたたむ</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">リスト/テーブルがアクティブなときに選択した項目とフォーカスのある項目のリスト/テーブル背景色</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">コマンド {1} の実行中にエラー {0} が発生しました。{1} を提供する拡張機能が原因である可能性があります。</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">セルの枠線の色。</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">入力ボックスの背景が無効にされました。</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">入力ボックスの前景が無効にされました。</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">フォーカスしたときのボタンの外枠の色。</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">チェック ボックスの前景が無効にされました。</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">SQL Agent のテーブル背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">SQL エージェントのテーブル セル背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">SQL Agent のテーブル ホバー背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">SQL Agent の見出し背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">SQL Agent のテーブル セル枠線色。</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">結果メッセージのエラー色。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">アクティブなセルを選択して、もう一度お試しください</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">読み込まれた拡張機能の一部は古い API を使用しています。[開発者ツール] ウィンドウの [コンソール] タブで詳細情報を確認してください。</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">セルの実行</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">実行のキャンセル</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">最後の実行でエラーが発生しました。もう一度実行するにはクリックしてください</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">今後表示しない</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">タスクをキャンセルできませんでした。</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">スクリプト</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">詳細の切り替え</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">読み込み中</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">ホーム</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">"{0}" セクションに無効なコンテンツがあります。機能拡張の所有者にお問い合わせください。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">ジョブ</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">ノートブック</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">アラート</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">プロキシ</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">演算子</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">サーバーのプロパティ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">データベースのプロパティ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">すべて選択/選択解除</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">フィルターの表示</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">クリア</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近の接続</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">サーバー</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">サーバー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">バックアップ ファイル</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">すべてのファイル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">検索: 検索語句を入力し Enter を押して検索するか、Esc を押して取り消します</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">検索</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">データベースを変更できませんでした</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">最後の発生</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">有効</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">応答間の遅延 (秒)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">カテゴリ名</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">電子メール アドレス</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">有効</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">アカウント名</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">資格情報名</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">説明</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">有効</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">オブジェクトを読み込んでいます</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">データベースを読み込んでいます</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">オブジェクトの読み込みが完了しました。</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">データベースの読み込みが完了しました。</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">型の名前で検索する (t:、v:、f:、sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">検索データベース</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">オブジェクトを読み込めません</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">データベースを読み込めません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">プロパティを読み込んでいます...</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">プロパティの読み込みが完了しました</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">ダッシュボードのプロパティを読み込めません</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">{0} を読み込んでいます</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">{0} の読み込みが完了しました</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">自動更新: オフ</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">最終更新日: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">表示する結果がありません。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">ステップ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">CSV として保存</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">JSON として保存</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Excel として保存</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">XML として保存</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">JSON にエクスポートするときに結果のエンコードは保存されません。ファイルが作成されたら、目的のエンコードで保存することを忘れないでください。</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">バッキング データ ソースでファイルへの保存はサポートされていません</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">コピー</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">ヘッダー付きでコピー</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">すべて選択</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">最大化</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">復元</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">グラフ</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">ビジュアライザー</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">F5 ショートカット キーでは、コード セルを選択する必要があります。実行するコード セルを選択してください。</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">結果をクリアするには、コード セルを選択する必要があります。実行するコード セルを選択してください。</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">ステップ ID</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">完了</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">ステップ名</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">メッセージ</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">スクリプトの生成</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">次へ</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">前へ</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">タブが初期化されていません</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">検索</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">ID '{0}' のツリー ビューは登録されていません。</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">検索</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">有効な providerId を持つ NotebookProvider をこのメソッドに渡す必要があります</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">前の一致項目</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">ノートブック プロバイダーが見つかりません</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">次の一致項目</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">マネージャーが見つかりません</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">ノートブック {0} の Notebook Manager にサーバー マネージャーがありません。それに対して操作を実行できません</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">ノートブック {0} の Notebook Manager にコンテンツ マネージャーがありません。それに対して操作を実行できません</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">ノートブック {0} の Notebook Manager にセッション マネージャーがありません。それに対して操作を実行できません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">有効な providerId を持つ NotebookProvider をこのメソッドに渡す必要があります</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">詳細の表示</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">詳細情報</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">保存されているすべてのアカウントのクリア</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">プレビュー機能</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">未リリースのプレビュー機能を有効にする</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">起動時に接続ダイアログを表示</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">古い API 通知</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">古い API 使用状況通知を有効または無効にする</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">編集データ セッションの接続に失敗しました</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">プロファイラー</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">未接続</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">サーバー {0} で XEvent Profiler セッションが予期せず停止しました。</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">新しいセッションを開始中にエラーが発生しました</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">{0} の XEvent Profiler セッションのイベントが失われました。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">アクションの表示</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">リソース ビューアー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">情報</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">警告</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">エラー</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">詳細の表示</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">コピー</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">閉じる</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">検索で多数の結果が返されました。最初の 999 件の一致のみ強調表示されます。</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">戻る</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0}/{1} 件</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">結果なし</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">詳細を表示しない</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">水平バー</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">バー</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">直線</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">円</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">散布</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">時系列</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">イメージ</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">カウント</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">テーブル</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">ドーナツ</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">グラフを作成するデータセットの行を取得できませんでした。</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">グラフの種類 '{0}' はサポートされていません。</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">パラメーター</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated"> が必須です。</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">無効な入力です。数値が必要です。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">接続先</target>
-      </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
-        <target state="translated">切断</target>
-      </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">保存されていない接続</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">インデックス {0} が無効です。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">参照 (プレビュー)</target>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">空白</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">一覧にフィルターをかけるには、ここに入力します</target>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">列 {0} のすべてのチェック ボックスをオンにする</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">接続のフィルター</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">フィルターを適用しています</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">フィルターを削除しています</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">フィルター適用済み</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">フィルターが削除されました</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存された接続</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存された接続</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">接続ブラウザー ツリー</target>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">アクションの表示</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">この拡張機能は Azure Data Studio で推奨されます。</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">読み込み中</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">読み込み完了</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">今後表示しない</target>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">無効な値</target>
       </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio には拡張機能の推奨事項があります。</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio には、データ可視化の拡張機能の推奨事項があります。
-インストールすると、ビジュアライザー アイコンを選択して、クエリ結果を視覚化できます。</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">すべてをインストール</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">推奨事項を表示</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">拡張機能の推奨事項のシナリオの種類を指定する必要があります。</target>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}。{1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">この機能ページはプレビュー段階です。プレビュー機能では、製品の永続的な部分になる予定の新しい機能が導入されています。これらは安定していますが、追加のアクセシビリティの改善が必要です。開発中の早期のフィードバックを歓迎しています。</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">読み込み中</target>
       </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">プレビュー</target>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">読み込み完了</target>
       </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">接続の作成</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">ビュー モデル用のモードビュー コード エディター。</target>
       </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">接続ダイアログを使用してデータベース インスタンスに接続します。</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">型 {0} のコンポーネントが見つかりませんでした</target>
       </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">クエリの実行</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">保存されていないファイルでの編集者の種類の変更はサポートされていません</target>
       </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">クエリ エディターを使用してデータを操作します。</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">上位 1000 を選択する</target>
       </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">ノートブックの作成</target>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">10 個</target>
       </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">ネイティブのノートブック エディターを使用して、新しいノートブックを作成します。</target>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">実行としてのスクリプト</target>
       </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">サーバーのデプロイ</target>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">変更としてのスクリプト</target>
       </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">選択したプラットフォームでリレーショナル データ サービスの新しいインスタンスを作成します。</target>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">データの編集</target>
       </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">リソース</target>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">作成としてのスクリプト</target>
       </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">履歴</target>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">ドロップとしてのスクリプト</target>
       </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">オブジェクトに対するスクリプトの選択を呼び出したときに返されたスクリプトはありません </target>
       </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">場所</target>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">選択</target>
       </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">さらに表示</target>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">作成</target>
       </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">起動時にウェルカム ページを表示する</target>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">挿入</target>
       </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">役に立つリンク</target>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">更新</target>
       </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">はじめに</target>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">削除</target>
       </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Azure Data Studio によって提供される機能を検出し、それらを最大限に活用する方法について説明します。</target>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">オブジェクト {1} に対する {0} としてスクリプトを作成したときに返されたスクリプトはありません</target>
       </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">ドキュメント</target>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">スクリプト作成に失敗しました</target>
       </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">PowerShell、API などのクイックスタート、攻略ガイド、リファレンスについては、ドキュメント センターを参照してください。</target>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">{0} としてスクリプトを作成したときに返されたスクリプトはありません</target>
       </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Azure Data Studio の概要</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
+        <target state="translated">切断されました</target>
       </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Azure Data Studio ノートブックの概要 | 公開されたデータ</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
         <target state="translated">拡張</target>
       </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">すべて表示</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">垂直タブのアクティブなタブの背景色</target>
       </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">詳細情報</target>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">ダッシュボードの境界線の色</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">ダッシュボード ウィジェットのタイトルの色</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">ダッシュボード ウィジェット サブテキストの色</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">プロパティ コンテナー コンポーネントに表示されるプロパティ色の値</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">プロパティ コンテナー コンポーネントに表示されるプロパティ名の色</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">ツールバーのオーバーフローの影の色</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">作成日: </target>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">アカウントの種類の識別子</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">ノートブック エラー: </target>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(省略可能) UI の accpunt を表すために使用するアイコン。ファイル パスまたはテーマを設定可能な構成のいずれかです</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">ジョブ エラー: </target>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">明るいテーマを使用した場合のアイコンのパス</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">ピン留めされました</target>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">暗いテーマを使用した場合のアイコンのパス</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">最近の実行</target>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">アカウント プロバイダーにアイコンを提供します。</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">過去の実行</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">適用可能な規則を表示する</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">{0} に適用可能な規則を表示する</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">評価の呼び出し</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">{0} の評価の呼び出し</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">スクリプトとしてエクスポート</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">すべての規則を表示し、GitHub の詳細を確認する</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">HTML レポートの作成</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">レポートが保存されました。開きますか?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開く</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">データベース {0} は、ベスト プラクティスに完全に準拠しています。お疲れさまでした。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">グラフ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">操作</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">オブジェクト</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">推定コスト</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">サブ ツリーの推定コスト</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">実際の行数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">推定行数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">実際の実行</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">推定 CPU コスト</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">推定 IO コスト</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">並列</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">実際の再バインド数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">再バインドの推定数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">実際の巻き戻し数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">巻き戻しの推定数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">パーティション分割</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">上位操作</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">接続が見つかりません。</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">接続の追加</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">アカウントを追加する...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;既定&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">読み込んでいます...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">サーバー グループ</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;既定&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">新しいグループを追加する...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;保存しない&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} が必須です。</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0} がトリミングされます。</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">パスワードを記憶する</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">アカウント</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">アカウントの資格情報を更新</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Azure AD テナント</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">名前 (省略可能)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">詳細設定...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">アカウントを選択する必要があります</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">データベース</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">ファイルとファイル グループ</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">完全</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">差分</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">トランザクション ログ</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">ディスク</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">既定のサーバー設定を使用する</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">バックアップの圧縮</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">バックアップを圧縮しない</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">サーバー証明書</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">非対称キー</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">ノートブックまたはブックを格納するフォルダーを開いていません。</target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">ノートブックを開く</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">結果セットにはすべての一致項目のサブセットのみが含まれています。より限定的な検索条件を入力して、検索結果を絞り込んでください。</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">検索中です...</target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">'{0}' に '{1}' を除外した結果はありません - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">'{0}' に結果はありません - </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">'{0}' を除外した結果はありませんでした - </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">結果がありません。除外構成の設定を確認し、gitignore ファイルを調べてください - </target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">もう一度検索</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">検索のキャンセル</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">すべてのファイルでもう一度検索してください</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">設定を開く</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">検索により {1} 個のファイル内の {0} 件の結果が返されました</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">折りたたみと展開の切り替え</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">検索のキャンセル</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">すべて展開</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">すべて折りたたむ</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">検索結果のクリア</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">接続</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">SQL Server、Azure などからの接続を接続、クエリ、および管理します。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">次へ</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">ノートブック</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">1 か所で独自のノートブックまたはノートブックのコレクションの作成を開始します。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">拡張</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Microsoft (私たち) だけでなくサードパーティ コミュニティ (あなた) が開発した拡張機能をインストールすることにより、Azure Data Studio の機能を拡張します。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">設定</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">好みに応じて Azure Data Studio をカスタマイズします。自動保存やタブ サイズなどの設定の構成、キーボード ショートカットのカスタマイズ、好きな配色テーマへの切り替えを行うことができます。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">ウェルカム ページ</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">ウェルカム ページで、トップの機能、最近開いたファイル、推奨される拡張機能がわかります。Azure Data Studio で作業を開始する方法の詳細については、ビデオとドキュメントをご覧ください。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">完了</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">ユーザー紹介ツアー</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">紹介ツアーの非表示</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">詳細情報</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">ヘルプ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">行の削除</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">現在の行を元に戻す</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">メッセージ パネル</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">コピー</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">すべてコピー</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">Azure Portal で開きます</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">読み込み中</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">バックアップ名</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">読み込み完了</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">復旧モデル</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">バックアップの種類</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">バックアップ ファイル</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">アルゴリズム</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">証明書または非対称キー</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">メディア</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">既存のメディア セットにバックアップ</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">新しいメディア セットにバックアップ</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">既存のバックアップ セットに追加</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">既存のすべてのバックアップ セットを上書きする</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">新しいメディア セット名</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">新しいメディア セットの説明</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">メディアに書き込む前にチェックサムを行う</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">完了時にバックアップを検証する</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">エラー時に続行</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">有効期限</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">バックアップ保持日数の設定</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">コピーのみのバックアップ</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">高度な構成</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">圧縮</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">バックアップの圧縮の設定</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">暗号化</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">トランザクション ログ</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">トランザクション ログの切り捨て</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">ログ末尾のバックアップ</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">信頼性</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">メディア名が必須です</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">使用可能な証明書または非対称キーがありません</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">ファイルを追加</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">ファイルを削除</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">入力が無効です。値は 0 以上でなければなりません。</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">スクリプト</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">バックアップ</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">ファイルへのバックアップのみがサポートされています</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">バックアップ ファイルのパスが必須です</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">次をクリック</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ コード</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">または</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ テキスト</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">コードまたはテキストのセルを追加するため</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">バックアップ</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">StdIn:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">バックアップを使用するにはプレビュー機能を有効にする必要があります</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">バックアップ コマンドは、データベース コンテキストの外ではサポートされていません。データベースを選択して、もう一度お試しください。</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL データベースでは、バックアップ コマンドはサポートされていません。</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">バックアップ</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">コード セルの内容の展開</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">データベース</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">コード セル コンテンツを折りたたむ</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">ファイルとファイル グループ</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">完全</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">差分</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">トランザクション ログ</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">ディスク</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">既定のサーバー設定を使用する</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">バックアップの圧縮</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">バックアップを圧縮しない</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">サーバー証明書</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">非対称キー</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">XML プラン表示</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">結果グリッド</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">セルの追加</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">コード セル</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">テキスト セル</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">セルを下に移動します</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">セルを上に移動します</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">削除</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">セルの追加</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">コード セル</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">テキスト セル</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">SQL カーネル エラー</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">ノートブックのセルを実行するには、接続を選択する必要があります</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">上位 {0} 行を表示しています。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">前回の実行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">次回の実行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">有効</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">状態</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">カテゴリ</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">実行可能</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">スケジュール</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">前回の実行の結果</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">以前の実行</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">このジョブに利用できるステップはありません。</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">エラー: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">型 {0} のコンポーネントが見つかりませんでした</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">検索</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">検索</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">前の一致項目</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">次の一致項目</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">閉じる</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">検索で多数の結果が返されました。最初の 999 件の一致のみ強調表示されます。</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} / {1} 件</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">結果なし</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">スキーマ</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">種類</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">クエリの実行</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">出力用の {0} レンダラーが見つかりませんでした。次の MIME の種類があります: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">安全 </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">セレクター {0} のコンポーネントが見つかりませんでした</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">コンポーネントのレンダリング エラー: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">読み込んでいます...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">読み込んでいます...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">編集</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">終了</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">最新の情報に更新</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">アクションの表示</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">ウィジェットの削除</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">クリックしてピン留めを外します</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">クリックしてピン留めします</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">インストールされている機能を開く</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">ウィジェットの折りたたみ</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">ウィジェットの展開</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} は不明なコンテナーです。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名前</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">ターゲット データベース</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">前回の実行</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">次回の実行</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">状態</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">前回の実行の結果</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">以前の実行</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">このジョブに利用できるステップはありません。</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">エラー: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">ノートブック エラー: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">読み込みエラー...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">アクションの表示</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">一致する項目が見つかりませんでした</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">検索一覧が 1 項目にフィルター処理されました</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">検索一覧が {0} 項目にフィルター処理されました</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">失敗</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">成功</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">再試行</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">取り消されました</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">進行中</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">不明な状態</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">実行中</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">スレッドを待機しています</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">再試行の間</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">アイドル状態</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">中断中</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[古い]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">はい</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">いいえ</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">スケジュールが設定されていません</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">実行しない</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">太字</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">斜体</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">下線を付ける</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">強調表示</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">コード</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">リンク</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">リスト</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">順序指定済みリスト</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">イメージ</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">マークダウン プレビューの切り替え - オフ</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">見出し</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">見出し 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">見出し 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">見出し 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">段落</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">リンクの挿入</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">画像の挿入</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">リッチ テキスト ビュー</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">分割ビュー</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">マークダウン ビュー</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">分析情報の作成</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">アクティブなエディターが SQL エディターではないため、分析情報を作成できません</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">マイ ウィジェット</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">グラフの構成</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">イメージとしてコピー</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">保存するグラフが見つかりませんでした</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">イメージとして保存</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">グラフが保存されたパス: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">グラフ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">水平バー</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">バー</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">直線</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">円</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">散布</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">時系列</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">イメージ</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">カウント</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">テーブル</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">ドーナツ</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">グラフを作成するデータセットの行を取得できませんでした。</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">グラフの種類 '{0}' はサポートされていません。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">組み込みグラフ</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">グラフに表示する最大の行数です。警告: これを大きくするとパフォーマンスに影響が及ぶ場合があります。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">閉じる</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">同じ名前のサーバー グループが既に存在します。</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">系列 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">テーブルに有効なイメージが含まれていません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">組み込みグラフの最大行カウントを超過しました。最初の {0} 行だけが使用されます。値を構成するには、ユーザー設定を開き、'builtinCharts.maxRowCount' を検索してください。</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">今後表示しない</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">接続中: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">実行中のコマンド: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">新しいクエリを開いています: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">サーバー情報が提供されていないため接続できません</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">エラー {0} により URL を開くことができませんでした</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">これにより、サーバー {0} に接続されます</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">接続しますか?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">開く(&amp;&amp;O)</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">クエリ ファイルへの接続中</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">ユーザー設定の {0} は {1} に置き換えられました。</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">ワークスペース設定の {0} は {1} に置き換えられました。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">接続リストに格納する最近使用された接続の最大数。</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">使用する既定の SQL エンジン。.sql ファイル内の既定の言語プロバイダーが駆動され、新しい接続が作成されるときに既定で使用されます。</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">接続ダイアログが開いたり、解析が実行されたりするときにクリップボードの内容の解析を試行します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">接続状態</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">プロバイダーの共通 ID</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">プロバイダーの表示名</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">プロバイダーの Notebook カーネル別名</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">サーバーの種類のアイコン パス</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">接続のオプション</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">ツリー プロバイダーのユーザー表示名</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">プロバイダーの ID は、ツリー データ プロバイダーを登録するときと同じである必要があり、'connectionDialog/' で始まる必要があります</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">このコンテナーの一意の識別子。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">タブに表示されるコンテナー。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">単一または複数のダッシュ ボード コンテナーを提供し、ユーザーが自分のダッシュボードに追加できるようにします。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">ダッシュボード コンテナーに、拡張用に指定された ID はありません。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">ダッシュボード コンテナーに、拡張用に指定されたコンテナーはありません。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">空間ごとにダッシュボード コンテナーを 1 つだけ定義する必要があります。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">拡張用にダッシュボード コンテナーで定義されているコンテナーの種類が不明です。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">このタブに表示される controlhost。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">"{0}" セクションに無効なコンテンツがあります。機能拡張の所有者にお問い合わせください。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">このタブに表示されるウィジェットまたは Web ビューのリスト。</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">ウィジェットや Web ビューが拡張機能用のウィジェット コンテナー内に必要です。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">このタブに表示されるモデルに基づくビュー。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">このナビゲーション セクションの一意の識別子。すべての要求で拡張機能に渡されます。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(省略可能) UI でこのナビゲーション セクションを表すために使用されるアイコン。ファイル パスまたはテーマを設定可能な構成のいずれかです</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">明るいテーマを使用した場合のアイコンのパス</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">暗いテーマを使用した場合のアイコンのパス</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">ユーザーに表示するナビゲーション セクションのタイトル。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">このナビゲーション セクションに表示されるコンテナー。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">このナビゲーション セクションに表示されるダッシュボード コンテナーのリスト。</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">ナビゲーション セクションに、拡張用に指定されたタイトルはありません。</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">ナビゲーション セクションに、拡張用に指定されたコンテナーはありません。</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">空間ごとにダッシュボード コンテナーを 1 つだけ定義する必要があります。</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION 内の NAV_SECTION は拡張用に無効なコンテナーです。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">このタブに表示される Web ビュー。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">このタブに表示されるウィジェットのリスト。</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">拡張には、ウィジェット コンテナー内にウィジェットのリストが必要です。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">編集</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">終了</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">最新の情報に更新</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">アクションの表示</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">ウィジェットの削除</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">クリックしてピン留めを外します</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">クリックしてピン留めします</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">インストールされている機能を開く</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">ウィジェットの折りたたみ</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">ウィジェットの展開</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} は不明なコンテナーです。</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">分析情報の作成</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">このタブの一意の識別子。すべての要求で拡張機能に渡されます。</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">アクティブなエディターが SQL エディターではないため、分析情報を作成できません</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">ユーザーを表示するタブのタイトル。</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">マイ ウィジェット</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">ユーザーに表示されるこのタブの説明。</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">グラフの構成</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">この項目を表示するために true にする必要がある条件</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">イメージとしてコピー</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">このタブと互換性のある接続の種類を定義します。設定されていない場合、既定値は 'MSSQL' に設定されます</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">保存するグラフが見つかりませんでした</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">このタブに表示されるコンテナー。</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">イメージとして保存</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">このタブを常に表示するか、またはユーザーが追加したときにのみ表示するかどうか。</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">このタブを接続の種類の [ホーム] タブとして使用するかどうか。</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">グラフが保存されたパス: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">このタブが属しているグループの一意識別子。ホーム グループの値: home。</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(省略可能) UI でこのタブを表すために使用されるアイコン。ファイル パスまたはテーマを設定可能な構成のいずれかです</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">明るいテーマを使用した場合のアイコンのパス</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">暗いテーマを使用した場合のアイコンのパス</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">ユーザーがダッシュボードに追加する 1 つまたは、複数のタブを提供します。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">拡張機能にタイトルが指定されていません。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">表示するよう指定された説明はありません。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">拡張機能にコンテナーが指定されていません。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">空間ごとにダッシュボード コンテナーを 1 つだけ定義する必要があります</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">このタブ グループの一意識別子。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">タブ グループのタイトル。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">ユーザーがダッシュボードに追加するための 1 つまたは複数のタブ グループを提供します。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">タブ グループの ID が指定されていません。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">タブ グループのタイトルが指定されていません。</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">管理</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">監視中</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">パフォーマンス</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">セキュリティ</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">トラブルシューティング</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">設定</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">データベース タブ</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">データベース</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">コードの追加</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">テキストの追加</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">ダッシュボード</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">ファイルの作成</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">コンテンツを表示できませんでした: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">プロパティ `icon` は省略するか、文字列または `{dark, light}` などのリテラルにする必要があります</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">セルの追加</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">ダッシュ ボードに表示するプロパティを定義します</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">コード セル</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">プロパティのラベルとして使用する値</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">テキスト セル</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">値にアクセスするためのオブジェクト内の値</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">すべて実行</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">無視される値を指定します</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">セル</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">無視されるか値がない場合に表示される既定値です</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">コード</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">ダッシュボードのプロパティを定義するためのフレーバー</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">テキスト</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">フレーバーの ID</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">セルの実行</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">このフレーバーを使用する条件</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; 前へ</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">比較するフィールド</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">次へ &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">比較に使用する演算子</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">URI {0} を含むセルは、このモデルには見つかりませんでした</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">フィールドを比較する値</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">セルの実行に失敗しました。詳細については、現在選択されているセルの出力内のエラーをご覧ください。</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">データベース ページに表示するプロパティ</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">サーバー ページに表示するプロパティ</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">このプロバイダーがダッシュボードをサポートすることを定義します</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">プロバイダー ID (例: MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">ダッシュボードに表示するプロパティ値</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">この項目を表示するために true にする必要がある条件</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">ウィジェットのヘッダーを非表示にするかどうか。既定値は false です。</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">コンテナーのタイトル</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">グリッド内のコンポーネントの行</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">グリッド内のコンポーネントの rowspan。既定値は 1 です。グリッド内の行数に設定するには '*' を使用します。</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">グリッド内のコンポーネントの列</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">グリッドのコンポーネントの colspan。既定値は 1 です。グリッドの列数に設定するには '*' を使用します。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">このタブの一意の識別子。すべての要求で拡張機能に渡されます。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">拡張機能タブが不明またはインストールされていません。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">データベースのプロパティ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">プロパティ ウィジェットを有効または無効にする</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">表示するプロパティ値</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">プロパティの表示名</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">データベース情報オブジェクトの値</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">無視する特定の値を指定します</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">復旧モデル</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">前回のデータベース バックアップ</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">最終ログ バックアップ</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">互換性レベル</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">所有者</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">データベース ダッシュボード ページをカスタマイズする</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">検索</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">データベース ダッシュボード タブをカスタマイズする</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">サーバーのプロパティ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">プロパティ ウィジェットを有効または無効にする</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">表示するプロパティ値</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">プロパティの表示名</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">サーバー情報オブジェクトの値</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">バージョン</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">エディション</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">コンピューター名</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">OS バージョン</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">検索</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">サーバー ダッシュ ボード ページをカスタマイズします</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">サーバー ダッシュボードのタブをカスタマイズします</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">ホーム</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">データベースを変更できませんでした</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">アクションの表示</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">一致する項目が見つかりませんでした</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">検索一覧が 1 項目にフィルター処理されました</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">検索一覧が {0} 項目にフィルター処理されました</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">スキーマ</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">種類</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">オブジェクトを読み込んでいます</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">データベースを読み込んでいます</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">オブジェクトの読み込みが完了しました。</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">データベースの読み込みが完了しました。</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">型の名前で検索する (t:、v:、f:、sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">検索データベース</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">オブジェクトを読み込めません</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">データベースを読み込めません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">クエリの実行</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">{0} を読み込んでいます</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">{0} の読み込みが完了しました</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">自動更新: オフ</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">最終更新日: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">表示する結果がありません。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">ウィジェットを追加します。そこでは、サーバーまたはデータベースのクエリを実行して、その結果をグラフや集計されたカウントなどの複数の方法で表示できます</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">分析情報の結果をキャッシュするために使用される一意識別子。</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">実行する SQL クエリ。返す結果セットは 1 つのみでなければなりません。</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[省略可能] クエリを含むファイルへのパス。'クエリ' が設定されていない場合に使用します</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[省略可能] 分単位の自動更新間隔。設定しないと、自動更新されません</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">使用するアクション</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">アクションのターゲット データベース。形式 '${ columnName }' を使用して、データ ドリブン列名を使用できます。</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">アクションのターゲット サーバー。形式 '${ columnName }' を使用して、データ ドリブン列名を使用できます。</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">アクションのターゲット ユーザー。形式 '${ columnName }' を使用して、データ ドリブン列名を使用できます。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">分析情報の識別子</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">ダッシュボード パレットに分析情報を提供します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">指定されたデータでグラフを表示できません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">ダッシュボード上のグラフとしてクエリの結果を表示します</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">'列名' -&gt; 色をマップします。たとえば、「'column1': red」を追加して、この列で赤色が使用されるようにします </target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">グラフの凡例の優先される位置と表示範囲を示します。これはクエリに基づく列名で、各グラフ項目のラベルにマップされます</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">dataDirection が横の場合、true に設定すると凡例に最初の列値が使用されます。</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">dataDirection が縦の場合、true に設定すると凡例に列名が使用されます。</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">データを列 (縦) 方向から、または行 (横) 方向から読み取るかを定義します。時系列の場合、方向は縦にする必要があるため、これは無視されます。</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">showTopNData を設定すると、上位 N 個のデータのみがグラフに表示されます。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Y 軸の最小値</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Y 軸の最大値</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Y 軸のラベル</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">X 軸の最小値</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">X 軸の最大値</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">X 軸のラベル</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">グラフのデータ セットのデータ プロパティを示します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">結果セットの各列について、行 0 の値をカウントとして表示し、その後に列名が続きます。たとえば、'1 正常'、'3 異常' をサポートします。ここで、'正常' は列名、1 は行 1 セル 1 の値です。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">イメージを表示します。例: ggplot2 を使用して R クエリによって返されたイメージ</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">必要な形式は何ですか。JPEG、PNG、またはその他の形式ですか?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">これは 16 進数、base64 または、他の形式でエンコードされていますか？</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">単純なテーブルに結果を表示する</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">プロパティを読み込んでいます...</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">プロパティの読み込みが完了しました</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">ダッシュボードのプロパティを読み込めません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">データベース接続</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">データ ソース接続</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">データソース グループ</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">保存された接続は、追加された日付順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">保存された接続は、表示名のアルファベット順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">保存された接続と接続グループの並べ替え順序を制御します。</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">起動の構成</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">Azure Data Studio の起動時にサーバー ビューを表示する場合には true (既定)。最後に開いたビューを表示する場合には false</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">ビューの識別子。`vscode.window.registerTreeDataProviderForView` API を介してデータ プロバイダーを登録するには、これを使用します。また、`onView:${id}` イベントを `activationEvents` に登録することによって、拡張機能のアクティブ化をトリガーするためにも使用できます。</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">ビューの判読できる名前。これが表示されます</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">このビューを表示するために満たす必要がある条件</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">ビューをエディターに提供します</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">アクティビティ バーのデータ エクスプローラー コンテナーにビューを提供します</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">コントリビューション ビュー コンテナーにビューを提供します</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">ビュー コンテナー '{1}'に同じ ID '{0}' のビューを複数登録できません</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">ビュー ID `{0}` はビュー コンテナー `{1}` に既に登録されています</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">ビューは配列にする必要があります</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">プロパティ `{0}` は必須で、`string` 型でなければなりません</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">プロパティ `{0}` は省略するか、`string` 型にする必要があります</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">サーバー</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">接続</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">接続の表示</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">切断</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">最新の情報に更新</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">起動時にデータ SQL の編集ペインを表示する</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">実行</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">編集内容の破棄がエラーで失敗しました: </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">SQL ペインの表示</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">SQL ペインを閉じる</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">最大行数:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">行の削除</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">現在の行を元に戻す</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">CSV として保存</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">JSON として保存</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Excel として保存</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">XML として保存</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">コピー</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">ヘッダー付きでコピー</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">すべて選択</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">ダッシュボード タブ ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">タイトル</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">説明</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">ダッシュボード分析情報 ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">タイミング</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">ギャラリーから拡張機能情報を取得します</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">拡張機能 ID</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">拡張機能 '{0}' が見つかりませんでした。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">推奨事項を表示</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">拡張機能のインストール</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">拡張機能の作成...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">今後表示しない</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio には拡張機能の推奨事項があります。</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio には、データ可視化の拡張機能の推奨事項があります。
+インストールすると、ビジュアライザー アイコンを選択して、クエリ結果を視覚化できます。</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">すべてをインストール</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">推奨事項を表示</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">拡張機能の推奨事項のシナリオの種類を指定する必要があります。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">この拡張機能は Azure Data Studio で推奨されます。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">ジョブ</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">ノートブック</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">アラート</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">プロキシ</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">演算子</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">最後の発生</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">有効</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">応答間の遅延 (秒)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">カテゴリ名</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">適用可能な規則を表示する</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">ステップ ID</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">{0} に適用可能な規則を表示する</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">ステップ名</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">評価の呼び出し</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">{0} の評価の呼び出し</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">スクリプトとしてエクスポート</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">すべての規則を表示し、GitHub の詳細を確認する</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">HTML レポートの作成</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">レポートが保存されました。開きますか?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開く</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">キャンセル</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">メッセージ</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">データ</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">接続</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">クエリ エディター</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">ノートブック</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">ダッシュボード</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">ステップ</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">ダッシュボード タブ ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">タイトル</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">説明</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">ダッシュボード分析情報 ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">名前</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">タイミング</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">前回の実行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">次回の実行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">有効</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">状態</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">カテゴリ</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">実行可能</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">スケジュール</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">前回の実行の結果</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">以前の実行</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">このジョブに利用できるステップはありません。</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">エラー: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">テーブルに有効なイメージが含まれていません</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">作成日: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">ノートブック エラー: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">ジョブ エラー: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">ピン留めされました</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">最近の実行</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">過去の実行</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">その他</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">編集</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">ターゲット データベース</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">閉じる</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">前回の実行</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">セルの変換</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">次回の実行</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">上のセルの実行</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">状態</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">下のセルの実行</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">前回の実行の結果</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">コードを上に挿入</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">以前の実行</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">コードを下に挿入</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">このジョブに利用できるステップはありません。</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">テキストを上に挿入</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">エラー: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">テキストを下に挿入</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">セルを折りたたむ</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">セルの展開</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">パラメーター セルの作成</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">パラメーター セルの削除</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">結果のクリア</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">ノートブック エラー: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">ノートブック セッションの開始中にエラーが発生しました。</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">不明な理由によりサーバーが起動しませんでした</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">電子メール アドレス</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">カーネル {0} が見つかりませんでした。既定のカーネルが代わりに使用されます。</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">有効</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">系列 {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">アカウント名</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">閉じる</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">資格情報名</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="ja">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated"># Injected-Parameters
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">説明</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">このカーネルのセルを実行する接続を選択してください</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">セルの削除に失敗しました。</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">カーネルの変更に失敗しました。カーネル {0} が使用されます。エラー: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">次のエラーにより、カーネルの変更に失敗しました: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">コンテキストの変更に失敗しました: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">セッションを開始できませんでした: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">ノートブックを閉じるときにクライアント セッション エラーが発生しました: {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">プロバイダー {0} のノートブック マネージャーが見つかりません</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">有効</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">その他</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">編集</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">閉じる</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">セルの変換</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">上のセルの実行</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">下のセルの実行</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">コードを上に挿入</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">コードを下に挿入</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">テキストを上に挿入</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">テキストを下に挿入</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">セルを折りたたむ</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">セルの展開</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">パラメーター セルの作成</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">パラメーター セルの削除</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">結果のクリア</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">セルの追加</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">コード セル</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">テキスト セル</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">セルを下に移動します</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">セルを上に移動します</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">削除</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">セルの追加</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">コード セル</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">テキスト セル</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">パラメーター</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">アクティブなセルを選択して、もう一度お試しください</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">セルの実行</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">実行のキャンセル</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">最後の実行でエラーが発生しました。もう一度実行するにはクリックしてください</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">コード セルの内容の展開</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">コード セル コンテンツを折りたたむ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">太字</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">斜体</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">下線を付ける</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">強調表示</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">コード</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">リンク</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">リスト</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">順序指定済みリスト</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">イメージ</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">マークダウン プレビューの切り替え - オフ</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">見出し</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">見出し 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">見出し 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">見出し 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">段落</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">リンクの挿入</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">画像の挿入</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">リッチ テキスト ビュー</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">分割ビュー</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">マークダウン ビュー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">出力用の {0} レンダラーが見つかりませんでした。次の MIME の種類があります: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">安全 </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">セレクター {0} のコンポーネントが見つかりませんでした</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">コンポーネントのレンダリング エラー: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">次をクリック</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ コード</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">または</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ テキスト</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">コードまたはテキストのセルを追加するため</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">コード セルの追加</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">テキスト セルの追加</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">StdIn:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;ダブルクリックして編集&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;ここにコンテンツを追加...&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">検索</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">検索</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">前の一致項目</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">次の一致項目</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">閉じる</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">検索で多数の結果が返されました。最初の 999 件の一致のみ強調表示されます。</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0}/{1} 件</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">結果なし</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">コードの追加</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">テキストの追加</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">ファイルの作成</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">コンテンツを表示できませんでした: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">セルの追加</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">コード セル</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">テキスト セル</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">すべて実行</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">セル</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">コード</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">テキスト</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">セルの実行</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; 前へ</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">次へ &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">URI {0} を含むセルは、このモデルには見つかりませんでした</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">セルの実行に失敗しました。詳細については、現在選択されているセルの出力内のエラーをご覧ください。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新しいノートブック</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新しいノートブック</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">ワークスペースを設定して開く</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">SQL カーネル: セルでエラーが発生したときに Notebook の実行を停止します。</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(プレビュー) 現在のノートブック プロバイダーのすべてのカーネルを表示します。</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">ノートブックでの Azure Data Studio コマンドの実行を許可します。</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">ノートブックのテキスト セルのダブルクリックして編集を有効する</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">テキストはリッチ テキスト (WYSIWYG とも呼ばれる) として表示されます。</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">マークダウンが左側に表示され、レンダリングされたテキストの右側にプレビューが表示されます。</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">テキストはマークダウンとして表示されます。</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">テキスト セルに使用される既定の編集モード</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(プレビュー) ノートブック メタデータに接続名を保存します。</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">ノートブック マークダウン プレビューで使用される行の高さを制御します。この数値はフォント サイズを基準とします。</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(プレビュー) レンダリングされたノートブックを差分エディターで表示します。</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">ノートブックのリッチ テキスト エディターを元に戻す操作の履歴に格納される変更の最大数です。</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">ノートブックの検索</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">フルテキスト検索および Quick Open でファイルやフォルダーを除外するための glob パターンを構成します。'#files.exclude#' 設定からすべての glob パターンを継承します。glob パターンの詳細については、[こちら](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) を参照してください。</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">ファイル パスの照合基準となる glob パターン。これを true または false に設定すると、パターンがそれぞれ有効/無効になります。</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">一致するファイルの兄弟をさらにチェックします。一致するファイル名の変数として $(basename) を使用します。</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">この設定は推奨されず、現在 "search.usePCRE2" にフォール バックします。</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">推奨されません。高度な正規表現機能サポートのために "search.usePCRE2" の利用を検討してください。</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">有効にすると、searchService プロセスは 1 時間操作がない場合でもシャットダウンされず、アクティブな状態に保たれます。これにより、ファイル検索キャッシュがメモリに保持されます。</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">ファイルを検索するときに、`.gitignore` ファイルと `.ignore` ファイルを使用するかどうかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">ファイルを検索するときに、グローバルの `.gitignore` と `.ignore` ファイルを使用するかどうかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">グローバル シンボル検索の結果を、Quick Open の結果ファイルに含めるかどうか。</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">最近開いたファイルの結果を、Quick Open の結果ファイルに含めるかどうか。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">履歴エントリは、使用されるフィルター値に基づいて関連性によって並び替えられます。関連性の高いエントリが最初に表示されます。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">履歴エントリは、新しい順に並べ替えられます。最近開いたエントリが最初に表示されます。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">フィルター処理時に、 Quick Open におけるエディター履歴の並べ替え順序を制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">検索中にシンボリック リンクをたどるかどうかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">すべて小文字のパターンの場合、大文字と小文字を区別しないで検索し、そうでない場合は大文字と小文字を区別して検索します。</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">macOS で検索ビューが共有の検索クリップボードを読み取りまたは変更するかどうかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">検索をサイドバーのビューとして表示するか、より水平方向の空間をとるためにパネル領域のパネルとして表示するかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">この設定は非推奨です。代わりに検索ビューのコンテキスト メニューをお使いください。</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">結果が 10 件未満のファイルが展開されます。他のファイルは折りたたまれます。</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">検索結果を折りたたむか展開するかどうかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">一致項目を選択するか置換するときに、置換のプレビューを開くかどうかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">検索結果に行番号を表示するかどうかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">テキスト検索に PCRE2 正規表現エンジンを使用するかどうか。これにより、先読みや後方参照といった高度な正規表現機能を使用できるようになります。ただし、すべての PCRE2 機能がサポートされているわけではありません。JavaScript によってサポートされる機能のみが使用できます。</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">廃止されました。PCRE2 でのみサポートされている正規表現機能を使用すると、PCRE2 が自動的に使用されます。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">検索ビューが狭い場合はアクションバーを右に、検索ビューが広い場合はコンテンツの直後にアクションバーを配置します。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">アクションバーを常に右側に表示します。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">検索ビューの行内のアクションバーの位置を制御します。</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">入力中の文字列を全てのファイルから検索する。</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">アクティブなエディターで何も選択されていないときに、カーソルに最も近い語からのシード検索を有効にします。</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">検索ビューにフォーカスを置いたときに、ワークスペースの検索クエリが、エディターで選択されているテキストに更新されます。これは、クリックされたときか、'workbench.views.search.focus' コマンドがトリガーされたときに発生します。</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">'#search.searchOnType#' を有効にすると、文字が入力されてから検索が開始されるまでのタイムアウト (ミリ秒) が制御されます。'search.searchOnType' が無効になっている場合には影響しません。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">ダブルクリックすると、カーソルの下にある単語が選択されます。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">ダブルクリックすると、アクティブなエディター グループに結果が開きます。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">ダブルクリックすると、結果はエディター グループの横に開かれ、まだ存在しない場合は作成されます。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">検索エディターで結果をダブル クリックした場合の効果を構成します。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">結果はフォルダー名とファイル名でアルファベット順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">結果はフォルダーの順序を無視したファイル名でアルファベット順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">結果は、ファイル拡張子でアルファベット順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">結果は、ファイルの最終更新日で降順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">結果は、ファイルあたりの数で降順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">結果は、ファイルごとのカウントで昇順に並べ替えられます。</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">検索結果の並べ替え順序を制御します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">カーネルを読み込んでいます...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">カーネルを変更しています...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">接続先: </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">カーネル </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">コンテキストを読み込んでいます...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">接続の変更</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">接続を選択</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">カーネルなし</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">カーネルがサポートされていないため、このノートブックはパラメーターを指定して実行できません。サポートされているカーネルと形式を使用してください。[詳細情報](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">パラメーター セルが追加されるまで、パラメーターを指定してこのノートブックを実行することはできません。[詳細情報](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">パラメーター セルにパラメーターが追加されるまで、パラメーターを指定してこのノートブックを実行することはできません。[詳細情報] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">結果のクリア</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">信頼されています</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">信頼されていません</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">セルを折りたたむ</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">セルを展開する</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">パラメーターを指定して実行</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">なし</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新しいノートブック</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">次の文字列を検索</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">前の文字列を検索</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">検索結果</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">検索パスが見つかりません: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">ノートブック</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">ノートブックまたはブックを格納するフォルダーを開いていません。</target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">ノートブックを開く</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">結果セットにはすべての一致項目のサブセットのみが含まれています。より限定的な検索条件を入力して、検索結果を絞り込んでください。</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">検索中です...</target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">'{0}' に '{1}' を除外した結果はありません - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">'{0}' に結果はありません - </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">'{0}' を除外した結果はありませんでした - </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">結果がありません。除外構成の設定を確認し、gitignore ファイルを調べてください - </target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">もう一度検索</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">すべてのファイルでもう一度検索してください</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">設定を開く</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">検索により {1} 個のファイル内の {0} 件の結果が返されました</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">折りたたみと展開の切り替え</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">検索のキャンセル</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">すべて展開</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">すべて折りたたむ</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">検索結果のクリア</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">検索: 検索語句を入力し Enter を押して検索するか、Esc を押して取り消します</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">検索</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">URI {0} を含むセルは、このモデルには見つかりませんでした</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">セルの実行に失敗しました。詳細については、現在選択されているセルの出力内のエラーをご覧ください。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">出力を表示するには、このセルを実行してください。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">このビューは空です。[セルの挿入] ボタンをクリックして、このビューにセルを追加します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">エラー {0} でコピーに失敗しました</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">グラフの表示</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">テーブルの表示</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">出力用の {0} レンダラーが見つかりませんでした。次の MIME の種類があります: {1}。</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(安全) </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">Plotly グラフの表示エラー: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">接続が見つかりません。</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">接続の追加</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">オブジェクト エクスプローラー ビューレットで使用するサーバー グループ カラー パレット。</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">オブジェクト エクスプローラー ビューレットの自動展開サーバー グループ。</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(プレビュー) 動的ノード フィルターなどの新機能をサポートする、新しい非同期サーバー ツリーをサーバー ビューおよび接続ダイアログに使用します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">データ</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">接続</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">クエリ エディター</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">ノートブック</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">ダッシュボード</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">組み込みグラフ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">ビュー テンプレートを指定する</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">セッション テンプレートを指定する</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Profiler フィルター</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">接続</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">切断</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">開始</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">新しいセッション</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">一時停止</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">再開</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">データのクリア</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">データをクリアしますか?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">自動スクロール: オン</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">自動スクロール: オフ</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">折りたたんだパネルを切り替える</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">列の編集</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">次の文字列を検索</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">前の文字列を検索</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Profiler を起動</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">フィルター...</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">フィルターのクリア</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">フィルターをクリアしますか?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">ビューの選択</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">セッションの選択</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">セッションを選択:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">ビューを選択:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">テキスト</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">ラベル</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">値</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">詳細</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">検索</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">検索</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">前の一致項目</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">次の一致項目</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">閉じる</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">検索で多数の結果が返されました。最初の 999 件の一致のみ強調表示されます。</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} / {1} 件</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">結果なし</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">イベント テキストの Profiler エディター。読み取り専用</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">イベント (フィルター処理済み): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">イベント: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">イベント数</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">CSV として保存</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">JSON として保存</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Excel として保存</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">XML として保存</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">JSON にエクスポートするときに結果のエンコードは保存されません。ファイルが作成されたら、目的のエンコードで保存することを忘れないでください。</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">バッキング データ ソースでファイルへの保存はサポートされていません</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">コピー</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">ヘッダー付きでコピー</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">すべて選択</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">最大化</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">復元</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">グラフ</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">ビジュアライザー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">SQL 言語の選択</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">SQL 言語プロバイダーの変更</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">SQL 言語のフレーバー</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">SQL エンジン プロバイダーの変更</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">エンジン {0} を使用している接続が存在します。変更するには、切断するか、接続を変更してください</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">現時点でアクティブなテキスト エディターはありません</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">言語プロバイダーの選択</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">XML プラン表示</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">結果グリッド</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">フィルター/並べ替えに使用する行の最大数を超えました。更新するには、[ユーザーの設定] に移動し、設定を変更します: 'queryEditor.results.inMemoryDataProcessingThreshold'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">現在のクエリにフォーカスを移動する</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">クエリの実行</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">現在のクエリを実行</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">結果を含むクエリのコピー</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">クエリと結果が正常にコピーされました。</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">実際のプランで現在のクエリを実行</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">クエリのキャンセル</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">IntelliSense キャッシュの更新</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">クエリ結果の切り替え</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">クエリと結果の間のフォーカスの切り替え</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">ショートカットを実行するにはエディター パラメーターが必須です</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">クエリの解析</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">コマンドが正常に完了しました</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">コマンドが失敗しました: </target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">サーバーに接続してください</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">メッセージ パネル</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">コピー</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">すべてコピー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">クエリ結果</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新しいクエリ</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">クエリ エディター</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">true の場合、CSV として結果を保存する際に列ヘッダーが組み込まれます</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">CSV として保存するときに値の間に使用するカスタム区切り記号</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">結果を CSV として保存するときに行を区切るために使用する文字</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">結果を CSV として保存するときにテキスト フィールドを囲むために使用する文字</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">結果を CSV として保存するときに使用するファイル エンコード</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">true の場合、XML として結果を保存すると XML 出力がフォーマットされます</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">結果を XML として保存するときに使用されるファイル エンコード</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">結果のストリーミングを有効にします。視覚上の小さな問題がいくつかあります</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">結果を結果ビューからコピーするための構成オプション</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">複数行の結果を結果ビューからコピーするための構成オプション</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(試験的) 結果の最適化されたテーブルを使用します。一部の機能がなく、準備中の場合があります。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">メモリ内でフィルター処理と並べ替えを実行できる行の最大数を制御します。この数を超えた場合、並べ替えとフィルター処理は無効になります。警告: これを増やすと、パフォーマンスに影響を与える可能性があります。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">結果保存後に Azure Data Studio でファイルを開くかどうかを指定します。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">各バッチの実行時間を表示するかどうか</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">メッセージを右端で折り返す</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">クエリ結果からグラフ ビューアーを開くときに使用する既定のグラフの種類</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">タブの色指定は無効になります</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">各エディター タブの上部境界線は、関連するサーバー グループと同じ色になります</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">各エディター タブの背景色は、関連するサーバー グループと同じになります</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">アクティブな接続のサーバー グループに基づいてタブに色を付ける方法を制御します</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">タイトルにタブの接続情報を表示するかを制御します。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">生成された SQL ファイルを保存するかをプロンプトで確認する</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">ショートカット テキストをプロシージャ呼び出しまたはクエリ実行として実行するにはキー バインド workbench.action.query.shortcut{0} を設定します。クエリ エディターで選択したテキストはクエリの末尾でパラメーターとして渡されます。または、これを {arg} で参照することができます。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新しいクエリ</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">実行</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">説明</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">実際</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">切断</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">接続の変更</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">接続</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">SQLCMD を有効にする</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">SQLCMD を無効にする</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">データベースの選択</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">データベースを変更できませんでした</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">データベースを変更できませんでした: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">ノートブックとしてエクスポート</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">結果</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">メッセージ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">経過時間</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">行数</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} 行</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">クエリを実行しています...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">実行状態</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">選択の要約</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">平均: {0}  数: {1}  合計: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">結果グリッドとメッセージ</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">フォント ファミリを制御します。</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">フォントの太さを制御します。</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">フォント サイズ (ピクセル単位) を制御します。</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">文字間隔 (ピクセル単位) を制御します。</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">ピクセル単位で行の高さを制御する</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">セルの埋め込みをピクセル単位で制御します</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">最初の結果について、列の幅を自動サイズ設定します。多数の列がある場合や、大きいセルがある場合、パフォーマンスの問題が発生する可能性があります</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">自動サイズ設定される列の最大幅 (ピクセル単位)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">Query History の切り替え</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">削除</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">すべての履歴をクリア</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">クエリを開く</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">クエリの実行</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">Query History キャプチャの切り替え</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Query History キャプチャの一時停止</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Query History キャプチャの開始</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">成功</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">失敗</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">表示するクエリがありません。</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">Query History</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">クエリ履歴</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">Query History キャプチャが有効かどうか。false の場合、実行されたクエリはキャプチャされません。</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">すべての履歴をクリア</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Query History キャプチャの一時停止</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Query History キャプチャの開始</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">表示</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Query History (&amp;&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">Query History</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">クエリ プラン</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">操作</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">オブジェクト</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">推定コスト</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">サブ ツリーの推定コスト</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">実際の行数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">推定行数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">実際の実行</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">推定 CPU コスト</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">推定 IO コスト</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">並列</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">実際の再バインド数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">再バインドの推定数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">実際の巻き戻し数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">巻き戻しの推定数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">パーティション分割</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">上位操作</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">リソース ビューアー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">最新の情報に更新</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">リンクを開いているときにエラーが発生しました: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">コマンド '{0}' の実行でエラーが発生しました: {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">リソース ビューアー ツリー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">リソースの識別子。</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">ビューの判読できる名前。これが表示されます</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">リソース アイコンへのパス。</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">リソースをリソース ビューに提供します</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">プロパティ `{0}` は必須で、`string` 型でなければなりません</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">プロパティ `{0}` は省略するか、`string` 型にする必要があります</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">復元</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">復元</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">復元を使用するには、プレビュー機能を有効にする必要があります</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">復元コマンドは、サーバー コンテキストの外ではサポートされていません。サーバーまたはデータベースを選択して、もう一度お試しください。</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL データベースでは、復元コマンドはサポートされていません。</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">復元</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">作成としてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">ドロップとしてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">上位 1000 を選択する</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">実行としてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">変更としてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">データの編集</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">上位 1000 を選択する</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">10 個</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">作成としてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">実行としてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">変更としてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">ドロップとしてのスクリプト</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">最新の情報に更新</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">ノード '{0}' の更新でエラーが発生しました: {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} 個のタスクが進行中です</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">表示</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">タスク</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">タスク(&amp;&amp;T)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">タスクの切り替え</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">成功</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">失敗</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">進行中</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">未開始</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">キャンセル済み</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">キャンセル中</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">表示するタスク履歴がありません。</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">タスク履歴</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">タスク エラー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">タスクを取り消せませんでした。</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">スクリプト</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">ビュー データを提供できるデータ プロバイダーが登録されていません。</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">最新の情報に更新</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">すべて折りたたむ</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">コマンド {1} の実行中にエラー {0} が発生しました。{1} を提供する拡張機能が原因である可能性があります。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">閉じる</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">プレビュー機能により、新機能と機能改善にフル アクセスできることで、Azure Data Studio のエクスペリエンスが拡張されます。プレビュー機能の詳細については、[ここ] ({0}) を参照してください。プレビュー機能を有効にしますか?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">はい (推奨)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">いいえ、今後は表示しない</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">この機能ページはプレビュー段階です。プレビュー機能では、製品の永続的な部分になる予定の新しい機能が導入されています。これらは安定していますが、追加のアクセシビリティの改善が必要です。開発中の早期のフィードバックを歓迎しています。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">プレビュー</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">接続の作成</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">接続ダイアログを使用してデータベース インスタンスに接続します。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">クエリの実行</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">クエリ エディターを使用してデータを操作します。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">ノートブックの作成</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">ネイティブのノートブック エディターを使用して、新しいノートブックを作成します。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">サーバーのデプロイ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">選択したプラットフォームでリレーショナル データ サービスの新しいインスタンスを作成します。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">リソース</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">履歴</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名前</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">場所</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">さらに表示</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">起動時にウェルカム ページを表示する</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">役に立つリンク</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">はじめに</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Azure Data Studio によって提供される機能を検出し、それらを最大限に活用する方法について説明します。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">ドキュメント</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">PowerShell、API などのクイックスタート、攻略ガイド、リファレンスについては、ドキュメント センターを参照してください。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">ビデオ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Azure Data Studio の概要</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Azure Data Studio ノートブックの概要 | 公開されたデータ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">拡張</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">すべて表示</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">詳細情報</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">接続</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">SQL Server、Azure などからの接続を接続、クエリ、および管理します。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">次へ</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">ノートブック</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">1 か所で独自のノートブックまたはノートブックのコレクションの作成を開始します。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">拡張</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Microsoft (私たち) だけでなくサードパーティ コミュニティ (あなた) が開発した拡張機能をインストールすることにより、Azure Data Studio の機能を拡張します。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">設定</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">好みに応じて Azure Data Studio をカスタマイズします。自動保存やタブ サイズなどの設定の構成、キーボード ショートカットのカスタマイズ、好きな配色テーマへの切り替えを行うことができます。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">ウェルカム ページ</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">ウェルカム ページで、トップの機能、最近開いたファイル、推奨される拡張機能がわかります。Azure Data Studio で作業を開始する方法の詳細については、ビデオとドキュメントをご覧ください。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">完了</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">ユーザー紹介ツアー</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">紹介ツアーの非表示</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">詳細情報</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">ヘルプ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">ようこそ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 管理パック</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 管理パック</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">SQL Server の管理パックは、一般的なデータベース管理拡張機能のコレクションであり、SQL Server の管理に役立ちます</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server エージェント</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">SQL Server のインポート</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server DACPAC</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Azure Data Studio のリッチ クエリ エディターを使用して PowerShell スクリプトを作成して実行します</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">データ仮想化</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">SQL Server 2019 を使用してデータを仮想化し、インタラクティブなウィザードを使用して外部テーブルを作成します</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">Azure Data Studio で Postgres データベースを接続、クエリ、および管理します</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">{0} のサポートは既にインストールされています。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">{0} に追加のサポートをインストールしたあと、ウィンドウが再度読み込まれます。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">{0} に追加のサポートをインストールしています...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">ID {1} のサポート {0} は見つかりませんでした。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">新しい接続</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">新しいクエリ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">新しいノートブック</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">サーバーのデプロイ</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">ようこそ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">新規</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">開く…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">ファイルを開く…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">フォルダーを開く</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">ツアーの開始</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">クイック ツアー バーを閉じる</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">Azure Data Studio のクイック ツアーを開始しますか?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">ようこそ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">パス {1} のフォルダー {0} を開く</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">インストール</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">{0} キーマップのインストール</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">{0} に追加のサポートをインストールする</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">インストール済み</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">{0} キーマップは既にインストールされています</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">{0} のサポートは既にインストールされています</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">詳細</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">ウェルカム ページの背景色。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">開始</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">新しい接続</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">新しいクエリ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">新しいノートブック</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">ファイルを開く</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">ファイルを開く</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">デプロイ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">新しいデプロイ…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">最近</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">その他...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">最近使用したフォルダーなし</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">ヘルプ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">はじめに</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">ドキュメント</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">問題または機能要求を報告する</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">GitHub リポジトリ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">リリース ノート</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">起動時にウェルカム ページを表示する</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">カスタマイズ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">拡張</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">SQL Server 管理パックなど、必要な拡張機能をダウンロードする</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">キーボード ショートカット</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">お気に入りのコマンドを見つけてカスタマイズする</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">配色テーマ</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">エディターとコードの外観を自由に設定します</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">詳細</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">すべてのコマンドの検索と実行</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">コマンド パレット ({0}) にすばやくアクセスしてコマンドを検索します</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">最新リリースの新機能を見る</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">毎月新機能を紹介する新しいブログ記事</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Twitter でフォローする</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">コミュニティがどのように Azure Data Studio を使用しているかについて、最新情報を把握し、エンジニアと直接話し合います。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">アカウント</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">リンクされたアカウント</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">閉じる</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">リンクされているアカウントはありません。アカウントを追加してください。</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">アカウントを追加する</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">有効にされているクラウドがありません。[設定] -&gt; [Azure アカウント構成の検索] に移動し、 少なくとも 1 つのクラウドを有効にしてください</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">認証プロバイダーを選択していません。もう一度お試しください。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">アカウントの追加でのエラー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">このアカウントの資格情報を更新する必要があります。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">閉じる</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">アカウントを追加しています...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">ユーザーがアカウントの更新をキャンセルしました</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Azure アカウント</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Azure テナント</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">コピーして開く</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">ユーザー コード</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">Web サイト</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">自動 OAuth を開始できません。自動 OAuth は既に進行中です。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">管理サービスとの対話には接続が必須です</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">登録されているハンドラーがありません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">評価サービスとの対話には接続が必要です</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">登録されているハンドラーがありません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">詳細プロパティ</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">破棄</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">サーバーの説明 (省略可能)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">リストのクリア</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">最近の接続履歴をクリアしました</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">一覧からすべての接続を削除してよろしいですか?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">削除</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">現在の接続文字列を取得する</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">接続文字列は使用できません</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">使用できるアクティブな接続がありません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">参照</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">一覧にフィルターをかけるには、ここに入力します</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">接続のフィルター</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">フィルターを適用しています</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">フィルターを削除しています</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">フィルター適用済み</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">フィルターが削除されました</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">保存された接続</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">保存された接続</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">接続ブラウザー ツリー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">接続エラー</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">接続は、Kerberos エラーのため失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">Kerberos を構成するためのヘルプを {0} で確認できます</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">以前に接続した場合は、kinit を再実行しなければならない場合があります。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">接続</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">接続しています</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">接続の種類</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">最近</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">接続の詳細</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">接続</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">最近の接続</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">最近の接続はありません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">接続用の Azure アカウント トークンの取得に失敗しました</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">接続が承認されていません</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">この接続をキャンセルしてもよろしいですか?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">アカウントを追加する...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;既定&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">読み込んでいます...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">サーバー グループ</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;既定&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">新しいグループを追加する...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;保存しない&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} が必須です。</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0} がトリミングされます。</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">パスワードを記憶する</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">アカウント</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">アカウントの資格情報を更新</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Azure AD テナント</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">名前 (省略可能)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">詳細設定...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">アカウントを選択する必要があります</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">接続先</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">切断</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">保存されていない接続</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">ダッシュボードの拡張機能を開く</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">まだダッシュボードの拡張機能がインストールされていません。拡張機能マネージャーに移動し、推奨される拡張機能をご確認ください。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">ステップ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">完了</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">編集データ セッションを初期化できませんでした: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">閉じる</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">アクション</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">コピーの詳細</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">エラー</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">警告</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">情報</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">無視する</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">選択されたパス</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">ファイルの種類</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">破棄</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">ファイルの選択</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">ファイル ブラウザー ツリー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">ファイル ブラウザーの読み込み中にエラーが発生しました。</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">ファイル ブラウザーのエラー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">すべてのファイル</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">セルをコピー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">分析情報ポップアップに渡された接続プロファイルはありませんでした</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">分析情報エラー</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">クエリ ファイルの読み取り中にエラーが発生しました: </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">分析情報の構成の解析中にエラーが発生しました。クエリ配列/文字列、またはクエリ ファイルが見つかりませんでした</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">アイテム</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">値</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">分析情報の詳細</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">プロパティ</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">値</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">分析情報</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">アイテム</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">アイテムの詳細</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">クエリ ファイルが、次のどのパスにも見つかりませんでした:
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">失敗</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">成功</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">再試行</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">取り消されました</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">進行中</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">不明な状態</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">実行中</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">スレッドを待機しています</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">再試行の間</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">アイドル状態</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">中断中</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[古い]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">スケジュールが設定されていません</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">実行しない</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">JobManagementService と対話するには接続が必須です</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">登録されているハンドラーがありません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">ノートブック セッションの開始中にエラーが発生しました。</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">不明な理由によりサーバーが起動しませんでした</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">カーネル {0} が見つかりませんでした。既定のカーネルが代わりに使用されます。</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="ja">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="ja">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="ja">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">保存されていないファイルでの編集者の種類の変更はサポートされていません</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated"># Injected-Parameters
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">このカーネルのセルを実行する接続を選択してください</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">セルの削除に失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">カーネルの変更に失敗しました。カーネル {0} が使用されます。エラー: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">次のエラーにより、カーネルの変更に失敗しました: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">コンテキストの変更に失敗しました: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">セッションを開始できませんでした: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">ノートブックを閉じるときにクライアント セッション エラーが発生しました: {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">プロバイダー {0} のノートブック マネージャーが見つかりません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">ノートブック マネージャーを作成するときに URI が渡されませんでした</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">ノートブック プロバイダーが存在しません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">このノートブックには、 {0} という名前のビューが既に存在します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">SQL カーネル エラー</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">ノートブックのセルを実行するには、接続を選択する必要があります</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">上位 {0} 行を表示しています。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">リッチ テキスト</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">分割ビュー</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">認識されない nbformat v{0}.{1}</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">このファイルは有効なノートブック形式ではありません</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">セルの種類 {0} が不明</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">出力の種類 {0} を認識できません</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">{0} のデータは、文字列または文字列の配列である必要があります</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">出力の種類 {0} を認識できません</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">ノートブック プロバイダーの識別子。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">このノートブック プロバイダーにどのファイル拡張子を登録する必要があるか</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">このノートブック プロバイダーへの標準装備が必要なカーネル</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">ノートブック プロバイダーを提供します。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">'%%sql' などのセル マジックの名前。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">このセル マジックがセルに含まれる場合に使用されるセルの言語</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">Spark / SQL など、このマジックが示すオプションの実行対象</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">これが有効なカーネルのオプションのセット (python3、pyspark、sql など)</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">ノートブックの言語を提供します。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">読み込んでいます...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">最新の情報に更新</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">接続の編集</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">切断</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">新しい接続</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">新しいサーバー グループ</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">サーバー グループの編集</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">アクティブな接続を表示</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">すべての接続を表示</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">接続の削除</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">グループの削除</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">オブジェクト エクスプローラー セッションを作成できませんでした</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">複数のエラー:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">必要な接続プロバイダー '{0}' が見つからないため、展開できません</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">ユーザーによる取り消し</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">ファイアウォール ダイアログが取り消されました</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">読み込んでいます...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">最近の接続</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">サーバー</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">サーバー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">イベントで並べ替え</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">列で並べ替え</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">プロファイラー</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">すべてクリア</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">適用</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">フィルター</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">この句を削除する</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">フィルターを保存する</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">フィルターを読み込む</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">句を追加する</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">フィールド</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">演算子</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">値</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">Null である</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">Null でない</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">含む</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">含まない</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">次で始まる</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">次で始まらない</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">行のコミットに失敗しました: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">次の場所でクエリの実行を開始しました: </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">クエリ「{0}」の実行を開始しました</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">行 {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">失敗したクエリのキャンセル中: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">セルの更新が失敗しました: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">予期しないエラーにより、実行が失敗しました: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">総実行時間: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">行 {0} でのクエリの実行が開始されました</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">バッチ {0} の実行を開始しました</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">バッチ実行時間: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">エラー {0} でコピーに失敗しました</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">結果を保存できませんでした。 </target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">結果ファイルの選択</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (コンマ区切り)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Excel ブック</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">プレーン テキスト</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">ファイルを保存しています...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">結果が {0} に正常に保存されました </target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">ファイルを開く</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">開始</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">終了</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">新しいファイアウォール規則の作成</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">このクライアント IP アドレスではサーバーにアクセスできません。アクセスできるようにするには、Azure アカウントにサインインし、新しいファイアウォール規則を作成します。</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">ファイアウォール設定の詳細情報</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">ファイアウォール規則</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">自分のクライアント IP アドレスを追加 </target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">自分のサブネット IP 範囲を追加</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">アカウントの追加でのエラー</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">ファイアウォール規則のエラー</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">バックアップ ファイルのパス</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">ターゲット データベース</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">復元</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">データベースの復元</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">データベース</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">バックアップ ファイル</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">データベースの復元</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">スクリプト</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">ソース</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">復元元</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">バックアップ ファイルのパスが必須です。</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">１つまたは複数のファイル パスをコンマで区切って入力してください。</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">データベース</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">ターゲット</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">復元先</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">復元計画</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">復元するバックアップ セット</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">データベース ファイルを名前を付けて復元</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">データベース ファイルの詳細を復元する</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">論理ファイル名</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">ファイルの種類</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">元のファイル名</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">復元ファイル名</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">復元オプション</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">ログ末尾のバックアップ</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">サーバーの接続</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">全般</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">ファイル</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">オプション​​</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">バックアップ ファイル</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">すべてのファイル</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">サーバー グループ</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">キャンセル</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">サーバー グループ名</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">グループ名が必須です。</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">グループの説明</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">グループの色</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">サーバー グループを追加する</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">サーバー グループの編集</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">1 つ以上のタスクを実行中です。終了してもよろしいですか?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">はい</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">いいえ</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="ja">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">はじめに</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">「はじめに」を表示する</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">はじめに(&amp;&amp;S)</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/admin-tool-ext-win.ko.xlf
+++ b/resources/xlf/ko/admin-tool-ext-win.ko.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/ko/agent.ko.xlf
+++ b/resources/xlf/ko/agent.ko.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">새 일정</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">확인</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">취소</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">일정 이름</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">일정</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">프록시 만들기</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">프록시 편집</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">일반</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">프록시 이름</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">자격 증명 이름</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">설명</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">하위 시스템</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">운영 체제(CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">복제 스냅샷</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">복제 트랜잭션 로그 판독기</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">복제 배포자</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">복제 병합</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">복제 큐 판독기</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">SQL Server Analysis Services 쿼리</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">SQL Server Analysis Services 명령</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">SQL Server Integration Services 패키지</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">다음 하위 시스템에 대해 활성화</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">작업 일정</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">사용 가능한 일정:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">설명</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">연산자 만들기</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">연산자 편집</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">일반</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">알림</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">사용</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">전자 메일 이름</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">호출기 전자 메일 이름</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">월요일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">화요일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">수요일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">목요일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">금요일  </target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">토요일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">일요일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">업무 시작일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">업무 종료일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">호출기 연락 가능 근무 일정</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">경고 목록</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">경고 이름</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">전자 메일</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">호출기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">일반</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">작업 일정</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">단계</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">일정</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">경고</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">사용 가능한 일정:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">알림</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">작업 이름을 비워 둘 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">이름</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">소유자</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">ID</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">범주</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">설명</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">사용</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">작업 단계 목록</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">단계</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">형식</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">성공한 경우</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">실패한 경우</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">새 단계</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">단계 편집</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">단계 삭제</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">단계를 위로 이동</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">단계를 아래로 이동</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">시작 단계</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">작업 완료 시 수행할 동작</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">전자 메일</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">페이지</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">Windows 애플리케이션 이벤트 로그에 쓰기</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">자동으로 작업 삭제</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">일정 목록</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">일정 선택</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">일정 이름</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">경고 목록</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">새 경고</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">경고 이름</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">사용</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">형식</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">새 작업</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">작업 편집</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">전송할 추가 알림 메시지</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">응답 간격</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">지연(분)</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">연산자 만들기</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">연산자 편집</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">일반</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">알림</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">사용</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">전자 메일 이름</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">호출기 전자 메일 이름</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">월요일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">화요일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">수요일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">목요일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">금요일  </target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">토요일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">일요일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">업무 시작일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">업무 종료일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">호출기 연락 가능 근무 일정</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">경고 목록</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">경고 이름</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">전자 메일</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">호출기</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">프록시를 업데이트하지 못했습니다. '{0}'</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">일반</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">'{0}' 프록시를 업데이트했습니다.</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">단계</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">'{0}' 프록시를 만들었습니다.</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">일정</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">경고</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">알림</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">작업 이름을 비워 둘 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">소유자</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">범주</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">설명</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">사용</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">작업 단계 목록</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">단계</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">형식</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">성공한 경우</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">실패한 경우</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">새 단계</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">단계 편집</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">단계 삭제</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">단계를 위로 이동</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">단계를 아래로 이동</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">시작 단계</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">작업 완료 시 수행할 동작</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">전자 메일</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">페이지</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">Windows 애플리케이션 이벤트 로그에 쓰기</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">자동으로 작업 삭제</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">일정 목록</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">일정 선택</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">일정 제거</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">경고 목록</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">새 경고</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">경고 이름</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">사용</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">형식</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">새 작업</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">작업 편집</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">'{0}' 단계를 업데이트하지 못했습니다.</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">작업 이름을 지정해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">단계 이름을 지정해야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">'{0}' 단계를 업데이트하지 못했습니다.</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">작업 이름을 지정해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">단계 이름을 지정해야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">이 기능은 아직 개발 중입니다. 가장 최근 변경 기능을 사용해 보려면 최신 참가자 빌드를 확인하세요.</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">템플릿을 업데이트함</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">템플릿 업데이트 실패</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">예약하기 전에 전자 필기장을 저장해야 합니다. 저장한 후 예약을 다시 시도하세요.</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">새 연결 추가</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">연결 선택</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">올바른 연결을 선택하세요</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">이 기능은 아직 개발 중입니다. 가장 최근 변경 기능을 사용해 보려면 최신 참가자 빌드를 확인하세요.</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">프록시 만들기</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">프록시 편집</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">일반</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">프록시 이름</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">자격 증명 이름</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">설명</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">하위 시스템</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">운영 체제(CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">복제 스냅샷</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">복제 트랜잭션 로그 판독기</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">복제 배포자</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">복제 병합</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">복제 큐 판독기</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">SQL Server Analysis Services 쿼리</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">SQL Server Analysis Services 명령</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">SQL Server Integration Services 패키지</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">프록시를 업데이트하지 못했습니다. '{0}'</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">'{0}' 프록시를 업데이트했습니다.</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">'{0}' 프록시를 만들었습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">새 Notebook 작업</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">전자 필기장 작업 편집</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">일반</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">Notebook 세부 정보</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">전자 필기장 경로</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">저장소 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">실행 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">데이터베이스 선택</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">작업 정보</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">소유자</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">일정 목록</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">일정 선택</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">일정 제거</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">설명</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">PC에서 예약할 전자 필기장 선택</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">모든 전자 필기장 작업 메타데이터 및 결과를 저장할 데이터베이스 선택</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">전자 필기장 쿼리를 실행할 데이터베이스 선택</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">전자 필기장이 완료되는 경우</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">전자 필기장이 실패하는 경우</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">전자 필기장이 성공하는 경우</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">전자 필기장 이름을 제공해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">템플릿 경로를 제공해야 함</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">전자 필기장 경로가 잘못됨</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">저장소 데이터베이스 선택</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">실행 데이터베이스 선택</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">이름이 비슷한 작업이 이미 있음</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">Notebook 업데이트 실패 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">Notebook 만들기 실패 ‘{0}’</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">Notebook '{0}'을(를) 업데이트함</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">Notebook '{0}'이(가) 생성됨</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/azurecore.ko.xlf
+++ b/resources/xlf/ko/azurecore.ko.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">계정 {0}({1}) 구독 {2}({3}) 테넌트 {4}의 리소스 그룹을 가져오는 동안 오류 발생: {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">계정 {0}({1}) 구독 {2}({3}) 테넌트 {4}의 위치를 가져오는 동안 오류 발생: {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">잘못된 쿼리</target>
@@ -379,8 +383,8 @@
         <target state="translated">SQL Server - Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
-        <target state="translated">Azure Arc 사용 PostgreSQL 하이퍼스케일</target>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
+        <target state="translated">Azure Arc가 지원되는 PostgreSQL 하이퍼스케일</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
         <source xml:lang="en">Unable to open link, missing required values</source>
@@ -411,7 +415,7 @@
         <target state="translated">Azure 인증에서 식별되지 않은 오류 발생</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">ID가 '{0}'인 지정된 테넌트를 찾을 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,8 +423,8 @@
         <target state="translated">인증 관련 오류가 발생했거나 토큰이 시스템에서 삭제되었습니다. 계정을 다시 Azure Data Studio에 추가해 보세요.</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
-        <target state="translated">오류로 인해 토큰 검색에 실패했습니다. 개발자 도구를 열어 오류를 확인합니다.</target>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
+        <target state="translated">오류로 인해 토큰 검색에 실패했습니다. 개발자 도구를 열어 오류 확인</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
         <source xml:lang="en">No access token returned from Microsoft OAuth</source>
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">{0} 계정의 자격 증명을 가져오지 못했습니다. 계정 대화 상자로 이동하고 계정을 새로 고치세요.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">이 계정의 요청은 제한되었습니다. 다시 시도하려면 더 적은 수의 구독을 선택하세요.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">Azure 리소스를 로드하는 동안 오류가 발생했습니다. {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Azure 데이터 탐색기 클러스터</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/big-data-cluster.ko.xlf
+++ b/resources/xlf/ko/big-data-cluster.ko.xlf
@@ -12,15 +12,15 @@
       </trans-unit>
       <trans-unit id="command.connectController.title">
         <source xml:lang="en">Connect to Existing Controller</source>
-        <target state="new">Connect to Existing Controller</target>
+        <target state="translated">기존 컨트롤러에 연결</target>
       </trans-unit>
       <trans-unit id="command.createController.title">
         <source xml:lang="en">Create New Controller</source>
-        <target state="new">Create New Controller</target>
+        <target state="translated">새 컨트롤러 만들기</target>
       </trans-unit>
       <trans-unit id="command.removeController.title">
         <source xml:lang="en">Remove Controller</source>
-        <target state="new">Remove Controller</target>
+        <target state="translated">컨트롤러 제거</target>
       </trans-unit>
       <trans-unit id="command.refreshController.title">
         <source xml:lang="en">Refresh</source>
@@ -49,16 +49,136 @@
       <trans-unit id="bdc.view.welcome.connect">
         <source xml:lang="en">No SQL Big Data Cluster controllers registered. [Learn More](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
 [Connect Controller](command:bigDataClusters.command.connectController)</source>
-        <target state="new">No SQL Big Data Cluster controllers registered. [Learn More](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
-[Connect Controller](command:bigDataClusters.command.connectController)</target>
+        <target state="translated">등록된 SQL 빅 데이터 클러스터 컨트롤러가 없습니다. [자세한 정보](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
+[컨트롤러 연결](command:bigDataClusters.command.connectController)</target>
       </trans-unit>
       <trans-unit id="bdc.view.welcome.loading">
         <source xml:lang="en">Loading controllers...</source>
-        <target state="new">Loading controllers...</target>
+        <target state="translated">컨트롤러를 로드하는 중...</target>
       </trans-unit>
       <trans-unit id="bdc.ignoreSslVerification.desc">
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">True인 경우 HDFS, Spark 및 Controller와 같은 SQL Server 빅 데이터 클러스터 엔드포인트를 대상으로 SSL 확인 오류 무시</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">SQL Server 빅 데이터 클러스터</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">SQL Server 빅 데이터 클러스터를 사용하면 Kubernetes에서 실행되는 SQL Server, Spark 및 HDFS 컨테이너의 확장 가능한 클러스터를 배포할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">버전</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">배포 대상</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">새 Azure Kubernetes Service 클러스터</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">기존 Azure Kubernetes Service 클러스터</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">기존 Kubernetes 클러스터(kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">기존 Azure Red Hat OpenShift 클러스터</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">기존 OpenShift 클러스터</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">SQL Server 빅 데이터 클러스터 설정</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">클러스터 이름</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">컨트롤러 사용자 이름</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">암호</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">암호 확인</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Azure 설정</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">구독 ID</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">내 기본 Azure 구독 사용</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">리소스 그룹 이름</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">지역</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">AKS 클러스터 이름</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">VM 크기</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">VM 수</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">스토리지 클래스 이름</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">데이터 용량(GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">로그 용량(GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">{0}, {1} 및 {2}에 동의합니다.</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Microsoft 개인정보처리방침</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">azdata 사용 조건</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">SQL Server 사용 조건</target>
       </trans-unit>
     </body>
   </file>
@@ -254,299 +374,299 @@
     <body>
       <trans-unit id="bdc.dashboard.status">
         <source xml:lang="en">Status Icon</source>
-        <target state="new">Status Icon</target>
+        <target state="translated">상태 아이콘</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.instance">
         <source xml:lang="en">Instance</source>
-        <target state="new">Instance</target>
+        <target state="translated">인스턴스</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.state">
         <source xml:lang="en">State</source>
-        <target state="new">State</target>
+        <target state="translated">상태</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.view">
         <source xml:lang="en">View</source>
-        <target state="new">View</target>
+        <target state="translated">보기</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.notAvailable">
         <source xml:lang="en">N/A</source>
-        <target state="new">N/A</target>
+        <target state="translated">해당 없음</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.healthStatusDetails">
         <source xml:lang="en">Health Status Details</source>
-        <target state="new">Health Status Details</target>
+        <target state="translated">상태 세부 정보</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.metricsAndLogs">
         <source xml:lang="en">Metrics and Logs</source>
-        <target state="new">Metrics and Logs</target>
+        <target state="translated">메트릭 및 로그</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.healthStatus">
         <source xml:lang="en">Health Status</source>
-        <target state="new">Health Status</target>
+        <target state="translated">상태</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.nodeMetrics">
         <source xml:lang="en">Node Metrics</source>
-        <target state="new">Node Metrics</target>
+        <target state="translated">노드 메트릭</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.sqlMetrics">
         <source xml:lang="en">SQL Metrics</source>
-        <target state="new">SQL Metrics</target>
+        <target state="translated">SQL 메트릭</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.logs">
         <source xml:lang="en">Logs</source>
-        <target state="new">Logs</target>
+        <target state="translated">로그</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewNodeMetrics">
         <source xml:lang="en">View Node Metrics {0}</source>
-        <target state="new">View Node Metrics {0}</target>
+        <target state="translated">노드 메트릭 {0} 보기</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewSqlMetrics">
         <source xml:lang="en">View SQL Metrics {0}</source>
-        <target state="new">View SQL Metrics {0}</target>
+        <target state="translated">SQL 메트릭 {0} 보기</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewLogs">
         <source xml:lang="en">View Kibana Logs {0}</source>
-        <target state="new">View Kibana Logs {0}</target>
+        <target state="translated">Kibana 로그 {0} 보기</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.lastUpdated">
         <source xml:lang="en">Last Updated : {0}</source>
-        <target state="new">Last Updated : {0}</target>
+        <target state="translated">마지막으로 업데이트한 날짜: {0}</target>
       </trans-unit>
       <trans-unit id="basicAuthName">
         <source xml:lang="en">Basic</source>
-        <target state="new">Basic</target>
+        <target state="translated">기본</target>
       </trans-unit>
       <trans-unit id="integratedAuthName">
         <source xml:lang="en">Windows Authentication</source>
-        <target state="new">Windows Authentication</target>
+        <target state="translated">Windows 인증</target>
       </trans-unit>
       <trans-unit id="addNewController">
         <source xml:lang="en">Add New Controller</source>
-        <target state="new">Add New Controller</target>
+        <target state="translated">새 컨트롤러 추가</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
-        <target state="new">URL</target>
+        <target state="translated">URL</target>
       </trans-unit>
       <trans-unit id="username">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">사용자 이름</target>
       </trans-unit>
       <trans-unit id="password">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">암호</target>
       </trans-unit>
       <trans-unit id="rememberPassword">
         <source xml:lang="en">Remember Password</source>
-        <target state="new">Remember Password</target>
+        <target state="translated">암호 저장</target>
       </trans-unit>
       <trans-unit id="clusterManagementUrl">
         <source xml:lang="en">Cluster Management URL</source>
-        <target state="new">Cluster Management URL</target>
+        <target state="translated">클러스터 관리 URL</target>
       </trans-unit>
       <trans-unit id="textAuthCapital">
         <source xml:lang="en">Authentication type</source>
-        <target state="new">Authentication type</target>
+        <target state="translated">인증 유형</target>
       </trans-unit>
       <trans-unit id="hdsf.dialog.connection.section">
         <source xml:lang="en">Cluster Connection</source>
-        <target state="new">Cluster Connection</target>
+        <target state="translated">클러스터 연결</target>
       </trans-unit>
       <trans-unit id="add">
         <source xml:lang="en">Add</source>
-        <target state="new">Add</target>
+        <target state="translated">추가</target>
       </trans-unit>
       <trans-unit id="cancel">
         <source xml:lang="en">Cancel</source>
-        <target state="new">Cancel</target>
+        <target state="translated">취소</target>
       </trans-unit>
       <trans-unit id="ok">
         <source xml:lang="en">OK</source>
-        <target state="new">OK</target>
+        <target state="translated">확인</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.refresh">
         <source xml:lang="en">Refresh</source>
-        <target state="new">Refresh</target>
+        <target state="translated">새로 고침</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.troubleshoot">
         <source xml:lang="en">Troubleshoot</source>
-        <target state="new">Troubleshoot</target>
+        <target state="translated">문제 해결</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.bdcOverview">
         <source xml:lang="en">Big Data Cluster overview</source>
-        <target state="new">Big Data Cluster overview</target>
+        <target state="translated">빅 데이터 클러스터 개요</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterDetails">
         <source xml:lang="en">Cluster Details</source>
-        <target state="new">Cluster Details</target>
+        <target state="translated">클러스터 세부 정보</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterOverview">
         <source xml:lang="en">Cluster Overview</source>
-        <target state="new">Cluster Overview</target>
+        <target state="translated">클러스터 개요</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.serviceEndpoints">
         <source xml:lang="en">Service Endpoints</source>
-        <target state="new">Service Endpoints</target>
+        <target state="translated">서비스 엔드포인트</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterProperties">
         <source xml:lang="en">Cluster Properties</source>
-        <target state="new">Cluster Properties</target>
+        <target state="translated">클러스터 속성</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterState">
         <source xml:lang="en">Cluster State</source>
-        <target state="new">Cluster State</target>
+        <target state="translated">클러스터 상태</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.serviceName">
         <source xml:lang="en">Service Name</source>
-        <target state="new">Service Name</target>
+        <target state="translated">서비스 이름</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.service">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">서비스</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.endpoint">
         <source xml:lang="en">Endpoint</source>
-        <target state="new">Endpoint</target>
+        <target state="translated">엔드포인트</target>
       </trans-unit>
       <trans-unit id="copiedEndpoint">
         <source xml:lang="en">Endpoint '{0}' copied to clipboard</source>
-        <target state="new">Endpoint '{0}' copied to clipboard</target>
+        <target state="translated">엔드포인트 '{0}'이(가) 클립보드에 복사됨</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.copy">
         <source xml:lang="en">Copy</source>
-        <target state="new">Copy</target>
+        <target state="translated">복사</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewDetails">
         <source xml:lang="en">View Details</source>
-        <target state="new">View Details</target>
+        <target state="translated">세부 정보 보기</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewErrorDetails">
         <source xml:lang="en">View Error Details</source>
-        <target state="new">View Error Details</target>
+        <target state="translated">오류 세부 정보 보기</target>
       </trans-unit>
       <trans-unit id="connectController.dialog.title">
         <source xml:lang="en">Connect to Controller</source>
-        <target state="new">Connect to Controller</target>
+        <target state="translated">컨트롤러에 연결</target>
       </trans-unit>
       <trans-unit id="mount.main.section">
         <source xml:lang="en">Mount Configuration</source>
-        <target state="new">Mount Configuration</target>
+        <target state="translated">탑재 구성</target>
       </trans-unit>
       <trans-unit id="mount.task.name">
         <source xml:lang="en">Mounting HDFS folder on path {0}</source>
-        <target state="new">Mounting HDFS folder on path {0}</target>
+        <target state="translated">경로 {0}에 HDFS 폴더를 탑재하는 중</target>
       </trans-unit>
       <trans-unit id="refreshmount.task.name">
         <source xml:lang="en">Refreshing HDFS Mount on path {0}</source>
-        <target state="new">Refreshing HDFS Mount on path {0}</target>
+        <target state="translated">경로 {0}에서 HDFS 탑재를 새로 고치는 중</target>
       </trans-unit>
       <trans-unit id="deletemount.task.name">
         <source xml:lang="en">Deleting HDFS Mount on path {0}</source>
-        <target state="new">Deleting HDFS Mount on path {0}</target>
+        <target state="translated">경로 {0}에서 HDFS 탑재를 삭제하는 중</target>
       </trans-unit>
       <trans-unit id="mount.task.submitted">
         <source xml:lang="en">Mount creation has started</source>
-        <target state="new">Mount creation has started</target>
+        <target state="translated">탑재 만들기를 시작했습니다.</target>
       </trans-unit>
       <trans-unit id="refreshmount.task.submitted">
         <source xml:lang="en">Refresh mount request submitted</source>
-        <target state="new">Refresh mount request submitted</target>
+        <target state="translated">탑재 새로 고침 요청이 제출됨</target>
       </trans-unit>
       <trans-unit id="deletemount.task.submitted">
         <source xml:lang="en">Delete mount request submitted</source>
-        <target state="new">Delete mount request submitted</target>
+        <target state="translated">탑재 삭제 요청이 제출됨</target>
       </trans-unit>
       <trans-unit id="mount.task.complete">
         <source xml:lang="en">Mounting HDFS folder is complete</source>
-        <target state="new">Mounting HDFS folder is complete</target>
+        <target state="translated">HDFS 폴더 탑재가 완료되었습니다.</target>
       </trans-unit>
       <trans-unit id="mount.task.inprogress">
         <source xml:lang="en">Mounting is likely to complete, check back later to verify</source>
-        <target state="new">Mounting is likely to complete, check back later to verify</target>
+        <target state="translated">탑재가 완료될 수 있습니다. 나중에 다시 확인하세요.</target>
       </trans-unit>
       <trans-unit id="mount.dialog.title">
         <source xml:lang="en">Mount HDFS Folder</source>
-        <target state="new">Mount HDFS Folder</target>
+        <target state="translated">HDFS 폴더 탑재</target>
       </trans-unit>
       <trans-unit id="mount.hdfsPath.title">
         <source xml:lang="en">HDFS Path</source>
-        <target state="new">HDFS Path</target>
+        <target state="translated">HDFS 경로</target>
       </trans-unit>
       <trans-unit id="mount.hdfsPath.info">
         <source xml:lang="en">Path to a new (non-existing) directory which you want to associate with the mount</source>
-        <target state="new">Path to a new (non-existing) directory which you want to associate with the mount</target>
+        <target state="translated">탑재와 연결하려는 새(기존 항목 아님) 디렉터리의 경로</target>
       </trans-unit>
       <trans-unit id="mount.remoteUri.title">
         <source xml:lang="en">Remote URI</source>
-        <target state="new">Remote URI</target>
+        <target state="translated">원격 URI</target>
       </trans-unit>
       <trans-unit id="mount.remoteUri.info">
         <source xml:lang="en">The URI to the remote data source. Example for ADLS: abfs://fs@saccount.dfs.core.windows.net/</source>
-        <target state="new">The URI to the remote data source. Example for ADLS: abfs://fs@saccount.dfs.core.windows.net/</target>
+        <target state="translated">원격 데이터 원본에 대한 URI입니다. ADLS의 예: abfs://fs@saccount.dfs.core.windows.net/</target>
       </trans-unit>
       <trans-unit id="mount.credentials.title">
         <source xml:lang="en">Credentials</source>
-        <target state="new">Credentials</target>
+        <target state="translated">자격 증명</target>
       </trans-unit>
       <trans-unit id="mount.credentials.info">
         <source xml:lang="en">Mount credentials for authentication to remote data source for reads</source>
-        <target state="new">Mount credentials for authentication to remote data source for reads</target>
+        <target state="translated">읽기 위해 원격 데이터 원본에 인증용 자격 증명 탑재</target>
       </trans-unit>
       <trans-unit id="refreshmount.dialog.title">
         <source xml:lang="en">Refresh Mount</source>
-        <target state="new">Refresh Mount</target>
+        <target state="translated">탑재 새로 고침</target>
       </trans-unit>
       <trans-unit id="deleteMount.dialog.title">
         <source xml:lang="en">Delete Mount</source>
-        <target state="new">Delete Mount</target>
+        <target state="translated">탑재 삭제</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.loadingClusterStateCompleted">
         <source xml:lang="en">Loading cluster state completed</source>
-        <target state="new">Loading cluster state completed</target>
+        <target state="translated">클러스터 상태 로드 완료</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.loadingHealthStatusCompleted">
         <source xml:lang="en">Loading health status completed</source>
-        <target state="new">Loading health status completed</target>
+        <target state="translated">상태 로드 완료</target>
       </trans-unit>
       <trans-unit id="err.controller.username.required">
         <source xml:lang="en">Username is required</source>
-        <target state="new">Username is required</target>
+        <target state="translated">사용자 이름이 필요합니다.</target>
       </trans-unit>
       <trans-unit id="err.controller.password.required">
         <source xml:lang="en">Password is required</source>
-        <target state="new">Password is required</target>
+        <target state="translated">암호는 필수입니다.</target>
       </trans-unit>
       <trans-unit id="endpointsError">
         <source xml:lang="en">Unexpected error retrieving BDC Endpoints: {0}</source>
-        <target state="new">Unexpected error retrieving BDC Endpoints: {0}</target>
+        <target state="translated">BDC 엔드포인트를 검색하는 동안 예기치 않은 오류 발생: {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.noConnection">
         <source xml:lang="en">The dashboard requires a connection. Please click retry to enter your credentials.</source>
-        <target state="new">The dashboard requires a connection. Please click retry to enter your credentials.</target>
+        <target state="translated">대시보드에 연결이 필요합니다. 자격 증명을 입력하려면 다시 시도를 클릭하세요.</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.unexpectedError">
         <source xml:lang="en">Unexpected error occurred: {0}</source>
-        <target state="new">Unexpected error occurred: {0}</target>
+        <target state="translated">예기치 않은 오류가 발생했습니다. {0}</target>
       </trans-unit>
       <trans-unit id="mount.hdfs.loginerror1">
         <source xml:lang="en">Login to controller failed</source>
-        <target state="new">Login to controller failed</target>
+        <target state="translated">컨트롤러에 로그인하지 못함</target>
       </trans-unit>
       <trans-unit id="mount.hdfs.loginerror2">
         <source xml:lang="en">Login to controller failed: {0}</source>
-        <target state="new">Login to controller failed: {0}</target>
+        <target state="translated">컨트롤러에 로그인하지 못함: {0}</target>
       </trans-unit>
       <trans-unit id="mount.err.formatting">
         <source xml:lang="en">Bad formatting of credentials at {0}</source>
-        <target state="new">Bad formatting of credentials at {0}</target>
+        <target state="translated">{0}에 있는 자격 증명 형식이 잘못됨</target>
       </trans-unit>
       <trans-unit id="mount.task.error">
         <source xml:lang="en">Error mounting folder: {0}</source>
-        <target state="new">Error mounting folder: {0}</target>
+        <target state="translated">폴더 탑재 오류: {0}</target>
       </trans-unit>
       <trans-unit id="mount.error.unknown">
         <source xml:lang="en">Unknown error occurred during the mount process</source>
-        <target state="new">Unknown error occurred during the mount process</target>
+        <target state="translated">탑재 프로세스 중에 알 수 없는 오류가 발생했습니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -566,7 +686,7 @@
       </trans-unit>
       <trans-unit id="bdc.error.getClusterConfig">
         <source xml:lang="en">Error retrieving cluster config from {0}</source>
-        <target state="new">Error retrieving cluster config from {0}</target>
+        <target state="translated">{0}에서 클러스터 구성을 검색하는 동안 오류 발생</target>
       </trans-unit>
       <trans-unit id="bdc.error.getEndPoints">
         <source xml:lang="en">Error retrieving endpoints from {0}</source>
@@ -582,7 +702,7 @@
       </trans-unit>
       <trans-unit id="bdc.error.statusHdfs">
         <source xml:lang="en">Error getting mount status</source>
-        <target state="new">Error getting mount status</target>
+        <target state="translated">탑재 상태를 가져오는 동안 오류 발생</target>
       </trans-unit>
       <trans-unit id="bdc.error.refreshHdfs">
         <source xml:lang="en">Error refreshing mount</source>
@@ -602,7 +722,7 @@
       </trans-unit>
       <trans-unit id="bdc.dashboard.title">
         <source xml:lang="en">Big Data Cluster Dashboard -</source>
-        <target state="new">Big Data Cluster Dashboard -</target>
+        <target state="translated">빅 데이터 클러스터 대시보드 -</target>
       </trans-unit>
       <trans-unit id="textYes">
         <source xml:lang="en">Yes</source>
@@ -614,7 +734,7 @@
       </trans-unit>
       <trans-unit id="textConfirmRemoveController">
         <source xml:lang="en">Are you sure you want to remove '{0}'?</source>
-        <target state="new">Are you sure you want to remove '{0}'?</target>
+        <target state="translated">'{0}'을(를) 제거하시겠습니까?</target>
       </trans-unit>
     </body>
   </file>
@@ -622,7 +742,7 @@
     <body>
       <trans-unit id="bdc.controllerTreeDataProvider.error">
         <source xml:lang="en">Unexpected error loading saved controllers: {0}</source>
-        <target state="new">Unexpected error loading saved controllers: {0}</target>
+        <target state="translated">저장된 컨트롤러를 로드하는 동안 예기치 않은 오류 발생: {0}</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/cms.ko.xlf
+++ b/resources/xlf/ko/cms.ko.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">로드하는 중...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">저장된 서버를 로드하는 동안 예기치 않은 오류가 발생했습니다. {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">로드하는 중...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">중앙 관리 서버 그룹에 이름이 {0}인 등록된 서버가 이미 있습니다.</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Azure SQL Database 서버는 중앙 관리 서버로 사용할 수 없습니다.</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Azure SQL Server는 중앙 관리 서버로 사용될 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/ko/dacpac.ko.xlf
+++ b/resources/xlf/ko/dacpac.ko.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="ko">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Dacpac</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">.DACPAC 및 .BACPAC 파일이 기본적으로 저장되는 폴더의 전체 경로입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">대상 서버</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">원본 서버</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">원본 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">대상 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">파일 위치</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">파일 선택</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">설정 요약</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">버전</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">설정</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">값</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">데이터베이스 이름</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">열기</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">기존 데이터베이스 업그레이드</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">새 데이터베이스</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">나열된 배포 작업의 {0}(으)로 인해 데이터가 손실될 수 있습니다. 배포 관련 문제가 발생하는 경우 사용할 수 있는 백업 또는 스냅샷이 있는지 확인하세요.</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">데이터가 손실되더라도 계속 진행</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">나열된 배포 작업에서 데이터 손실이 발생하지 않습니다.</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">저장</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">파일 위치</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">버전(x.x.x.x 사용, x는 숫자임)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">열기</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">데이터 계층 애플리케이션 .dacpac 파일을 SQL Server의 인스턴스에 배포[Dacpac 배포]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">데이터베이스의 스키마 및 데이터를 논리적 .bacpac 파일 형식으로 내보내기[Bacpac 내보내기]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">데이터베이스 이름</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">기존 데이터베이스 업그레이드</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">새 데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">대상 데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">대상 서버</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">원본 서버</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">원본 데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">버전</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">설정</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">값</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">기본값</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">데이터 계층 애플리케이션 마법사</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">스크립트 생성</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">마법사가 닫히면 작업 보기에서 스크립트 생성 상태를 볼 수 있습니다. 완료되면 생성된 스크립트가 열립니다.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">기본값</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">계획 작업 배포</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">SQL Server 인스턴스에 같은 이름의 데이터베이스가 이미 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">정의되지 않은 네임스페이스:</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">파일 이름은 마침표(.)로 끝날 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">파일 이름은 공백일 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">잘못된 파일 문자</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">이 파일 이름은 Windows에서 예약되어 있습니다. 다른 이름을 선택하고 다시 시도하세요.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">예약된 파일 이름입니다. 다른 이름을 선택하고 다시 시도하십시오.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">파일 이름은 공백으로 끝날 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">파일 이름이 255자를 초과합니다.</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">배포 플랜 '{0}'을(를) 생성하지 못했습니다.</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">배포 스크립트 생성 실패 '{0}'</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">{0} 작업 실패 '{1}'</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">마법사가 닫히면 작업 보기에서 스크립트 생성 상태를 볼 수 있습니다. 완료되면 생성된 스크립트가 열립니다.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/import.ko.xlf
+++ b/resources/xlf/ko/import.ko.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="ko">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">플랫 파일 가져오기 구성</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[옵션] 디버그 출력을 콘솔에 로깅한 다음(보기 -&gt; 출력), 드롭다운에서 해당 출력 채널을 선택합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">{0}이(가) 시작됨</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">{0}을(를) 시작하는 중</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">{0}:{1}을(를) 시작하지 못함</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">{1}에 {0} 설치 중</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">{0} 서비스를 설치하는 중</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">설치된 {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">{0} 다운로드 중</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0}KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">{0} 다운로드 중</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">{0} 다운로드 완료</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">추출된 {0}({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">사용자 의견 제공</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">서비스 구성 요소를 시작할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">데이터베이스가 있는 서버</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">테이블이 생성된 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">잘못된 파일 위치입니다. 다른 입력 파일을 사용해 보세요.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">찾아보기</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">열기</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">가져올 파일의 위치</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">새 테이블 이름</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">테이블 스키마</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">데이터 가져오기</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">다음</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">열 이름</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">데이터 형식</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">기본 키</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">Null 허용</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">이 작업은 입력 파일 구조를 분석하여 처음 50개 행의 미리 보기를 아래에 생성했습니다.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">이 작업이 실패했습니다. 다른 입력 파일을 사용해 보세요.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">새로 고침</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">정보 가져오기</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ 테이블에 데이터를 입력했습니다.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">이 작업은 입력 파일 구조를 분석하여 처음 50개 행의 미리 보기를 아래에 생성했습니다.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">이 작업이 실패했습니다. 다른 입력 파일을 사용해 보세요.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">새로 고침</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">데이터 가져오기</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">다음</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">열 이름</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">데이터 형식</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">기본 키</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">Null 허용</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">데이터베이스가 있는 서버</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">테이블이 생성된 데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">찾아보기</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">열기</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">가져올 파일의 위치</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">새 테이블 이름</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">테이블 스키마</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">이 마법사를 사용하기 전에 서버에 연결하세요.</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">SQL Server 가져오기 확장은 이 유형의 연결을 지원하지 않습니다.</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">새 파일 가져오기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">사용자 의견 제공</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">서비스 구성 요소를 시작할 수 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">서비스가 시작됨</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">서비스를 시작하는 중...</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">가져오기 서비스 {0}을(를) 시작하지 못했습니다.</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">{1}에 {0} 서비스를 설치하는 중</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">서비스를 설치하는 중</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">설치됨</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">{0} 다운로드 중</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0}KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">서비스를 다운로드하는 중</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">완료되었습니다.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/notebook.ko.xlf
+++ b/resources/xlf/ko/notebook.ko.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Notebook에서 사용하는 기존 python 설치의 로컬 경로입니다.</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">Python을 업데이트하라는 메시지가 표시되지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">모든 전자 필기장이 닫힌 후 서버를 종료하기 전에 대기해야 할 시간(분)입니다(종료하지 않으려면 0을 입력하세요).</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Notebook 편집기에서 편집기 기본 설정을 재정의합니다. 설정에는 배경색, 현재 선 색 및 테두리가 포함됩니다.</target>
@@ -32,7 +40,7 @@
       </trans-unit>
       <trans-unit id="notebook.trustedBooks.description">
         <source xml:lang="en">Notebooks contained in these books will automatically be trusted.</source>
-        <target state="new">Notebooks contained in these books will automatically be trusted.</target>
+        <target state="translated">이 Book에 포함된 Notebook은 자동으로 신뢰할 수 있습니다.</target>
       </trans-unit>
       <trans-unit id="notebook.maxBookSearchDepth.description">
         <source xml:lang="en">Maximum depth of subdirectories to search for Books (Enter 0 for infinite)</source>
@@ -40,15 +48,19 @@
       </trans-unit>
       <trans-unit id="notebook.collapseBookItems.description">
         <source xml:lang="en">Collapse Book items at root level in the Notebooks Viewlet</source>
-        <target state="new">Collapse Book items at root level in the Notebooks Viewlet</target>
+        <target state="translated">Notebook 뷰렛에서 루트 수준의 Book 항목 축소</target>
       </trans-unit>
       <trans-unit id="notebook.remoteBookDownloadTimeout.description">
         <source xml:lang="en">Download timeout in milliseconds for GitHub books</source>
-        <target state="new">Download timeout in milliseconds for GitHub books</target>
+        <target state="translated">GitHub 문서의 다운로드 시간 제한(밀리초)</target>
       </trans-unit>
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
-        <target state="new">Notebooks that are pinned by the user for the current workspace</target>
+        <target state="translated">사용자가 현재 작업 영역에 고정한 Notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,72 +151,84 @@
         <target state="translated">Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">책 저장</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Jupyter Book 저장</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="new">Trust Book</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Jupyter Book 신뢰</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">책 검색</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Jupyter Book 검색</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
-        <target state="new">Notebooks</target>
+        <target state="translated">Notebook</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="new">Provided Books</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">Jupyter Book 제공</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
-        <target state="new">Pinned notebooks</target>
+        <target state="translated">고정된 Notebook</target>
       </trans-unit>
       <trans-unit id="title.PreviewLocalizedBook">
         <source xml:lang="en">Get localized SQL Server 2019 guide</source>
-        <target state="new">Get localized SQL Server 2019 guide</target>
+        <target state="translated">지역화된 SQL Server 2019 가이드 가져오기</target>
       </trans-unit>
       <trans-unit id="title.openJupyterBook">
         <source xml:lang="en">Open Jupyter Book</source>
-        <target state="new">Open Jupyter Book</target>
+        <target state="translated">Jupyter Book 열기</target>
       </trans-unit>
       <trans-unit id="title.closeJupyterBook">
         <source xml:lang="en">Close Jupyter Book</source>
-        <target state="new">Close Jupyter Book</target>
+        <target state="translated">Jupyter Book 닫기</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="new">Close Jupyter Notebook</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">Notebook 닫기</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">Notebook 제거</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">Notebook 추가</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">Markdown 파일 추가</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
-        <target state="new">Reveal in Books</target>
+        <target state="translated">Book에 표시</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="new">Create Book (Preview)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Jupyter Book 만들기</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
-        <target state="new">Open Notebooks in Folder</target>
+        <target state="translated">폴더에서 Notebook 열기</target>
       </trans-unit>
       <trans-unit id="title.openRemoteJupyterBook">
         <source xml:lang="en">Add Remote Jupyter Book</source>
-        <target state="new">Add Remote Jupyter Book</target>
+        <target state="translated">원격 Jupyter Book 추가</target>
       </trans-unit>
       <trans-unit id="title.pinNotebook">
         <source xml:lang="en">Pin Notebook</source>
-        <target state="new">Pin Notebook</target>
+        <target state="translated">Notebook 고정</target>
       </trans-unit>
       <trans-unit id="title.unpinNotebook">
         <source xml:lang="en">Unpin Notebook</source>
-        <target state="new">Unpin Notebook</target>
+        <target state="translated">Notebook 고정 해제</target>
       </trans-unit>
       <trans-unit id="title.moveTo">
         <source xml:lang="en">Move to ...</source>
-        <target state="new">Move to ...</target>
+        <target state="translated">이동 대상...</target>
       </trans-unit>
     </body>
   </file>
@@ -212,11 +236,11 @@
     <body>
       <trans-unit id="ensureDirOutputMsg">
         <source xml:lang="en">... Ensuring {0} exists</source>
-        <target state="new">... Ensuring {0} exists</target>
+        <target state="translated">... {0}이(가) 있는지 확인</target>
       </trans-unit>
       <trans-unit id="executeCommandProcessExited">
         <source xml:lang="en">Process exited with error code: {0}. StdErr Output: {1}</source>
-        <target state="new">Process exited with error code: {0}. StdErr Output: {1}</target>
+        <target state="translated">프로세스가 종료되었습니다(오류 코드: {0}). StdErr 출력: {1}</target>
       </trans-unit>
     </body>
   </file>
@@ -224,11 +248,11 @@
     <body>
       <trans-unit id="managePackages.localhost">
         <source xml:lang="en">localhost</source>
-        <target state="new">localhost</target>
+        <target state="translated">localhost</target>
       </trans-unit>
       <trans-unit id="managePackages.packageNotFound">
         <source xml:lang="en">Could not find the specified package</source>
-        <target state="new">Could not find the specified package</target>
+        <target state="translated">지정된 패키지를 찾을 수 없습니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -248,293 +272,333 @@
       </trans-unit>
       <trans-unit id="noBDCConnectionError">
         <source xml:lang="en">Spark kernels require a connection to a SQL Server Big Data Cluster master instance.</source>
-        <target state="new">Spark kernels require a connection to a SQL Server Big Data Cluster master instance.</target>
+        <target state="translated">Spark 커널을 SQL Server 빅 데이터 클러스터 마스터 인스턴스에 연결해야 합니다.</target>
       </trans-unit>
       <trans-unit id="providerNotValidError">
         <source xml:lang="en">Non-MSSQL providers are not supported for spark kernels.</source>
-        <target state="new">Non-MSSQL providers are not supported for spark kernels.</target>
+        <target state="translated">비 MSSQL 공급자는 Spark 커널에서 지원되지 않습니다.</target>
       </trans-unit>
       <trans-unit id="allFiles">
         <source xml:lang="en">All Files</source>
-        <target state="new">All Files</target>
+        <target state="translated">모든 파일</target>
       </trans-unit>
       <trans-unit id="labelSelectFolder">
         <source xml:lang="en">Select Folder</source>
-        <target state="new">Select Folder</target>
+        <target state="translated">폴더 선택</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="new">Select Book</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Jupyter Book 선택</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
-        <target state="new">Folder already exists. Are you sure you want to delete and replace this folder?</target>
+        <target state="translated">폴더가 이미 있습니다. 이 폴더를 삭제하고 바꾸시겠습니까?</target>
       </trans-unit>
       <trans-unit id="openNotebookCommand">
         <source xml:lang="en">Open Notebook</source>
-        <target state="new">Open Notebook</target>
+        <target state="translated">Notebook 열기</target>
       </trans-unit>
       <trans-unit id="openMarkdownCommand">
         <source xml:lang="en">Open Markdown</source>
-        <target state="new">Open Markdown</target>
+        <target state="translated">Markdown 열기</target>
       </trans-unit>
       <trans-unit id="openExternalLinkCommand">
         <source xml:lang="en">Open External Link</source>
-        <target state="new">Open External Link</target>
+        <target state="translated">외부 링크 열기</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="new">Book is now trusted in the workspace.</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">이제 Jupyter Book은 작업 영역에서 신뢰할 수 있습니다.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="new">Book is already trusted in this workspace.</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">Jupyter Book은 이미 이 작업 영역에서 신뢰할 수 있습니다.</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="new">Book is no longer trusted in this workspace</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">Jupyter Book은 더 이상 이 작업 영역에서 신뢰할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="new">Book is already untrusted in this workspace.</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">Jupyter Book은 이미 이 작업 영역에서 신뢰할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="new">Book {0} is now pinned in the workspace.</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">Jupyter Book {0}는 이제 작업 영역에 고정됩니다.</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="new">Book {0} is no longer pinned in this workspace</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Jupyter Book {0}은(는) 더 이상 이 작업 영역에 고정되지 않습니다.</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="new">Failed to find a Table of Contents file in the specified book.</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">지정된 Jupyter Book에서 목차 파일을 찾지 못했습니다.</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="new">No books are currently selected in the viewlet.</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">뷰렛에 현재 선택된 Jupyter Book이 없습니다.</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="new">Select Book Section</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Jupyter Book 섹션 선택</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
-        <target state="new">Add to this level</target>
+        <target state="translated">이 수준에 추가</target>
       </trans-unit>
       <trans-unit id="missingFileError">
         <source xml:lang="en">Missing file : {0} from {1}</source>
-        <target state="new">Missing file : {0} from {1}</target>
+        <target state="translated">누락된 파일: {1}의 {0}</target>
       </trans-unit>
       <trans-unit id="InvalidError.tocFile">
         <source xml:lang="en">Invalid toc file</source>
-        <target state="new">Invalid toc file</target>
+        <target state="translated">잘못된 toc 파일</target>
       </trans-unit>
       <trans-unit id="Invalid toc.yml">
         <source xml:lang="en">Error: {0} has an incorrect toc.yml file</source>
-        <target state="new">Error: {0} has an incorrect toc.yml file</target>
+        <target state="translated">오류: {0}에 잘못된 toc.yml 파일이 있음</target>
       </trans-unit>
       <trans-unit id="configFileError">
         <source xml:lang="en">Configuration file missing</source>
-        <target state="new">Configuration file missing</target>
+        <target state="translated">구성 파일 없음</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="new">Open book {0} failed: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Jupyter Book {0} 열기 실패: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="new">Failed to read book {0}: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">Jupyter Book {0}을(를) 읽지 못했습니다. {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
-        <target state="new">Open notebook {0} failed: {1}</target>
+        <target state="translated">{0} Notebook을 열지 못함: {1}</target>
       </trans-unit>
       <trans-unit id="openMarkdownError">
         <source xml:lang="en">Open markdown {0} failed: {1}</source>
-        <target state="new">Open markdown {0} failed: {1}</target>
+        <target state="translated">{0} Markdown을 열지 못함: {1}</target>
       </trans-unit>
       <trans-unit id="openUntitledNotebookError">
         <source xml:lang="en">Open untitled notebook {0} as untitled failed: {1}</source>
-        <target state="new">Open untitled notebook {0} as untitled failed: {1}</target>
+        <target state="translated">제목 없는 Notebook {0}을(를) 제목 없음으로 열지 못함: {1}</target>
       </trans-unit>
       <trans-unit id="openExternalLinkError">
         <source xml:lang="en">Open link {0} failed: {1}</source>
-        <target state="new">Open link {0} failed: {1}</target>
+        <target state="translated">링크 {0} 열기 실패: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="new">Close book {0} failed: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Jupyter Book {0} 닫기 실패: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
  The file has been renamed to {2} to prevent data loss.</source>
-        <target state="new">File {0} already exists in the destination folder {1} 
- The file has been renamed to {2} to prevent data loss.</target>
+        <target state="translated">대상 폴더 {1}에 {0} 파일이 이미 있습니다. 
+ 데이터 손실을 방지하기 위해 파일 이름이 {2}(으)로 바뀌었습니다.</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="new">Error while editing book {0}: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Jupyter Book {0}을(를) 편집하는 동안 오류 발생: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="new">Error while selecting a book or a section to edit: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">Jupyter Book 또는 편집할 섹션을 선택하는 동안 오류 발생: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">{1}에서 {0} 섹션을 찾지 못했습니다.</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
-        <target state="new">URL</target>
+        <target state="translated">URL</target>
       </trans-unit>
       <trans-unit id="repoUrl">
         <source xml:lang="en">Repository URL</source>
-        <target state="new">Repository URL</target>
+        <target state="translated">리포지토리 URL</target>
       </trans-unit>
       <trans-unit id="location">
         <source xml:lang="en">Location</source>
-        <target state="new">Location</target>
+        <target state="translated">위치</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="new">Add Remote Book</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">원격 Jupyter Book 추가</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
-        <target state="new">GitHub</target>
+        <target state="translated">GitHub</target>
       </trans-unit>
       <trans-unit id="onsharedFile">
         <source xml:lang="en">Shared File</source>
-        <target state="new">Shared File</target>
+        <target state="translated">공유 파일</target>
       </trans-unit>
       <trans-unit id="releases">
         <source xml:lang="en">Releases</source>
-        <target state="new">Releases</target>
+        <target state="translated">릴리스</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="new">Book</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter Book</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
-        <target state="new">Version</target>
+        <target state="translated">버전</target>
       </trans-unit>
       <trans-unit id="language">
         <source xml:lang="en">Language</source>
-        <target state="new">Language</target>
+        <target state="translated">언어</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="new">No books are currently available on the provided link</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">제공된 링크에 현재 사용 가능한 Jupyter Book이 없습니다.</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
-        <target state="new">The url provided is not a Github release url</target>
+        <target state="translated">제공된 URL은 GitHub 릴리스 URL이 아닙니다.</target>
       </trans-unit>
       <trans-unit id="search">
         <source xml:lang="en">Search</source>
-        <target state="new">Search</target>
+        <target state="translated">검색</target>
       </trans-unit>
       <trans-unit id="add">
         <source xml:lang="en">Add</source>
-        <target state="new">Add</target>
+        <target state="translated">추가</target>
       </trans-unit>
       <trans-unit id="close">
         <source xml:lang="en">Close</source>
-        <target state="new">Close</target>
+        <target state="translated">닫기</target>
       </trans-unit>
       <trans-unit id="invalidTextPlaceholder">
         <source xml:lang="en">-</source>
-        <target state="new">-</target>
+        <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="new">Remote Book download is in progress</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">원격 Jupyter Book 다운로드가 진행 중입니다.</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="new">Remote Book download is complete</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">원격 Jupyter Book 다운로드가 완료되었습니다.</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="new">Error while downloading remote Book</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">원격 Jupyter Book을 다운로드하는 동안 오류 발생</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="new">Error while decompressing remote Book</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">원격 Jupyter Book의 압축을 푸는 동안 오류 발생</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="new">Error while creating remote Book directory</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">원격 Jupyter Book 디렉터리를 만드는 동안 오류 발생</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="new">Downloading Remote Book</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">원격 Jupyter Book 다운로드</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
-        <target state="new">Resource not Found</target>
+        <target state="translated">리소스를 찾을 수 없음</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="new">Books not Found</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">Jupyter Book을 찾을 수 없음</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
-        <target state="new">Releases not Found</target>
+        <target state="translated">릴리스를 찾을 수 없음</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="new">The selected book is not valid</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">선택한 Jupyter Book이 유효하지 않습니다.</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
-        <target state="new">Http Request failed with error: {0} {1}</target>
+        <target state="translated">오류로 인해 Http 요청 실패: {0} {1}</target>
       </trans-unit>
       <trans-unit id="msgDownloadLocation">
         <source xml:lang="en">Downloading to {0}</source>
-        <target state="new">Downloading to {0}</target>
+        <target state="translated">{0}에 다운로드</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="new">New Group</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">새 Jupyter Book(미리 보기)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="new">Groups are used to organize Notebooks.</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Jupyter Book은 Notebook을 구성하는 데 사용됩니다.</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="new">Browse locations...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">자세히 알아보세요.</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="new">Select content folder</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">콘텐츠 폴더</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">찾아보기</target>
       </trans-unit>
       <trans-unit id="create">
         <source xml:lang="en">Create</source>
-        <target state="new">Create</target>
+        <target state="translated">만들기</target>
       </trans-unit>
       <trans-unit id="name">
         <source xml:lang="en">Name</source>
-        <target state="new">Name</target>
+        <target state="translated">이름</target>
       </trans-unit>
       <trans-unit id="saveLocation">
         <source xml:lang="en">Save location</source>
-        <target state="new">Save location</target>
+        <target state="translated">저장 위치</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
-        <target state="new">Content folder (Optional)</target>
+        <target state="translated">콘텐츠 폴더(선택 사항)</target>
       </trans-unit>
       <trans-unit id="msgContentFolderError">
         <source xml:lang="en">Content folder path does not exist</source>
-        <target state="new">Content folder path does not exist</target>
+        <target state="translated">콘텐츠 폴더 경로가 없습니다.</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="new">Save location path does not exist</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">저장 위치 경로가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">{0}에 액세스하는 동안 오류가 발생했습니다.</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">새 Notebook(미리 보기)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">새 Markdown(미리 보기)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">파일 확장명</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">파일이 이미 있습니다. 이 파일을 덮어쓰시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">제목</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">파일 이름</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">저장 위치 경로가 유효하지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">{0} 파일이 대상 폴더에 이미 있습니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">현재 다른 Python 설치를 진행 중입니다. 완료될 때까지 기다립니다.</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">업데이트를 하기 위해 활성 Python Notebook 세션이 종료됩니다. 지금 계속하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">이제 python {0}에서 Azure Data Studio를 사용할 수 있습니다. 현재 Python 버전(3.6.6)은 2021년 12월에 지원되지 않습니다. 지금 Python {0}을(를) 업데이트하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">Python {0}이(가) 설치되고 Python 3.6.6을 대체합니다. 일부 패키지는 더 이상 새 버전과 호환되지 않거나 다시 설치해야 할 수 있습니다. 모든 pip 패키지를 다시 설치하는 데 도움이 되는 전자 필기장이 만들어집니다. 지금 업데이트를 계속하시겠습니까?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">오류: {0}(을) 나타내며 Notebook 종속성 설치에 실패했습니다.</target>
@@ -598,11 +674,23 @@
       </trans-unit>
       <trans-unit id="msgPackageRetrievalFailed">
         <source xml:lang="en">Encountered an error when trying to retrieve list of installed packages: {0}</source>
-        <target state="new">Encountered an error when trying to retrieve list of installed packages: {0}</target>
+        <target state="translated">설치된 패키지 목록을 검색하는 동안 오류가 발생했습니다. {0}</target>
       </trans-unit>
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
-        <target state="new">Encountered an error when getting Python user path: {0}</target>
+        <target state="translated">Python 사용자 경로를 가져올 때 오류가 발생했습니다. {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">다시 묻지 않음</target>
       </trans-unit>
     </body>
   </file>
@@ -610,35 +698,35 @@
     <body>
       <trans-unit id="configurePython.okButtonText">
         <source xml:lang="en">Install</source>
-        <target state="new">Install</target>
+        <target state="translated">설치</target>
       </trans-unit>
       <trans-unit id="configurePython.invalidLocationMsg">
         <source xml:lang="en">The specified install location is invalid.</source>
-        <target state="new">The specified install location is invalid.</target>
+        <target state="translated">지정된 설치 위치가 잘못되었습니다.</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonNotFoundMsg">
         <source xml:lang="en">No Python installation was found at the specified location.</source>
-        <target state="new">No Python installation was found at the specified location.</target>
+        <target state="translated">지정된 위치에서 Python 설치를 찾을 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="configurePython.wizardNameWithKernel">
         <source xml:lang="en">Configure Python to run {0} kernel</source>
-        <target state="new">Configure Python to run {0} kernel</target>
+        <target state="translated">{0} 커널을 실행하도록 Python 구성</target>
       </trans-unit>
       <trans-unit id="configurePython.wizardNameWithoutKernel">
         <source xml:lang="en">Configure Python to run kernels</source>
-        <target state="new">Configure Python to run kernels</target>
+        <target state="translated">커널을 실행하도록 Python 구성</target>
       </trans-unit>
       <trans-unit id="configurePython.page0Name">
         <source xml:lang="en">Configure Python Runtime</source>
-        <target state="new">Configure Python Runtime</target>
+        <target state="translated">Python 런타임 구성</target>
       </trans-unit>
       <trans-unit id="configurePython.page1Name">
         <source xml:lang="en">Install Dependencies</source>
-        <target state="new">Install Dependencies</target>
+        <target state="translated">종속성 설치</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonInstallDeclined">
         <source xml:lang="en">Python installation was declined.</source>
-        <target state="new">Python installation was declined.</target>
+        <target state="translated">Python 설치가 거부되었습니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -678,55 +766,55 @@
     <body>
       <trans-unit id="configurePython.browseButtonText">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">찾아보기</target>
       </trans-unit>
       <trans-unit id="configurePython.selectFileLabel">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">선택</target>
       </trans-unit>
       <trans-unit id="configurePython.descriptionWithKernel">
         <source xml:lang="en">The {0} kernel requires a Python runtime to be configured and dependencies to be installed.</source>
-        <target state="new">The {0} kernel requires a Python runtime to be configured and dependencies to be installed.</target>
+        <target state="translated">{0} 커널을 사용하려면 Python 런타임을 구성하고 종속성을 설치해야 합니다.</target>
       </trans-unit>
       <trans-unit id="configurePython.descriptionWithoutKernel">
         <source xml:lang="en">Notebook kernels require a Python runtime to be configured and dependencies to be installed.</source>
-        <target state="new">Notebook kernels require a Python runtime to be configured and dependencies to be installed.</target>
+        <target state="translated">Notebook 커널에서는 Python 런타임을 구성하고 종속성을 설치해야 합니다.</target>
       </trans-unit>
       <trans-unit id="configurePython.installationType">
         <source xml:lang="en">Installation Type</source>
-        <target state="new">Installation Type</target>
+        <target state="translated">설치 유형</target>
       </trans-unit>
       <trans-unit id="configurePython.locationTextBoxText">
         <source xml:lang="en">Python Install Location</source>
-        <target state="new">Python Install Location</target>
+        <target state="translated">Python 설치 위치</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonConfigured">
         <source xml:lang="en">Python runtime configured!</source>
-        <target state="new">Python runtime configured!</target>
+        <target state="translated">Python 런타임이 구성되었습니다.</target>
       </trans-unit>
       <trans-unit id="configurePythyon.dropdownPathLabel">
         <source xml:lang="en">{0} (Python {1})</source>
-        <target state="new">{0} (Python {1})</target>
+        <target state="translated">{0}(Python {1})</target>
       </trans-unit>
       <trans-unit id="configurePythyon.noVersionsFound">
         <source xml:lang="en">No supported Python versions found.</source>
-        <target state="new">No supported Python versions found.</target>
+        <target state="translated">지원되는 Python 버전을 찾을 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="configurePythyon.defaultPathLabel">
         <source xml:lang="en">{0} (Default)</source>
-        <target state="new">{0} (Default)</target>
+        <target state="translated">{0}(기본값)</target>
       </trans-unit>
       <trans-unit id="configurePython.newInstall">
         <source xml:lang="en">New Python installation</source>
-        <target state="new">New Python installation</target>
+        <target state="translated">새 Python 설치</target>
       </trans-unit>
       <trans-unit id="configurePython.existingInstall">
         <source xml:lang="en">Use existing Python installation</source>
-        <target state="new">Use existing Python installation</target>
+        <target state="translated">기존 Python 설치 사용</target>
       </trans-unit>
       <trans-unit id="configurePythyon.customPathLabel">
         <source xml:lang="en">{0} (Custom)</source>
-        <target state="new">{0} (Custom)</target>
+        <target state="translated">{0}(사용자 지정)</target>
       </trans-unit>
     </body>
   </file>
@@ -734,27 +822,27 @@
     <body>
       <trans-unit id="configurePython.pkgNameColumn">
         <source xml:lang="en">Name</source>
-        <target state="new">Name</target>
+        <target state="translated">이름</target>
       </trans-unit>
       <trans-unit id="configurePython.existingVersionColumn">
         <source xml:lang="en">Existing Version</source>
-        <target state="new">Existing Version</target>
+        <target state="translated">기존 버전</target>
       </trans-unit>
       <trans-unit id="configurePython.requiredVersionColumn">
         <source xml:lang="en">Required Version</source>
-        <target state="new">Required Version</target>
+        <target state="translated">필요한 버전</target>
       </trans-unit>
       <trans-unit id="configurePython.kernelLabel">
         <source xml:lang="en">Kernel</source>
-        <target state="new">Kernel</target>
+        <target state="translated">커널</target>
       </trans-unit>
       <trans-unit id="configurePython.requiredDependencies">
         <source xml:lang="en">Install required kernel dependencies</source>
-        <target state="new">Install required kernel dependencies</target>
+        <target state="translated">필요한 커널 종속성 설치</target>
       </trans-unit>
       <trans-unit id="msgUnsupportedKernel">
         <source xml:lang="en">Could not retrieve packages for kernel {0}</source>
-        <target state="new">Could not retrieve packages for kernel {0}</target>
+        <target state="translated">{0} 커널의 패키지를 검색할 수 없음</target>
       </trans-unit>
     </body>
   </file>
@@ -774,7 +862,7 @@
       </trans-unit>
       <trans-unit id="notebookStartProcessExitPremature">
         <source xml:lang="en">Notebook process exited prematurely with error code: {0}. StdErr Output: {1}</source>
-        <target state="new">Notebook process exited prematurely with error code: {0}. StdErr Output: {1}</target>
+        <target state="translated">Notebook 프로세스가 조기에 종료되었습니다(오류 코드: {0}). StdErr 출력: {1}</target>
       </trans-unit>
       <trans-unit id="jupyterError">
         <source xml:lang="en">Error sent from Jupyter: {0}</source>
@@ -806,23 +894,23 @@
       </trans-unit>
       <trans-unit id="notebook.couldNotFindKnoxGateway">
         <source xml:lang="en">Could not find Knox gateway endpoint</source>
-        <target state="new">Could not find Knox gateway endpoint</target>
+        <target state="translated">Knox 게이트웨이 엔드포인트를 찾을 수 없음</target>
       </trans-unit>
       <trans-unit id="promptBDCUsername">
         <source xml:lang="en">{0}Please provide the username to connect to the BDC Controller:</source>
-        <target state="new">{0}Please provide the username to connect to the BDC Controller:</target>
+        <target state="translated">{0}BDC 컨트롤러에 연결하려면 사용자 이름을 제공하세요.</target>
       </trans-unit>
       <trans-unit id="promptBDCPassword">
         <source xml:lang="en">Please provide the password to connect to the BDC Controller</source>
-        <target state="new">Please provide the password to connect to the BDC Controller</target>
+        <target state="translated">BDC 컨트롤러에 연결하려면 암호를 제공하세요.</target>
       </trans-unit>
       <trans-unit id="bdcConnectError">
         <source xml:lang="en">Error: {0}. </source>
-        <target state="new">Error: {0}. </target>
+        <target state="translated">오류: {0}. </target>
       </trans-unit>
       <trans-unit id="clusterControllerConnectionRequired">
         <source xml:lang="en">A connection to the cluster controller is required to run Spark jobs</source>
-        <target state="new">A connection to the cluster controller is required to run Spark jobs</target>
+        <target state="translated">Spark 작업을 실행하려면 클러스터 컨트롤러에 대한 연결이 필요합니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -854,7 +942,7 @@
       </trans-unit>
       <trans-unit id="managePackages.deleteColumn">
         <source xml:lang="en">Delete</source>
-        <target state="new">Delete</target>
+        <target state="translated">삭제</target>
       </trans-unit>
       <trans-unit id="managePackages.uninstallButtonText">
         <source xml:lang="en">Uninstall selected packages</source>
@@ -866,7 +954,7 @@
       </trans-unit>
       <trans-unit id="managePackages.location">
         <source xml:lang="en">Location</source>
-        <target state="new">Location</target>
+        <target state="translated">위치</target>
       </trans-unit>
       <trans-unit id="managePackages.packageCount">
         <source xml:lang="en">{0} {1} packages found</source>
@@ -946,7 +1034,7 @@
     <body>
       <trans-unit id="managePackages.packageRequestError">
         <source xml:lang="en">Package info request failed with error: {0} {1}</source>
-        <target state="new">Package info request failed with error: {0} {1}</target>
+        <target state="translated">{0} {1} 오류를 나타내며 패키지 정보 요청 실패</target>
       </trans-unit>
     </body>
   </file>
@@ -954,15 +1042,15 @@
     <body>
       <trans-unit id="msgSampleCodeDataFrame">
         <source xml:lang="en">This sample code loads the file into a data frame and shows the first 10 results.</source>
-        <target state="new">This sample code loads the file into a data frame and shows the first 10 results.</target>
+        <target state="translated">이 샘플 코드는 파일을 데이터 프레임에 로드하고 처음 10개의 결과를 표시합니다.</target>
       </trans-unit>
       <trans-unit id="noNotebookVisible">
         <source xml:lang="en">No notebook editor is active</source>
-        <target state="new">No notebook editor is active</target>
+        <target state="translated">Notebook 편집기가 활성 상태가 아님</target>
       </trans-unit>
       <trans-unit id="notebookFiles">
         <source xml:lang="en">Notebooks</source>
-        <target state="new">Notebooks</target>
+        <target state="translated">Notebook</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">이 처리기에는 {0} 작업이 지원되지 않습니다.</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">HTTP 및 HTTPS 링크만 지원되기 때문에 {0} 링크를 열 수 없습니다.</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">HTTP, HTTPS 및 파일 링크만 지원되므로 링크 {0}을(를) 열 수 없음</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/ko/profiler.ko.xlf
+++ b/resources/xlf/ko/profiler.ko.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/ko/resource-deployment.ko.xlf
+++ b/resources/xlf/ko/resource-deployment.ko.xlf
@@ -12,7 +12,7 @@
       </trans-unit>
       <trans-unit id="deploy-resource-command-name">
         <source xml:lang="en">New Deployment…</source>
-        <target state="new">New Deployment…</target>
+        <target state="translated">새 배포...</target>
       </trans-unit>
       <trans-unit id="deploy-resource-command-category">
         <source xml:lang="en">Deployment</source>
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">Docker를 사용하여 SQL Server 컨테이너 이미지 실행</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">SQL Server 빅 데이터 클러스터</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">SQL Server 빅 데이터 클러스터를 사용하면 Kubernetes에서 실행되는 SQL Server, Spark 및 HDFS 컨테이너의 확장 가능한 클러스터를 배포할 수 있습니다.</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">버전</target>
@@ -44,43 +36,15 @@
       </trans-unit>
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
-        <target state="new">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="new">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">배포 대상</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">새 Azure Kubernetes Service 클러스터</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">기존 Azure Kubernetes Service 클러스터</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">기존 Kubernetes 클러스터(kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="new">Existing Azure Red Hat OpenShift cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="new">Existing OpenShift cluster</target>
+        <target state="translated">SQL Server 2019</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
-        <target state="new">Deploy SQL Server 2017 container images</target>
+        <target state="translated">SQL Server 2017 컨테이너 이미지 배포</target>
       </trans-unit>
       <trans-unit id="docker-sql-2019-title">
         <source xml:lang="en">Deploy SQL Server 2019 container images</source>
-        <target state="new">Deploy SQL Server 2019 container images</target>
+        <target state="translated">SQL Server 2019 컨테이너 이미지 배포</target>
       </trans-unit>
       <trans-unit id="docker-container-name-field">
         <source xml:lang="en">Container name</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">포트</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">SQL Server 빅 데이터 클러스터 설정</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">클러스터 이름</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">컨트롤러 사용자 이름</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">암호</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">암호 확인</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Azure 설정</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">구독 ID</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">내 기본 Azure 구독 사용</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">리소스 그룹 이름</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">지역</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">AKS 클러스터 이름</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">VM 크기</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">VM 수</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">스토리지 클래스 이름</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">데이터 용량(GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">로그 용량(GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">Windows의 SQL Server</target>
@@ -170,197 +70,185 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">Windows에서 SQL Server를 실행하고 시작할 버전을 선택합니다.</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">{0}, {1} 및 {2}에 동의합니다.</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
-        <target state="new">Microsoft Privacy Statement</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">azdata 사용 조건</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">SQL Server 사용 조건</target>
+        <target state="translated">Microsoft 개인정보처리방침</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
-        <target state="new">Deployment configuration</target>
+        <target state="translated">배포 구성</target>
       </trans-unit>
       <trans-unit id="azdata-install-location-description">
         <source xml:lang="en">Location of the azdata package used for the install command</source>
-        <target state="new">Location of the azdata package used for the install command</target>
+        <target state="translated">설치 명령에 사용되는 azdata 패키지의 위치</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-display-name">
         <source xml:lang="en">SQL Server on Azure Virtual Machine</source>
-        <target state="new">SQL Server on Azure Virtual Machine</target>
+        <target state="translated">Azure 가상 머신의 SQL Server</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-description">
         <source xml:lang="en">Create SQL virtual machines on Azure. Best for migrations and applications requiring OS-level access.</source>
-        <target state="new">Create SQL virtual machines on Azure. Best for migrations and applications requiring OS-level access.</target>
+        <target state="translated">Azure에서 SQL 가상 머신을 만듭니다. OS 수준 액세스가 필요한 마이그레이션 및 애플리케이션에 가장 적합합니다.</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-deploy-dialog-title">
         <source xml:lang="en">Deploy Azure SQL virtual machine</source>
-        <target state="new">Deploy Azure SQL virtual machine</target>
+        <target state="translated">Azure SQL 가상 머신 배포</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-deploy-dialog-action-text">
         <source xml:lang="en">Script to notebook</source>
-        <target state="new">Script to notebook</target>
+        <target state="translated">Notebook으로 스크립트</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement">
         <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="new">I accept {0}, {1} and {2}.</target>
+        <target state="translated">{0}, {1} 및 {2}에 동의합니다.</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement-sqlvm-eula">
         <source xml:lang="en">Azure SQL VM License Terms</source>
-        <target state="new">Azure SQL VM License Terms</target>
+        <target state="translated">Azure SQL VM 사용 조건</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement-azdata-eula">
         <source xml:lang="en">azdata License Terms</source>
-        <target state="new">azdata License Terms</target>
+        <target state="translated">azdata 사용 조건</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-azure-account-page-label">
         <source xml:lang="en">Azure information</source>
-        <target state="new">Azure information</target>
+        <target state="translated">Azure 정보</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-azure-location-label">
         <source xml:lang="en">Azure locations</source>
-        <target state="new">Azure locations</target>
+        <target state="translated">Azure 위치</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-information-page-label">
         <source xml:lang="en">VM information</source>
-        <target state="new">VM information</target>
+        <target state="translated">VM 정보</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-image-label">
         <source xml:lang="en">Image</source>
-        <target state="new">Image</target>
+        <target state="translated">이미지</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-image-sku-label">
         <source xml:lang="en">VM image SKU</source>
-        <target state="new">VM image SKU</target>
+        <target state="translated">VM 이미지 SKU</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-publisher-label">
         <source xml:lang="en">Publisher</source>
-        <target state="new">Publisher</target>
+        <target state="translated">게시자</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vmname-label">
         <source xml:lang="en">Virtual machine name</source>
-        <target state="new">Virtual machine name</target>
+        <target state="translated">가상 머신 이름</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vmsize-label">
         <source xml:lang="en">Size</source>
-        <target state="new">Size</target>
+        <target state="translated">크기</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-page-lable">
         <source xml:lang="en">Storage account</source>
-        <target state="new">Storage account</target>
+        <target state="translated">스토리지 계정</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-accountname-label">
         <source xml:lang="en">Storage account name</source>
-        <target state="new">Storage account name</target>
+        <target state="translated">스토리지 계정 이름</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-sku-label">
         <source xml:lang="en">Storage account SKU type</source>
-        <target state="new">Storage account SKU type</target>
+        <target state="translated">스토리지 계정 SKU 유형</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-administrator-account-page-label">
         <source xml:lang="en">Administrator account</source>
-        <target state="new">Administrator account</target>
+        <target state="translated">관리자 계정</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-username-label">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">사용자 이름</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-password-label">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">암호</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-password-confirm-label">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">암호 확인</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-summary-page-label">
         <source xml:lang="en">Summary</source>
-        <target state="new">Summary</target>
+        <target state="translated">요약</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-display-name">
         <source xml:lang="en">Azure SQL Database</source>
-        <target state="new">Azure SQL Database</target>
+        <target state="translated">Azure SQL Database</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-description">
         <source xml:lang="en">Create a SQL database, database server, or elastic pool in Azure.</source>
-        <target state="new">Create a SQL database, database server, or elastic pool in Azure.</target>
+        <target state="translated">Azure에서 SQL 데이터베이스, 데이터베이스 서버 또는 탄력적 풀을 만듭니다.</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-portal-ok-button-text">
         <source xml:lang="en">Create in Azure portal</source>
-        <target state="new">Create in Azure portal</target>
+        <target state="translated">Azure Portal에서 만들기</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-notebook-ok-button-text">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">선택</target>
       </trans-unit>
       <trans-unit id="resource-type-display-name">
         <source xml:lang="en">Resource Type</source>
-        <target state="new">Resource Type</target>
+        <target state="translated">리소스 종류</target>
       </trans-unit>
       <trans-unit id="sql-azure-single-database-display-name">
         <source xml:lang="en">Single Database</source>
-        <target state="new">Single Database</target>
+        <target state="translated">단일 데이터베이스</target>
       </trans-unit>
       <trans-unit id="sql-azure-elastic-pool-display-name">
         <source xml:lang="en">Elastic Pool</source>
-        <target state="new">Elastic Pool</target>
+        <target state="translated">탄력적 풀</target>
       </trans-unit>
       <trans-unit id="sql-azure-database-server-display-name">
         <source xml:lang="en">Database Server</source>
-        <target state="new">Database Server</target>
+        <target state="translated">데이터베이스 서버</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement">
         <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="new">I accept {0}, {1} and {2}.</target>
+        <target state="translated">{0}, {1} 및 {2}에 동의합니다.</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement-sqldb-eula">
         <source xml:lang="en">Azure SQL DB License Terms</source>
-        <target state="new">Azure SQL DB License Terms</target>
+        <target state="translated">Azure SQL DB 사용 조건</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement-azdata-eula">
         <source xml:lang="en">azdata License Terms</source>
-        <target state="new">azdata License Terms</target>
+        <target state="translated">azdata 사용 조건</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-display-name">
         <source xml:lang="en">Azure SQL managed instance</source>
-        <target state="new">Azure SQL managed instance</target>
+        <target state="translated">Azure SQL Managed Instance</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-display-description">
         <source xml:lang="en">Create a SQL Managed Instance in either Azure or a customer-managed environment</source>
-        <target state="new">Create a SQL Managed Instance in either Azure or a customer-managed environment</target>
+        <target state="translated">Azure 또는 고객 관리형 환경에서 SQL Managed Instance 만들기</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-okButton-text">
         <source xml:lang="en">Open in Portal</source>
-        <target state="new">Open in Portal</target>
+        <target state="translated">Portal에서 열기</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-resource-type-option-label">
         <source xml:lang="en">Resource Type</source>
-        <target state="new">Resource Type</target>
+        <target state="translated">리소스 종류</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-agreement">
         <source xml:lang="en">I accept {0} and {1}.</source>
-        <target state="new">I accept {0} and {1}.</target>
+        <target state="translated">{0} 및 {1}에 동의합니다.</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-agreement-eula">
         <source xml:lang="en">Azure SQL MI License Terms</source>
-        <target state="new">Azure SQL MI License Terms</target>
+        <target state="translated">Azure SQL MI 사용 조건</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-help-text">
         <source xml:lang="en">Azure SQL Managed Instance provides full SQL Server access and feature compatibility for migrating SQL Servers to Azure, or developing new applications. {0}.</source>
-        <target state="new">Azure SQL Managed Instance provides full SQL Server access and feature compatibility for migrating SQL Servers to Azure, or developing new applications. {0}.</target>
+        <target state="translated">Azure SQL Managed Instance는 SQL Server를 Azure로 마이그레이션하거나 새 애플리케이션을 개발하는 데 필요한 전체 SQL Server 액세스 및 기능 호환성을 제공합니다. {0}.</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-help-text-learn-more">
         <source xml:lang="en">Learn More</source>
-        <target state="new">Learn More</target>
+        <target state="translated">자세한 정보</target>
       </trans-unit>
     </body>
   </file>
@@ -368,227 +256,243 @@
     <body>
       <trans-unit id="azure.account">
         <source xml:lang="en">Azure Account</source>
-        <target state="new">Azure Account</target>
+        <target state="translated">Azure 계정</target>
       </trans-unit>
       <trans-unit id="azure.account.subscription">
         <source xml:lang="en">Subscription (selected subset)</source>
-        <target state="new">Subscription (selected subset)</target>
+        <target state="translated">구독(선택한 하위 집합)</target>
       </trans-unit>
       <trans-unit id="azure.account.subscriptionDescription">
         <source xml:lang="en">Change the currently selected subscriptions through the 'Select Subscriptions' action on an account listed in the 'Azure' tree view of the 'Connections' viewlet</source>
-        <target state="new">Change the currently selected subscriptions through the 'Select Subscriptions' action on an account listed in the 'Azure' tree view of the 'Connections' viewlet</target>
+        <target state="translated">'연결' 뷰렛의 'Azure' 트리 뷰에 나열된 계정의 '구독 선택' 작업을 통해 현재 선택된 구독 변경</target>
       </trans-unit>
       <trans-unit id="azure.account.resourceGroup">
         <source xml:lang="en">Resource Group</source>
-        <target state="new">Resource Group</target>
+        <target state="translated">리소스 그룹</target>
       </trans-unit>
       <trans-unit id="azure.account.location">
         <source xml:lang="en">Azure Location</source>
-        <target state="new">Azure Location</target>
+        <target state="translated">Azure 위치</target>
       </trans-unit>
       <trans-unit id="filePicker.browse">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">찾아보기</target>
       </trans-unit>
       <trans-unit id="button.label">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">선택</target>
       </trans-unit>
       <trans-unit id="kubeConfigClusterPicker.kubeConfigFilePath">
         <source xml:lang="en">Kube config file path</source>
-        <target state="new">Kube config file path</target>
+        <target state="translated">Kube 구성 파일 경로</target>
       </trans-unit>
       <trans-unit id="kubeConfigClusterPicker.clusterContextNotFound">
         <source xml:lang="en">No cluster context information found</source>
-        <target state="new">No cluster context information found</target>
+        <target state="translated">클러스터 컨텍스트 정보를 찾을 수 없음</target>
       </trans-unit>
       <trans-unit id="azure.signin">
         <source xml:lang="en">Sign in…</source>
-        <target state="new">Sign in…</target>
+        <target state="translated">로그인…</target>
       </trans-unit>
       <trans-unit id="azure.refresh">
         <source xml:lang="en">Refresh</source>
-        <target state="new">Refresh</target>
+        <target state="translated">새로 고침</target>
       </trans-unit>
       <trans-unit id="azure.yes">
         <source xml:lang="en">Yes</source>
-        <target state="new">Yes</target>
+        <target state="translated">예</target>
       </trans-unit>
       <trans-unit id="azure.no">
         <source xml:lang="en">No</source>
-        <target state="new">No</target>
+        <target state="translated">아니요</target>
       </trans-unit>
       <trans-unit id="azure.resourceGroup.createNewResourceGroup">
         <source xml:lang="en">Create a new resource group</source>
-        <target state="new">Create a new resource group</target>
+        <target state="translated">새 리소스 그룹 만들기</target>
       </trans-unit>
       <trans-unit id="azure.resourceGroup.NewResourceGroupAriaLabel">
         <source xml:lang="en">New resource group name</source>
-        <target state="new">New resource group name</target>
+        <target state="translated">새 리소스 그룹 이름</target>
       </trans-unit>
       <trans-unit id="deployCluster.Realm">
         <source xml:lang="en">Realm</source>
-        <target state="new">Realm</target>
+        <target state="translated">영역</target>
       </trans-unit>
       <trans-unit id="UnknownFieldTypeError">
         <source xml:lang="en">Unknown field type: "{0}"</source>
-        <target state="new">Unknown field type: "{0}"</target>
+        <target state="translated">알 수 없는 필드 형식: "{0}"</target>
       </trans-unit>
       <trans-unit id="optionsSource.alreadyDefined">
         <source xml:lang="en">Options Source with id:{0} is already defined</source>
-        <target state="new">Options Source with id:{0} is already defined</target>
+        <target state="translated">ID가 {0}인 옵션 원본이 이미 정의되어 있습니다.</target>
       </trans-unit>
       <trans-unit id="valueProvider.alreadyDefined">
         <source xml:lang="en">Value Provider with id:{0} is already defined</source>
-        <target state="new">Value Provider with id:{0} is already defined</target>
+        <target state="translated">ID가 {0}인 값 공급자가 이미 정의되어 있습니다.</target>
       </trans-unit>
       <trans-unit id="optionsSource.notDefined">
         <source xml:lang="en">No Options Source defined for id: {0}</source>
-        <target state="new">No Options Source defined for id: {0}</target>
+        <target state="translated">{0} ID에 대해 정의된 옵션 원본 없음</target>
       </trans-unit>
       <trans-unit id="valueProvider.notDefined">
         <source xml:lang="en">No Value Provider defined for id: {0}</source>
-        <target state="new">No Value Provider defined for id: {0}</target>
+        <target state="translated">{0} ID에 대해 정의된 값 공급자 없음</target>
       </trans-unit>
       <trans-unit id="getVariableValue.unknownVariableName">
         <source xml:lang="en">Attempt to get variable value for unknown variable:{0}</source>
-        <target state="new">Attempt to get variable value for unknown variable:{0}</target>
+        <target state="translated">알 수 없는 변수 {0}의 변수 값을 가져오려고 시도합니다.</target>
       </trans-unit>
       <trans-unit id="getIsPassword.unknownVariableName">
         <source xml:lang="en">Attempt to get isPassword for unknown variable:{0}</source>
-        <target state="new">Attempt to get isPassword for unknown variable:{0}</target>
+        <target state="translated">알 수 없는 변수 {0}의 isPassword를 가져오려고 시도합니다.</target>
       </trans-unit>
       <trans-unit id="optionsNotDefined">
         <source xml:lang="en">FieldInfo.options was not defined for field type: {0}</source>
-        <target state="new">FieldInfo.options was not defined for field type: {0}</target>
+        <target state="translated">FieldInfo.options가 필드 형식 {0}에 대해 정의되지 않았습니다.</target>
       </trans-unit>
       <trans-unit id="optionsNotObjectOrArray">
         <source xml:lang="en">FieldInfo.options must be an object if it is not an array</source>
-        <target state="new">FieldInfo.options must be an object if it is not an array</target>
+        <target state="translated">FieldInfo.options는 배열이 아닌 경우 개체여야 합니다.</target>
       </trans-unit>
       <trans-unit id="optionsTypeNotFound">
         <source xml:lang="en">When FieldInfo.options is an object it must have 'optionsType' property</source>
-        <target state="new">When FieldInfo.options is an object it must have 'optionsType' property</target>
+        <target state="translated">FieldInfo.options가 개체인 경우 'optionsType' 속성을 포함해야 합니다.</target>
       </trans-unit>
       <trans-unit id="optionsTypeRadioOrDropdown">
         <source xml:lang="en">When optionsType is not {0} then it must be {1}</source>
-        <target state="new">When optionsType is not {0} then it must be {1}</target>
+        <target state="translated">optionsType이 {0}이(가) 아니면 {1}이어야 합니다.</target>
       </trans-unit>
       <trans-unit id="azdataEulaNotAccepted">
         <source xml:lang="en">Deployment cannot continue. Azure Data CLI license terms have not yet been accepted. Please accept the EULA to enable the features that requires Azure Data CLI.</source>
-        <target state="new">Deployment cannot continue. Azure Data CLI license terms have not yet been accepted. Please accept the EULA to enable the features that requires Azure Data CLI.</target>
+        <target state="translated">배포를 계속할 수 없습니다. Azure Data CLI 사용 조건에 아직 동의하지 않았습니다. Azure Data CLI가 필요한 기능을 사용하려면 EULA에 동의하세요.</target>
       </trans-unit>
       <trans-unit id="azdataEulaDeclined">
         <source xml:lang="en">Deployment cannot continue. Azure Data CLI license terms were declined.You can either Accept EULA to continue or Cancel this operation</source>
-        <target state="new">Deployment cannot continue. Azure Data CLI license terms were declined.You can either Accept EULA to continue or Cancel this operation</target>
+        <target state="translated">배포를 계속할 수 없습니다. Azure Data CLI 사용 조건이 거부되었습니다. EULA에 동의하여 계속하거나 이 작업을 취소할 수 있습니다.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
-        <target state="new">Accept EULA &amp; Select</target>
+        <target state="translated">EULA에 동의 및 선택</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">이 리소스를 배포하려면 '{0}' 확장이 필요합니다. 지금 설치하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">설치</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">'{0}' 확장을 설치하는 중...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">'{0}'은(는) 알 수 없는 확장입니다.</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
-        <target state="new">Select the deployment options</target>
+        <target state="translated">배포 옵션 선택</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceSearchPlaceholder">
         <source xml:lang="en">Filter resources...</source>
-        <target state="new">Filter resources...</target>
+        <target state="translated">리소스 필터링...</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.tagsListViewTitle">
         <source xml:lang="en">Categories</source>
-        <target state="new">Categories</target>
+        <target state="translated">범주</target>
       </trans-unit>
       <trans-unit id="validation.multipleValidationErrors">
         <source xml:lang="en">There are some errors on this page, click 'Show Details' to view the errors.</source>
-        <target state="new">There are some errors on this page, click 'Show Details' to view the errors.</target>
+        <target state="translated">이 페이지에 오류가 있습니다. 오류를 보려면 '세부 정보 표시'를 클릭합니다.</target>
       </trans-unit>
       <trans-unit id="ui.ScriptToNotebookButton">
         <source xml:lang="en">Script</source>
-        <target state="new">Script</target>
+        <target state="translated">스크립트</target>
       </trans-unit>
       <trans-unit id="ui.DeployButton">
         <source xml:lang="en">Run</source>
-        <target state="new">Run</target>
+        <target state="translated">실행</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.ViewErrorDetail">
         <source xml:lang="en">View error detail</source>
-        <target state="new">View error detail</target>
+        <target state="translated">오류 세부 정보 보기</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.FailedToOpenNotebook">
         <source xml:lang="en">An error occurred opening the output notebook. {1}{2}.</source>
-        <target state="new">An error occurred opening the output notebook. {1}{2}.</target>
+        <target state="translated">출력 Notebook을 여는 동안 오류가 발생했습니다. {1}{2}.</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.BackgroundExecutionFailed">
         <source xml:lang="en">The task "{0}" has failed.</source>
-        <target state="new">The task "{0}" has failed.</target>
+        <target state="translated">"{0}" 작업이 실패했습니다.</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.TaskFailedWithNoOutputNotebook">
         <source xml:lang="en">The task "{0}" failed and no output Notebook was generated.</source>
-        <target state="new">The task "{0}" failed and no output Notebook was generated.</target>
+        <target state="translated">"{0}" 작업이 실패했으며 출력 Notebook이 생성되지 않았습니다.</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryAll">
         <source xml:lang="en">All</source>
-        <target state="new">All</target>
+        <target state="translated">모두</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnPrem">
         <source xml:lang="en">On-premises</source>
-        <target state="new">On-premises</target>
+        <target state="translated">온-프레미스</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoriesSqlServer">
         <source xml:lang="en">SQL Server</source>
-        <target state="new">SQL Server</target>
+        <target state="translated">SQL Server</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnHybrid">
         <source xml:lang="en">Hybrid</source>
-        <target state="new">Hybrid</target>
+        <target state="translated">하이브리드</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnPostgreSql">
         <source xml:lang="en">PostgreSQL</source>
-        <target state="new">PostgreSQL</target>
+        <target state="translated">PostgreSQL</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnCloud">
         <source xml:lang="en">Cloud</source>
-        <target state="new">Cloud</target>
+        <target state="translated">클라우드</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Description">
         <source xml:lang="en">Description</source>
-        <target state="new">Description</target>
+        <target state="translated">설명</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Tool">
         <source xml:lang="en">Tool</source>
-        <target state="new">Tool</target>
+        <target state="translated">도구</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Status">
         <source xml:lang="en">Status</source>
-        <target state="new">Status</target>
+        <target state="translated">상태</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Version">
         <source xml:lang="en">Version</source>
-        <target state="new">Version</target>
+        <target state="translated">버전</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.RequiredVersion">
         <source xml:lang="en">Required Version</source>
-        <target state="new">Required Version</target>
+        <target state="translated">필요한 버전</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.discoverPathOrAdditionalInformation">
         <source xml:lang="en">Discovered Path or Additional Information</source>
-        <target state="new">Discovered Path or Additional Information</target>
+        <target state="translated">검색된 경로 또는 추가 정보</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.requiredTools">
         <source xml:lang="en">Required tools</source>
-        <target state="new">Required tools</target>
+        <target state="translated">필요한 도구</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.InstallTools">
         <source xml:lang="en">Install tools</source>
-        <target state="new">Install tools</target>
+        <target state="translated">도구 설치</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Options">
         <source xml:lang="en">Options</source>
-        <target state="new">Options</target>
+        <target state="translated">옵션</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallingTool">
         <source xml:lang="en">Required tool '{0}' [ {1} ] is being installed now.</source>
-        <target state="new">Required tool '{0}' [ {1} ] is being installed now.</target>
+        <target state="translated">지금 필요한 도구 '{0}'[{1}]을(를) 설치하는 중입니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -596,45 +500,45 @@
     <body>
       <trans-unit id="getClusterContexts.errorFetchingClusters">
         <source xml:lang="en">An error ocurred while loading or parsing the config file:{0}, error is:{1}</source>
-        <target state="new">An error ocurred while loading or parsing the config file:{0}, error is:{1}</target>
+        <target state="translated">{0} 구성 파일을 로드하거나 구문 분석하는 동안 오류가 발생했습니다. 오류: {1}</target>
       </trans-unit>
       <trans-unit id="fileChecker.NotFile">
         <source xml:lang="en">Path: {0} is not a file, please select a valid kube config file.</source>
-        <target state="new">Path: {0} is not a file, please select a valid kube config file.</target>
+        <target state="translated">{0} 경로가 파일이 아닙니다. 유효한 kube 구성 파일을 선택하세요.</target>
       </trans-unit>
       <trans-unit id="fileChecker.FileNotFound">
         <source xml:lang="en">File: {0} not found. Please select a kube config file.</source>
-        <target state="new">File: {0} not found. Please select a kube config file.</target>
+        <target state="translated">{0} 파일을 찾을 수 없습니다. kube 구성 파일을 선택하세요.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedAccountsError">
         <source xml:lang="en">Unexpected error fetching accounts: {0}</source>
-        <target state="new">Unexpected error fetching accounts: {0}</target>
+        <target state="translated">계정을 가져오는 동안 예기치 않은 오류 발생: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.errorFetchingStorageClasses">
         <source xml:lang="en">Unexpected error fetching available kubectl storage classes : {0}</source>
-        <target state="new">Unexpected error fetching available kubectl storage classes : {0}</target>
+        <target state="translated">사용 가능한 kubectl 스토리지 클래스를 가져오는 동안 예기치 않은 오류 발생: {0}</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedSubscriptionsError">
         <source xml:lang="en">Unexpected error fetching subscriptions for account {0}: {1}</source>
-        <target state="new">Unexpected error fetching subscriptions for account {0}: {1}</target>
+        <target state="translated">{0} 계정의 구독을 가져오는 동안 예기치 않은 오류 발생: {1}</target>
       </trans-unit>
       <trans-unit id="azure.accounts.accountNotFoundError">
         <source xml:lang="en">The selected account '{0}' is no longer available. Click sign in to add it again or select a different account.</source>
-        <target state="new">The selected account '{0}' is no longer available. Click sign in to add it again or select a different account.</target>
+        <target state="translated">선택한 계정 '{0}'은(는) 더 이상 사용할 수 없습니다. [로그인]을 클릭하여 다시 추가하거나 다른 계정을 선택합니다.</target>
       </trans-unit>
       <trans-unit id="azure.accessError">
         <source xml:lang="en">
  Error Details: {0}.</source>
-        <target state="new">
- Error Details: {0}.</target>
+        <target state="translated">
+ 오류 세부 정보: {0}.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.accountStaleError">
         <source xml:lang="en">The access token for selected account '{0}' is no longer valid. Please click the sign in button and refresh the account or select a different account.</source>
-        <target state="new">The access token for selected account '{0}' is no longer valid. Please click the sign in button and refresh the account or select a different account.</target>
+        <target state="translated">선택한 계정 '{0}'의 액세스 토큰이 더 이상 유효하지 않습니다. [로그인] 단추를 클릭하고 계정을 새로 고치거나, 다른 계정을 선택하세요.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedResourceGroupsError">
         <source xml:lang="en">Unexpected error fetching resource groups for subscription {0}: {1}</source>
-        <target state="new">Unexpected error fetching resource groups for subscription {0}: {1}</target>
+        <target state="translated">{0} 구독의 리소스 그룹을 가져오는 동안 예기치 않은 오류 발생: {1}</target>
       </trans-unit>
       <trans-unit id="invalidSQLPassword">
         <source xml:lang="en">{0} doesn't meet the password complexity requirement. For more information: https://docs.microsoft.com/sql/relational-databases/security/password-policy</source>
@@ -650,139 +554,139 @@
     <body>
       <trans-unit id="deployAzureSQLVM.NewSQLVMTitle">
         <source xml:lang="en">Deploy Azure SQL VM</source>
-        <target state="new">Deploy Azure SQL VM</target>
+        <target state="translated">Azure SQL VM 배포</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Notebook으로 스크립트</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">빨간색 별표가 표시된 필수 필드를 입력하세요.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureSettingsPageTitle">
         <source xml:lang="en">Azure settings</source>
-        <target state="new">Azure settings</target>
+        <target state="translated">Azure 설정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureAccountDropdownLabel">
         <source xml:lang="en">Azure Account</source>
-        <target state="new">Azure Account</target>
+        <target state="translated">Azure 계정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureSubscriptionDropdownLabel">
         <source xml:lang="en">Subscription</source>
-        <target state="new">Subscription</target>
+        <target state="translated">구독</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.ResourceGroup">
         <source xml:lang="en">Resource Group</source>
-        <target state="new">Resource Group</target>
+        <target state="translated">리소스 그룹</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureRegionDropdownLabel">
         <source xml:lang="en">Region</source>
-        <target state="new">Region</target>
+        <target state="translated">지역</target>
       </trans-unit>
       <trans-unit id="deployeAzureSQLVM.VmSettingsPageTitle">
         <source xml:lang="en">Virtual machine settings</source>
-        <target state="new">Virtual machine settings</target>
+        <target state="translated">가상 머신 설정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmNameTextBoxLabel">
         <source xml:lang="en">Virtual machine name</source>
-        <target state="new">Virtual machine name</target>
+        <target state="translated">가상 머신 이름</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminUsernameTextBoxLabel">
         <source xml:lang="en">Administrator account username</source>
-        <target state="new">Administrator account username</target>
+        <target state="translated">관리자 계정 사용자 이름</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminPasswordTextBoxLabel">
         <source xml:lang="en">Administrator account password</source>
-        <target state="new">Administrator account password</target>
+        <target state="translated">관리자 계정 암호</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminConfirmPasswordTextBoxLabel">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">암호 확인</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmImageDropdownLabel">
         <source xml:lang="en">Image</source>
-        <target state="new">Image</target>
+        <target state="translated">이미지</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmSkuDropdownLabel">
         <source xml:lang="en">Image SKU</source>
-        <target state="new">Image SKU</target>
+        <target state="translated">이미지 SKU</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmImageVersionDropdownLabel">
         <source xml:lang="en">Image Version</source>
-        <target state="new">Image Version</target>
+        <target state="translated">이미지 버전</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmSizeDropdownLabel">
         <source xml:lang="en">Size</source>
-        <target state="new">Size</target>
+        <target state="translated">크기</target>
       </trans-unit>
       <trans-unit id="deployeAzureSQLVM.VmSizeLearnMoreLabel">
         <source xml:lang="en">Click here to learn more about pricing and supported VM sizes</source>
-        <target state="new">Click here to learn more about pricing and supported VM sizes</target>
+        <target state="translated">가격 책정 및 지원되는 VM 크기를 자세히 알아보려면 여기를 클릭합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsPageTitle">
         <source xml:lang="en">Networking</source>
-        <target state="new">Networking</target>
+        <target state="translated">네트워킹</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsPageDescription">
         <source xml:lang="en">Configure network settings</source>
-        <target state="new">Configure network settings</target>
+        <target state="translated">네트워크 설정 구성</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsNewVirtualNetwork">
         <source xml:lang="en">New virtual network</source>
-        <target state="new">New virtual network</target>
+        <target state="translated">새 가상 네트워크</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VirtualNetworkDropdownLabel">
         <source xml:lang="en">Virtual Network</source>
-        <target state="new">Virtual Network</target>
+        <target state="translated">Virtual Network</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsNewSubnet">
         <source xml:lang="en">New subnet</source>
-        <target state="new">New subnet</target>
+        <target state="translated">새 서브넷</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SubnetDropdownLabel">
         <source xml:lang="en">Subnet</source>
-        <target state="new">Subnet</target>
+        <target state="translated">서브넷</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PublicIPDropdownLabel">
         <source xml:lang="en">Public IP</source>
-        <target state="new">Public IP</target>
+        <target state="translated">공용 IP</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsUseExistingPublicIp">
         <source xml:lang="en">New public ip</source>
-        <target state="new">New public ip</target>
+        <target state="translated">새 공용 IP</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmRDPAllowCheckboxLabel">
         <source xml:lang="en">Enable Remote Desktop (RDP) inbound port (3389)</source>
-        <target state="new">Enable Remote Desktop (RDP) inbound port (3389)</target>
+        <target state="translated">RDP(원격 데스크톱) 인바운드 포트(3389) 사용</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlServerSettingsPageTitle">
         <source xml:lang="en">SQL Servers settings</source>
-        <target state="new">SQL Servers settings</target>
+        <target state="translated">SQL Server 설정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlConnectivityTypeDropdownLabel">
         <source xml:lang="en">SQL connectivity</source>
-        <target state="new">SQL connectivity</target>
+        <target state="translated">SQL 연결</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlPortLabel">
         <source xml:lang="en">Port</source>
-        <target state="new">Port</target>
+        <target state="translated">포트</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlEnableSQLAuthenticationLabel">
         <source xml:lang="en">Enable SQL authentication</source>
-        <target state="new">Enable SQL authentication</target>
+        <target state="translated">SQL 인증 사용</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationUsernameLabel">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">사용자 이름</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationPasswordLabel">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">암호</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationConfirmPasswordLabel">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">암호 확인</target>
       </trans-unit>
     </body>
   </file>
@@ -790,39 +694,39 @@
     <body>
       <trans-unit id="deployCluster.SaveConfigFiles">
         <source xml:lang="en">Save config files</source>
-        <target state="new">Save config files</target>
+        <target state="translated">구성 파일 저장</target>
       </trans-unit>
       <trans-unit id="deployCluster.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Notebook으로 스크립트</target>
       </trans-unit>
       <trans-unit id="deployCluster.SelectConfigFileFolder">
         <source xml:lang="en">Save config files</source>
-        <target state="new">Save config files</target>
+        <target state="translated">구성 파일 저장</target>
       </trans-unit>
       <trans-unit id="deployCluster.SaveConfigFileSucceeded">
         <source xml:lang="en">Config files saved to {0}</source>
-        <target state="new">Config files saved to {0}</target>
+        <target state="translated">구성 파일이 {0}에 저장됨</target>
       </trans-unit>
       <trans-unit id="deployCluster.NewAKSWizardTitle">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on a new AKS cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on a new AKS cluster</target>
+        <target state="translated">새 AKS 클러스터에 SQL Server 2019 빅 데이터 클러스터 배포</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingAKSWizardTitle">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing AKS cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing AKS cluster</target>
+        <target state="translated">기존 AKS 클러스터에 SQL Server 2019 빅 데이터 클러스터 배포</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingKubeAdm">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing kubeadm cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing kubeadm cluster</target>
+        <target state="translated">기존 kubeadm 클러스터에 SQL Server 2019 빅 데이터 클러스터 배포</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingARO">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing Azure Red Hat OpenShift cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing Azure Red Hat OpenShift cluster</target>
+        <target state="translated">기존 Azure Red Hat OpenShift 클러스터에 SQL Server 2019 빅 데이터 클러스터 배포</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingOpenShift">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing OpenShift cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing OpenShift cluster</target>
+        <target state="translated">기존 OpenShift 클러스터에 SQL Server 2019 빅 데이터 클러스터 배포</target>
       </trans-unit>
     </body>
   </file>
@@ -830,79 +734,79 @@
     <body>
       <trans-unit id="deploymentDialog.ToolStatus.NotInstalled">
         <source xml:lang="en">Not Installed</source>
-        <target state="new">Not Installed</target>
+        <target state="translated">설치되지 않음</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Installed">
         <source xml:lang="en">Installed</source>
-        <target state="new">Installed</target>
+        <target state="translated">설치됨</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Installing">
         <source xml:lang="en">Installing…</source>
-        <target state="new">Installing…</target>
+        <target state="translated">설치하는 중...</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Error">
         <source xml:lang="en">Error</source>
-        <target state="new">Error</target>
+        <target state="translated">오류</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Failed">
         <source xml:lang="en">Failed</source>
-        <target state="new">Failed</target>
+        <target state="translated">실패</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformationalMessage.Brew">
         <source xml:lang="en">•	brew is needed for deployment of the tools and needs to be pre-installed before necessary tools can be deployed</source>
-        <target state="new">•	brew is needed for deployment of the tools and needs to be pre-installed before necessary tools can be deployed</target>
+        <target state="translated">•	brew는 도구를 배포하는 데 필요하며 필요한 도구를 배포하기 전에 미리 설치해야 합니다.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformationalMessage.Curl">
         <source xml:lang="en">•	curl is needed for installation and needs to be pre-installed before necessary tools can be deployed</source>
-        <target state="new">•	curl is needed for installation and needs to be pre-installed before necessary tools can be deployed</target>
+        <target state="translated">•	curl은 설치에 필요하며 필요한 도구를 배포하기 전에 미리 설치해야 합니다.</target>
       </trans-unit>
       <trans-unit id="toolBase.getPip3InstallationLocation.LocationNotFound">
         <source xml:lang="en">   Could not find 'Location' in the output:</source>
-        <target state="new">   Could not find 'Location' in the output:</target>
+        <target state="translated">   출력에서 'Location'을 찾을 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="toolBase.getPip3InstallationLocation.Output">
         <source xml:lang="en">   output:</source>
-        <target state="new">   output:</target>
+        <target state="translated">   출력:</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallError">
         <source xml:lang="en">Error installing tool '{0}' [ {1} ].{2}Error: {3}{2}See output channel '{4}' for more details</source>
-        <target state="new">Error installing tool '{0}' [ {1} ].{2}Error: {3}{2}See output channel '{4}' for more details</target>
+        <target state="translated">'{0}'[{1}] 도구를 설치하는 동안 오류가 발생했습니다. {2}오류: {3}{2}자세한 내용은 출력 채널 '{4}'을(를) 참조하세요.</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallErrorInformation">
         <source xml:lang="en">Error installing tool. See output channel '{0}' for more details</source>
-        <target state="new">Error installing tool. See output channel '{0}' for more details</target>
+        <target state="translated">도구를 설치하는 동안 오류가 발생했습니다. 자세한 내용은 출력 채널 '{0}'을(를) 참조하세요.</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallFailed">
         <source xml:lang="en">Installation commands completed but version of tool '{0}' could not be detected so our installation attempt has failed. Detection Error: {1}{2}Cleaning up previous installations would help.</source>
-        <target state="new">Installation commands completed but version of tool '{0}' could not be detected so our installation attempt has failed. Detection Error: {1}{2}Cleaning up previous installations would help.</target>
+        <target state="translated">설치 명령이 완료되었지만 '{0}' 도구의 버전을 검색할 수 없어서 설치하지 못했습니다. 검색 오류: {1}{2}이전 설치를 정리하는 것이 도움이 됩니다.</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallFailInformation">
         <source xml:lang="en">Failed to detect version post installation. See output channel '{0}' for more details</source>
-        <target state="new">Failed to detect version post installation. See output channel '{0}' for more details</target>
+        <target state="translated">설치 후 버전을 검색하지 못했습니다. 자세한 내용은 출력 채널 '{0}'을(를) 참조하세요.</target>
       </trans-unit>
       <trans-unit id="toolBase.ManualUninstallCommand">
         <source xml:lang="en"> A possibly way to uninstall is using this command:{0}   &gt;{1}</source>
-        <target state="new"> A possibly way to uninstall is using this command:{0}   &gt;{1}</target>
+        <target state="translated"> 제거할 수 있는 방법은 {0}   &gt;{1} 명령을 사용하는 것입니다.</target>
       </trans-unit>
       <trans-unit id="toolBase.SeeOutputChannel">
         <source xml:lang="en">{0}See output channel '{1}' for more details</source>
-        <target state="new">{0}See output channel '{1}' for more details</target>
+        <target state="translated">{0}자세한 내용은 출력 채널 '{1}' 참조</target>
       </trans-unit>
       <trans-unit id="toolBase.installCore.CannotInstallTool">
         <source xml:lang="en">Cannot install tool:{0}::{1} as installation commands are unknown for your OS distribution, Please install {0} manually before proceeding</source>
-        <target state="new">Cannot install tool:{0}::{1} as installation commands are unknown for your OS distribution, Please install {0} manually before proceeding</target>
+        <target state="translated">OS 배포를 위한 설치 명령을 알 수 없으므로 {0}::{1} 도구를 설치할 수 없습니다. 계속하기 전에 {0}을(를) 수동으로 설치하세요.</target>
       </trans-unit>
       <trans-unit id="toolBase.addInstallationSearchPathsToSystemPath.SearchPaths">
         <source xml:lang="en">Search Paths for tool '{0}': {1}</source>
-        <target state="new">Search Paths for tool '{0}': {1}</target>
+        <target state="translated">'{0}' 도구의 검색 경로: {1}</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
-        <target state="new">Error retrieving version information. See output channel '{0}' for more details</target>
+        <target state="translated">버전 정보를 검색하는 동안 오류가 발생했습니다. 자세한 내용은 출력 채널 '{0}'을(를) 참조하세요.</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
-        <target state="new">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </target>
+        <target state="translated">버전 정보를 검색하는 동안 오류가 발생했습니다. {0}잘못된 출력이 수신되었습니다. 버전 명령 출력 '{1}'을(를) 가져옵니다. </target>
       </trans-unit>
     </body>
   </file>
@@ -910,87 +814,87 @@
     <body>
       <trans-unit id="deployAzureSQLDB.NewSQLDBTitle">
         <source xml:lang="en">Deploy Azure SQL DB</source>
-        <target state="new">Deploy Azure SQL DB</target>
+        <target state="translated">Azure SQL DB 배포</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Notebook으로 스크립트</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">빨간색 별표가 표시된 필수 필드를 입력하세요.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSettingsPageTitle">
         <source xml:lang="en">Azure SQL Database - Azure account settings</source>
-        <target state="new">Azure SQL Database - Azure account settings</target>
+        <target state="translated">Azure SQL Database - Azure 계정 설정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSettingsSummaryPageTitle">
         <source xml:lang="en">Azure account settings</source>
-        <target state="new">Azure account settings</target>
+        <target state="translated">Azure 계정 설정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureAccountDropdownLabel">
         <source xml:lang="en">Azure account</source>
-        <target state="new">Azure account</target>
+        <target state="translated">Azure 계정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSubscriptionDropdownLabel">
         <source xml:lang="en">Subscription</source>
-        <target state="new">Subscription</target>
+        <target state="translated">구독</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureDatabaseServersDropdownLabel">
         <source xml:lang="en">Server</source>
-        <target state="new">Server</target>
+        <target state="translated">서버</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.ResourceGroup">
         <source xml:lang="en">Resource group</source>
-        <target state="new">Resource group</target>
+        <target state="translated">리소스 그룹</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DatabaseSettingsPageTitle">
         <source xml:lang="en">Database settings</source>
-        <target state="new">Database settings</target>
+        <target state="translated">데이터베이스 설정</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallRuleNameLabel">
         <source xml:lang="en">Firewall rule name</source>
-        <target state="new">Firewall rule name</target>
+        <target state="translated">방화벽 규칙 이름</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DatabaseNameLabel">
         <source xml:lang="en">SQL database name</source>
-        <target state="new">SQL database name</target>
+        <target state="translated">SQL 데이터베이스 이름</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.CollationNameLabel">
         <source xml:lang="en">Database collation</source>
-        <target state="new">Database collation</target>
+        <target state="translated">데이터베이스 데이터 정렬</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.CollationNameSummaryLabel">
         <source xml:lang="en">Collation for database</source>
-        <target state="new">Collation for database</target>
+        <target state="translated">데이터베이스 데이터 정렬</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.IpAddressInfoLabel">
         <source xml:lang="en">Enter IP addresses in IPv4 format.</source>
-        <target state="new">Enter IP addresses in IPv4 format.</target>
+        <target state="translated">IPv4 형식으로 IP 주소를 입력합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.StartIpAddressLabel">
         <source xml:lang="en">Min IP address in firewall IP range</source>
-        <target state="new">Min IP address in firewall IP range</target>
+        <target state="translated">방화벽 IP 범위의 최소 IP 주소</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.EndIpAddressLabel">
         <source xml:lang="en">Max IP address in firewall IP range</source>
-        <target state="new">Max IP address in firewall IP range</target>
+        <target state="translated">방화벽 IP 범위의 최대 IP 주소</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.StartIpAddressShortLabel">
         <source xml:lang="en">Min IP address</source>
-        <target state="new">Min IP address</target>
+        <target state="translated">최소 IP 주소</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.EndIpAddressShortLabel">
         <source xml:lang="en">Max IP address</source>
-        <target state="new">Max IP address</target>
+        <target state="translated">최대 IP 주소</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallRuleDescription">
         <source xml:lang="en">Create a firewall rule for your local client IP in order to connect to your database through Azure Data Studio after creation is completed.</source>
-        <target state="new">Create a firewall rule for your local client IP in order to connect to your database through Azure Data Studio after creation is completed.</target>
+        <target state="translated">만들기가 완료된 후 Azure Data Studio를 통해 데이터베이스에 연결하려면 로컬 클라이언트 IP의 방화벽 규칙을 만듭니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallToggleLabel">
         <source xml:lang="en">Create a firewall rule</source>
-        <target state="new">Create a firewall rule</target>
+        <target state="translated">방화벽 규칙 만들기</target>
       </trans-unit>
     </body>
   </file>
@@ -998,7 +902,7 @@
     <body>
       <trans-unit id="resourceDeployment.KubeCtlDescription">
         <source xml:lang="en">Runs commands against Kubernetes clusters</source>
-        <target state="new">Runs commands against Kubernetes clusters</target>
+        <target state="translated">Kubernetes 클러스터에 대해 명령 실행</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.KubeCtlDisplayName">
         <source xml:lang="en">kubectl</source>
@@ -1006,67 +910,67 @@
       </trans-unit>
       <trans-unit id="resourceDeployment.invalidKubectlVersionOutput">
         <source xml:lang="en">Unable to parse the kubectl version command output: "{0}"</source>
-        <target state="new">Unable to parse the kubectl version command output: "{0}"</target>
+        <target state="translated">Kubectl 버전 명령 출력을 구문 분석할 수 없음: "{0}"</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.UpdatingBrewRepository">
         <source xml:lang="en">updating your brew repository for kubectl installation …</source>
-        <target state="new">updating your brew repository for kubectl installation …</target>
+        <target state="translated">kubectl 설치를 위해 brew 리포지토리를 업데이트하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.InstallingKubeCtl">
         <source xml:lang="en">installing kubectl …</source>
-        <target state="new">installing kubectl …</target>
+        <target state="translated">kubectl을 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AptGetUpdate">
         <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
+        <target state="translated">리포지토리 정보를 업데이트하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AptGetPackages">
         <source xml:lang="en">getting packages needed for kubectl installation …</source>
-        <target state="new">getting packages needed for kubectl installation …</target>
+        <target state="translated">kubectl 설치에 필요한 패키지를 가져오는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for kubectl …</source>
-        <target state="new">downloading and installing the signing key for kubectl …</target>
+        <target state="translated">kubectl의 서명 키를 다운로드하고 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AddingKubectlRepositoryInformation">
         <source xml:lang="en">adding the kubectl repository information …</source>
-        <target state="new">adding the kubectl repository information …</target>
+        <target state="translated">kubectl 리포지토리 정보를 추가하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.InstallingKubectl">
         <source xml:lang="en">installing kubectl …</source>
-        <target state="new">installing kubectl …</target>
+        <target state="translated">kubectl을 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DeletePreviousDownloadedKubectl.exe">
         <source xml:lang="en">deleting previously downloaded kubectl.exe if one exists …</source>
-        <target state="new">deleting previously downloaded kubectl.exe if one exists …</target>
+        <target state="translated">이전에 다운로드한 kubectl.exe 삭제 중(있는 경우)...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadingAndInstallingKubectl">
         <source xml:lang="en">downloading and installing the latest kubectl.exe …</source>
-        <target state="new">downloading and installing the latest kubectl.exe …</target>
+        <target state="translated">최신 kubectl.exe를 다운로드하고 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DeletePreviousDownloadedKubectl">
         <source xml:lang="en">deleting previously downloaded kubectl if one exists …</source>
-        <target state="new">deleting previously downloaded kubectl if one exists …</target>
+        <target state="translated">이전에 다운로드한 kubectl 삭제 중(있는 경우)...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadingKubectl">
         <source xml:lang="en">downloading the latest kubectl release …</source>
-        <target state="new">downloading the latest kubectl release …</target>
+        <target state="translated">최신 kubectl 릴리스를 다운로드하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.MakingExecutable">
         <source xml:lang="en">making kubectl executable …</source>
-        <target state="new">making kubectl executable …</target>
+        <target state="translated">kubectl 실행 파일을 만드는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.CleaningUpOldBackups">
         <source xml:lang="en">cleaning up any previously backed up version in the install location if they exist …</source>
-        <target state="new">cleaning up any previously backed up version in the install location if they exist …</target>
+        <target state="translated">설치 위치에서 이전에 백업된 버전을 정리하는 중(있는 경우)...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.BackupCurrentBinary">
         <source xml:lang="en">backing up any existing kubectl in the install location …</source>
-        <target state="new">backing up any existing kubectl in the install location …</target>
+        <target state="translated">설치 위치의 기존 kubectl을 백업하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.MoveToSystemPath">
         <source xml:lang="en">moving kubectl into the install location in the PATH …</source>
-        <target state="new">moving kubectl into the install location in the PATH …</target>
+        <target state="translated">PATH에서 설치 위치로 kubectl을 이동하는 중...</target>
       </trans-unit>
     </body>
   </file>
@@ -1074,7 +978,7 @@
     <body>
       <trans-unit id="wizardPage.ValidationError">
         <source xml:lang="en">There are some errors on this page, click 'Show Details' to view the errors.</source>
-        <target state="new">There are some errors on this page, click 'Show Details' to view the errors.</target>
+        <target state="translated">이 페이지에 오류가 있습니다. 오류를 보려면 '세부 정보 표시'를 클릭합니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -1082,24 +986,20 @@
     <body>
       <trans-unit id="deploymentDialog.OpenNotebook">
         <source xml:lang="en">Open Notebook</source>
-        <target state="new">Open Notebook</target>
+        <target state="translated">Notebook 열기</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.OkButtonText">
         <source xml:lang="en">OK</source>
-        <target state="new">OK</target>
+        <target state="translated">확인</target>
       </trans-unit>
       <trans-unit id="notebookType">
         <source xml:lang="en">Notebook type</source>
-        <target state="new">Notebook type</target>
+        <target state="translated">Notebook 유형</target>
       </trans-unit>
     </body>
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">{0} 확장을 로드하지 못했습니다. package.json의 리소스 종류 정의에서 오류가 감지되었습니다. 자세한 내용은 디버그 콘솔을 참조하세요.</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">리소스 종류 {0}이(가) 정의되지 않았습니다.</target>
@@ -1118,31 +1018,31 @@
     <body>
       <trans-unit id="resourceDeployment.outputChannel">
         <source xml:lang="en">Deployments</source>
-        <target state="new">Deployments</target>
+        <target state="translated">배포</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.ErroredOut">
         <source xml:lang="en">	&gt;&gt;&gt; {0}   … errored out: {1}</source>
-        <target state="new">	&gt;&gt;&gt; {0}   … errored out: {1}</target>
+        <target state="translated">	&gt;&gt;&gt; {0}    ... 오류가 발생했습니다. {1}</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.IgnoringError">
         <source xml:lang="en">	&gt;&gt;&gt; Ignoring error in execution and continuing tool deployment</source>
-        <target state="new">	&gt;&gt;&gt; Ignoring error in execution and continuing tool deployment</target>
+        <target state="translated">	&gt;&gt;&gt; 실행 시 오류 무시 및 도구 배포 계속</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.stdout">
         <source xml:lang="en">    stdout: </source>
-        <target state="new">    stdout: </target>
+        <target state="translated">    stdout: </target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.stderr">
         <source xml:lang="en">    stderr: </source>
-        <target state="new">    stderr: </target>
+        <target state="translated">    stderr: </target>
       </trans-unit>
       <trans-unit id="platformService.RunStreamedCommand.ExitedWithCode">
         <source xml:lang="en">    &gt;&gt;&gt; {0}    … exited with code: {1}</source>
-        <target state="new">    &gt;&gt;&gt; {0}    … exited with code: {1}</target>
+        <target state="translated">    &gt;&gt;&gt; {0}    … 종료됨(코드: {1})</target>
       </trans-unit>
       <trans-unit id="platformService.RunStreamedCommand.ExitedWithSignal">
         <source xml:lang="en">    &gt;&gt;&gt; {0}   … exited with signal: {1}</source>
-        <target state="new">    &gt;&gt;&gt; {0}   … exited with signal: {1}</target>
+        <target state="translated">    &gt;&gt;&gt; {0}    … 종료됨(신호: {1})</target>
       </trans-unit>
     </body>
   </file>
@@ -1158,31 +1058,31 @@
     <body>
       <trans-unit id="deployCluster.serviceScaleTableTitle">
         <source xml:lang="en">Service scale settings (Instances)</source>
-        <target state="new">Service scale settings (Instances)</target>
+        <target state="translated">서비스 스케일링 설정(인스턴스)</target>
       </trans-unit>
       <trans-unit id="deployCluster.storageTableTitle">
         <source xml:lang="en">Service storage settings (GB per Instance)</source>
-        <target state="new">Service storage settings (GB per Instance)</target>
+        <target state="translated">서비스 스토리지 설정(인스턴스당 GB)</target>
       </trans-unit>
       <trans-unit id="deployCluster.featureTableTitle">
         <source xml:lang="en">Features</source>
-        <target state="new">Features</target>
+        <target state="translated">기능</target>
       </trans-unit>
       <trans-unit id="deployCluster.yesText">
         <source xml:lang="en">Yes</source>
-        <target state="new">Yes</target>
+        <target state="translated">예</target>
       </trans-unit>
       <trans-unit id="deployCluster.noText">
         <source xml:lang="en">No</source>
-        <target state="new">No</target>
+        <target state="translated">아니요</target>
       </trans-unit>
       <trans-unit id="deployCluster.summaryPageTitle">
         <source xml:lang="en">Deployment configuration profile</source>
-        <target state="new">Deployment configuration profile</target>
+        <target state="translated">배포 구성 프로필</target>
       </trans-unit>
       <trans-unit id="deployCluster.summaryPageDescription">
         <source xml:lang="en">Select the target configuration profile</source>
-        <target state="new">Select the target configuration profile</target>
+        <target state="translated">대상 구성 프로필 선택</target>
       </trans-unit>
       <trans-unit id="deployCluster.ProfileHintText">
         <source xml:lang="en">Note: The settings of the deployment profile can be customized in later steps.</source>
@@ -1190,15 +1090,15 @@
       </trans-unit>
       <trans-unit id="deployCluster.loadingProfiles">
         <source xml:lang="en">Loading profiles</source>
-        <target state="new">Loading profiles</target>
+        <target state="translated">프로필 로드</target>
       </trans-unit>
       <trans-unit id="deployCluster.loadingProfilesCompleted">
         <source xml:lang="en">Loading profiles completed</source>
-        <target state="new">Loading profiles completed</target>
+        <target state="translated">프로필 로드 완료</target>
       </trans-unit>
       <trans-unit id="deployCluster.profileRadioGroupLabel">
         <source xml:lang="en">Deployment configuration profile</source>
-        <target state="new">Deployment configuration profile</target>
+        <target state="translated">배포 구성 프로필</target>
       </trans-unit>
       <trans-unit id="deployCluster.loadProfileFailed">
         <source xml:lang="en">Failed to load the deployment profiles: {0}</source>
@@ -1222,19 +1122,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">서비스</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataStorageType">
         <source xml:lang="en">Data</source>
-        <target state="new">Data</target>
+        <target state="translated">데이터</target>
       </trans-unit>
       <trans-unit id="deployCluster.logsStorageType">
         <source xml:lang="en">Logs</source>
-        <target state="new">Logs</target>
+        <target state="translated">로그</target>
       </trans-unit>
       <trans-unit id="deployCluster.StorageType">
         <source xml:lang="en">Storage type</source>
-        <target state="new">Storage type</target>
+        <target state="translated">스토리지 유형</target>
       </trans-unit>
       <trans-unit id="deployCluster.basicAuthentication">
         <source xml:lang="en">Basic authentication</source>
@@ -1250,7 +1150,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.featureText">
         <source xml:lang="en">Feature</source>
-        <target state="new">Feature</target>
+        <target state="translated">기능</target>
       </trans-unit>
       <trans-unit id="deployCluster.ProfileNotSelectedError">
         <source xml:lang="en">Please select a deployment profile.</source>
@@ -1262,7 +1162,7 @@
     <body>
       <trans-unit id="deployCluster.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">빨간색 별표가 표시된 필수 필드를 입력하세요.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AzureSettingsPageTitle">
         <source xml:lang="en">Azure settings</source>
@@ -1322,7 +1222,7 @@
     <body>
       <trans-unit id="deployCluster.ClusterNameDescription">
         <source xml:lang="en">The cluster name must consist only of alphanumeric lowercase characters or '-' and must start and end with an alphanumeric character.</source>
-        <target state="new">The cluster name must consist only of alphanumeric lowercase characters or '-' and must start and end with an alphanumeric character.</target>
+        <target state="translated">클러스터 이름은 영숫자 소문자 또는 '-'로만 구성되어야 하며 영숫자 문자로 시작하고 끝나야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployCluster.ClusterSettingsPageTitle">
         <source xml:lang="en">Cluster settings</source>
@@ -1434,7 +1334,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.RealmDescription">
         <source xml:lang="en">If not provided, the domain DNS name will be used as the default value.</source>
-        <target state="new">If not provided, the domain DNS name will be used as the default value.</target>
+        <target state="translated">제공하지 않으면 도메인 DNS 이름이 기본값으로 사용됩니다.</target>
       </trans-unit>
       <trans-unit id="deployCluster.ClusterAdmins">
         <source xml:lang="en">Cluster admin group</source>
@@ -1470,7 +1370,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.AppOwners">
         <source xml:lang="en">App owners</source>
-        <target state="new">App owners</target>
+        <target state="translated">앱 소유자</target>
       </trans-unit>
       <trans-unit id="deployCluster.AppOwnersPlaceHolder">
         <source xml:lang="en">Use comma to separate the values.</source>
@@ -1494,19 +1394,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.Subdomain">
         <source xml:lang="en">Subdomain</source>
-        <target state="new">Subdomain</target>
+        <target state="translated">하위 도메인</target>
       </trans-unit>
       <trans-unit id="deployCluster.SubdomainDescription">
         <source xml:lang="en">A unique DNS subdomain to use for this SQL Server Big Data Cluster. If not provided, the cluster name will be used as the default value.</source>
-        <target state="new">A unique DNS subdomain to use for this SQL Server Big Data Cluster. If not provided, the cluster name will be used as the default value.</target>
+        <target state="translated">이 SQL Server 빅 데이터 클러스터에 사용할 고유한 DNS 하위 도메인입니다. 제공되지 않으면 클러스터 이름이 기본값으로 사용됩니다.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefix">
         <source xml:lang="en">Account prefix</source>
-        <target state="new">Account prefix</target>
+        <target state="translated">계정 접두사</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefixDescription">
         <source xml:lang="en">A unique prefix for AD accounts SQL Server Big Data Cluster will generate. If not provided, the subdomain name will be used as the default value. If a subdomain is not provided, the cluster name will be used as the default value.</source>
-        <target state="new">A unique prefix for AD accounts SQL Server Big Data Cluster will generate. If not provided, the subdomain name will be used as the default value. If a subdomain is not provided, the cluster name will be used as the default value.</target>
+        <target state="translated">AD 계정 SQL Server 빅 데이터 클러스터의 고유한 접두사가 생성됩니다. 제공되지 않으면 하위 도메인 이름이 기본값으로 사용됩니다. 하위 도메인이 제공되지 않으면 클러스터 이름이 기본값으로 사용됩니다.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AdminPasswordField">
         <source xml:lang="en">Password</source>
@@ -1646,19 +1546,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.controllerDataStorageClass">
         <source xml:lang="en">Controller's data storage class</source>
-        <target state="new">Controller's data storage class</target>
+        <target state="translated">컨트롤러의 데이터 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerDataStorageClaimSize">
         <source xml:lang="en">Controller's data storage claim size</source>
-        <target state="new">Controller's data storage claim size</target>
+        <target state="translated">컨트롤러의 데이터 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerLogsStorageClass">
         <source xml:lang="en">Controller's logs storage class</source>
-        <target state="new">Controller's logs storage class</target>
+        <target state="translated">컨트롤러의 로그 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerLogsStorageClaimSize">
         <source xml:lang="en">Controller's logs storage claim size</source>
-        <target state="new">Controller's logs storage claim size</target>
+        <target state="translated">컨트롤러의 로그 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.StoragePool">
         <source xml:lang="en">Storage pool (HDFS)</source>
@@ -1666,19 +1566,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolDataStorageClass">
         <source xml:lang="en">Storage pool's data storage class</source>
-        <target state="new">Storage pool's data storage class</target>
+        <target state="translated">스토리지 풀의 데이터 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolDataStorageClaimSize">
         <source xml:lang="en">Storage pool's data storage claim size</source>
-        <target state="new">Storage pool's data storage claim size</target>
+        <target state="translated">스토리지 풀의 데이터 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolLogsStorageClass">
         <source xml:lang="en">Storage pool's logs storage class</source>
-        <target state="new">Storage pool's logs storage class</target>
+        <target state="translated">스토리지 풀의 로그 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolLogsStorageClaimSize">
         <source xml:lang="en">Storage pool's logs storage claim size</source>
-        <target state="new">Storage pool's logs storage claim size</target>
+        <target state="translated">스토리지 풀의 로그 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataPool">
         <source xml:lang="en">Data pool</source>
@@ -1686,39 +1586,39 @@
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolDataStorageClass">
         <source xml:lang="en">Data pool's data storage class</source>
-        <target state="new">Data pool's data storage class</target>
+        <target state="translated">데이터 풀의 데이터 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolDataStorageClaimSize">
         <source xml:lang="en">Data pool's data storage claim size</source>
-        <target state="new">Data pool's data storage claim size</target>
+        <target state="translated">데이터 풀의 데이터 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolLogsStorageClass">
         <source xml:lang="en">Data pool's logs storage class</source>
-        <target state="new">Data pool's logs storage class</target>
+        <target state="translated">데이터 풀의 로그 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolLogsStorageClaimSize">
         <source xml:lang="en">Data pool's logs storage claim size</source>
-        <target state="new">Data pool's logs storage claim size</target>
+        <target state="translated">데이터 풀의 로그 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterDataStorageClass">
         <source xml:lang="en">SQL Server master's data storage class</source>
-        <target state="new">SQL Server master's data storage class</target>
+        <target state="translated">SQL Server 마스터의 데이터 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterDataStorageClaimSize">
         <source xml:lang="en">SQL Server master's data storage claim size</source>
-        <target state="new">SQL Server master's data storage claim size</target>
+        <target state="translated">SQL Server 마스터의 데이터 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterLogsStorageClass">
         <source xml:lang="en">SQL Server master's logs storage class</source>
-        <target state="new">SQL Server master's logs storage class</target>
+        <target state="translated">SQL Server 마스터의 로그 스토리지 클래스</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterLogsStorageClaimSize">
         <source xml:lang="en">SQL Server master's logs storage claim size</source>
-        <target state="new">SQL Server master's logs storage claim size</target>
+        <target state="translated">SQL Server 마스터의 로그 스토리지 클레임 크기</target>
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service name</source>
-        <target state="new">Service name</target>
+        <target state="translated">서비스 이름</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataStorageClassName">
         <source xml:lang="en">Storage class for data</source>
@@ -1738,7 +1638,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.StorageSettings">
         <source xml:lang="en">Storage settings</source>
-        <target state="new">Storage settings</target>
+        <target state="translated">스토리지 설정</target>
       </trans-unit>
       <trans-unit id="deployCluster.StorageSectionTitle">
         <source xml:lang="en">Storage settings</source>
@@ -1822,7 +1722,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.AppOwners">
         <source xml:lang="en">App owners</source>
-        <target state="new">App owners</target>
+        <target state="translated">앱 소유자</target>
       </trans-unit>
       <trans-unit id="deployCluster.AppReaders">
         <source xml:lang="en">App readers</source>
@@ -1830,11 +1730,11 @@
       </trans-unit>
       <trans-unit id="deployCluster.Subdomain">
         <source xml:lang="en">Subdomain</source>
-        <target state="new">Subdomain</target>
+        <target state="translated">하위 도메인</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefix">
         <source xml:lang="en">Account prefix</source>
-        <target state="new">Account prefix</target>
+        <target state="translated">계정 접두사</target>
       </trans-unit>
       <trans-unit id="deployCluster.DomainServiceAccountUserName">
         <source xml:lang="en">Service account username</source>
@@ -1902,7 +1802,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">서비스</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataStorageClassName">
         <source xml:lang="en">Storage class for data</source>
@@ -2010,11 +1910,11 @@
     <body>
       <trans-unit id="sqlVMDeploymentWizard.PasswordLengthError">
         <source xml:lang="en">Password must be between 12 and 123 characters long.</source>
-        <target state="new">Password must be between 12 and 123 characters long.</target>
+        <target state="translated">암호는 12~123자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="sqlVMDeploymentWizard.PasswordSpecialCharRequirementError">
         <source xml:lang="en">Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character.</source>
-        <target state="new">Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character.</target>
+        <target state="translated">암호는 소문자 1자, 대문자 1자, 숫자 1자 및 특수 문자 1자 중 3가지를 포함해야 합니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -2022,47 +1922,47 @@
     <body>
       <trans-unit id="deployAzureSQLVM.VnameLengthError">
         <source xml:lang="en">Virtual machine name must be between 1 and 15 characters long.</source>
-        <target state="new">Virtual machine name must be between 1 and 15 characters long.</target>
+        <target state="translated">가상 머신 이름은 1~15자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameOnlyNumericNameError">
         <source xml:lang="en">Virtual machine name cannot contain only numbers.</source>
-        <target state="new">Virtual machine name cannot contain only numbers.</target>
+        <target state="translated">가상 머신 이름을 숫자로만 설정할 수는 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNamePrefixSuffixError">
         <source xml:lang="en">Virtual machine name Can't start with underscore. Can't end with period or hyphen</source>
-        <target state="new">Virtual machine name Can't start with underscore. Can't end with period or hyphen</target>
+        <target state="translated">가상 머신 이름은 밑줄로 시작할 수 없습니다. 마침표 또는 하이픈으로 끝날 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameSpecialCharError">
         <source xml:lang="en">Virtual machine name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Virtual machine name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">가상 머신 이름에는 특수 문자 \/""[]:|&lt;&gt;+=;,?*@&amp;,가 포함될 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameExistsError">
         <source xml:lang="en">Virtual machine name must be unique in the current resource group.</source>
-        <target state="new">Virtual machine name must be unique in the current resource group.</target>
+        <target state="translated">가상 머신 이름은 현재 리소스 그룹에서 고유해야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameLengthError">
         <source xml:lang="en">Username must be between 1 and 20 characters long.</source>
-        <target state="new">Username must be between 1 and 20 characters long.</target>
+        <target state="translated">사용자 이름은 1~20자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameSuffixError">
         <source xml:lang="en">Username cannot end with period</source>
-        <target state="new">Username cannot end with period</target>
+        <target state="translated">사용자 이름은 마침표로 끝날 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameSpecialCharError">
         <source xml:lang="en">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp; .</source>
-        <target state="new">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp; .</target>
+        <target state="translated">사용자 이름에는 특수 문자 \/""[]:|&lt;&gt;+=;,?*@&amp;를 사용할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameReservedWordsError">
         <source xml:lang="en">Username must not include reserved words.</source>
-        <target state="new">Username must not include reserved words.</target>
+        <target state="translated">사용자 이름은 예약어를 포함하지 않아야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMConfirmPasswordError">
         <source xml:lang="en">Password and confirm password must match.</source>
-        <target state="new">Password and confirm password must match.</target>
+        <target state="translated">암호와 확인 암호가 일치해야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.vmDropdownSizeError">
         <source xml:lang="en">Select a valid virtual machine size.</source>
-        <target state="new">Select a valid virtual machine size.</target>
+        <target state="translated">유효한 가상 머신 크기를 선택합니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -2070,39 +1970,39 @@
     <body>
       <trans-unit id="deployAzureSQLVM.NewVnetPlaceholder">
         <source xml:lang="en">Enter name for new virtual network</source>
-        <target state="new">Enter name for new virtual network</target>
+        <target state="translated">새 가상 네트워크의 이름 입력</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewSubnetPlaceholder">
         <source xml:lang="en">Enter name for new subnet</source>
-        <target state="new">Enter name for new subnet</target>
+        <target state="translated">새 서브넷의 이름 입력</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewPipPlaceholder">
         <source xml:lang="en">Enter name for new public IP</source>
-        <target state="new">Enter name for new public IP</target>
+        <target state="translated">새 공용 IP의 이름 입력</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VnetNameLengthError">
         <source xml:lang="en">Virtual Network name must be between 2 and 64 characters long</source>
-        <target state="new">Virtual Network name must be between 2 and 64 characters long</target>
+        <target state="translated">Virtual Network 이름은 2~64자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewVnetError">
         <source xml:lang="en">Create a new virtual network</source>
-        <target state="new">Create a new virtual network</target>
+        <target state="translated">새 가상 네트워크 만들기</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SubnetNameLengthError">
         <source xml:lang="en">Subnet name must be between 1 and 80 characters long</source>
-        <target state="new">Subnet name must be between 1 and 80 characters long</target>
+        <target state="translated">서브넷 이름은 1~80자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewSubnetError">
         <source xml:lang="en">Create a new sub network</source>
-        <target state="new">Create a new sub network</target>
+        <target state="translated">새 하위 네트워크 만들기</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PipNameError">
         <source xml:lang="en">Public IP name must be between 1 and 80 characters long</source>
-        <target state="new">Public IP name must be between 1 and 80 characters long</target>
+        <target state="translated">공용 IP 이름은 1~80자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewPipError">
         <source xml:lang="en">Create a new new public Ip</source>
-        <target state="new">Create a new new public Ip</target>
+        <target state="translated">새 공용 IP 만들기</target>
       </trans-unit>
     </body>
   </file>
@@ -2110,27 +2010,27 @@
     <body>
       <trans-unit id="deployAzureSQLVM.PrivateConnectivityDropdownOptionDefault">
         <source xml:lang="en">Private (within Virtual Network)</source>
-        <target state="new">Private (within Virtual Network)</target>
+        <target state="translated">프라이빗(가상 네트워크 내)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.LocalConnectivityDropdownOption">
         <source xml:lang="en">Local (inside VM only)</source>
-        <target state="new">Local (inside VM only)</target>
+        <target state="translated">로컬(VM 내부 전용)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PublicConnectivityDropdownOption">
         <source xml:lang="en">Public (Internet)</source>
-        <target state="new">Public (Internet)</target>
+        <target state="translated">퍼블릭(인터넷)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlUsernameLengthError">
         <source xml:lang="en">Username must be between 2 and 128 characters long.</source>
-        <target state="new">Username must be between 2 and 128 characters long.</target>
+        <target state="translated">암호는 2~128자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlUsernameSpecialCharError">
         <source xml:lang="en">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?* .</source>
-        <target state="new">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?* .</target>
+        <target state="translated">사용자 이름에는 특수 문자(\/""[]:|&lt;&gt;+=;,?*)를 사용할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlConfirmPasswordError">
         <source xml:lang="en">Password and confirm password must match.</source>
-        <target state="new">Password and confirm password must match.</target>
+        <target state="translated">암호와 확인 암호가 일치해야 합니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -2138,7 +2038,7 @@
     <body>
       <trans-unit id="notebookWizard.autoSummaryPageTitle">
         <source xml:lang="en">Review your configuration</source>
-        <target state="new">Review your configuration</target>
+        <target state="translated">구성 검토</target>
       </trans-unit>
     </body>
   </file>
@@ -2146,55 +2046,55 @@
     <body>
       <trans-unit id="deployAzureSQLDB.DBMinIpInvalidError">
         <source xml:lang="en">Min Ip address is invalid</source>
-        <target state="new">Min Ip address is invalid</target>
+        <target state="translated">최소 IP 주소가 잘못되었습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBMaxIpInvalidError">
         <source xml:lang="en">Max Ip address is invalid</source>
-        <target state="new">Max Ip address is invalid</target>
+        <target state="translated">최대 IP 주소가 잘못되었습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallOnlyNumericNameError">
         <source xml:lang="en">Firewall name cannot contain only numbers.</source>
-        <target state="new">Firewall name cannot contain only numbers.</target>
+        <target state="translated">방화벽 이름에 숫자만 사용할 수는 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallLengthError">
         <source xml:lang="en">Firewall name must be between 1 and 100 characters long.</source>
-        <target state="new">Firewall name must be between 1 and 100 characters long.</target>
+        <target state="translated">방화벽 이름은 1~100자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallSpecialCharError">
         <source xml:lang="en">Firewall name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Firewall name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">방화벽 이름에는 특수 문자 \/""[]:|&lt;&gt;+=;,?*@&amp;,를 사용할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallUpperCaseError">
         <source xml:lang="en">Upper case letters are not allowed for firewall name</source>
-        <target state="new">Upper case letters are not allowed for firewall name</target>
+        <target state="translated">방화벽 이름에는 대문자를 사용할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameOnlyNumericNameError">
         <source xml:lang="en">Database name cannot contain only numbers.</source>
-        <target state="new">Database name cannot contain only numbers.</target>
+        <target state="translated">데이터베이스 이름은 숫자만 포함할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameLengthError">
         <source xml:lang="en">Database name must be between 1 and 100 characters long.</source>
-        <target state="new">Database name must be between 1 and 100 characters long.</target>
+        <target state="translated">데이터베이스 이름은 1~100자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameSpecialCharError">
         <source xml:lang="en">Database name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Database name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">데이터베이스 이름에는 특수 문자 \/""[]:|&lt;&gt;+=;,?*@&amp;,를 사용할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameExistsError">
         <source xml:lang="en">Database name must be unique in the current server.</source>
-        <target state="new">Database name must be unique in the current server.</target>
+        <target state="translated">데이터베이스 이름은 현재 서버에서 고유해야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationOnlyNumericNameError">
         <source xml:lang="en">Collation name cannot contain only numbers.</source>
-        <target state="new">Collation name cannot contain only numbers.</target>
+        <target state="translated">데이터 정렬 이름은 숫자만 포함할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationLengthError">
         <source xml:lang="en">Collation name must be between 1 and 100 characters long.</source>
-        <target state="new">Collation name must be between 1 and 100 characters long.</target>
+        <target state="translated">데이터 정렬 이름은 1~100자여야 합니다.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationSpecialCharError">
         <source xml:lang="en">Collation name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Collation name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">데이터 정렬 이름에는 특수 문자 \/""[]:|&lt;&gt;+=;,?*@&amp;,를 사용할 수 없습니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -2202,17 +2102,17 @@
     <body>
       <trans-unit id="deployAzureSQLDB.azureSignInError">
         <source xml:lang="en">Sign in to an Azure account first</source>
-        <target state="new">Sign in to an Azure account first</target>
+        <target state="translated">먼저 Azure 계정에 로그인</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.NoServerLabel">
         <source xml:lang="en">No servers found</source>
-        <target state="new">No servers found</target>
+        <target state="translated">서버를 찾을 수 없음</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.NoServerError">
         <source xml:lang="en">No servers found in current subscription.
 Select a different subscription containing at least one server</source>
-        <target state="new">No servers found in current subscription.
-Select a different subscription containing at least one server</target>
+        <target state="translated">현재 구독에서 서버를 찾을 수 없습니다.
+하나 이상의 서버를 포함하는 다른 구독을 선택합니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -2220,59 +2120,59 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="notebookWizard.toolsAndEulaPageTitle">
         <source xml:lang="en">Deployment pre-requisites</source>
-        <target state="new">Deployment pre-requisites</target>
-      </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="new">To proceed, you must accept the terms of the End User License Agreement(EULA)</target>
+        <target state="translated">배포 필수 구성 요소</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
-        <target state="new">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</target>
+        <target state="translated">일부 도구가 아직 검색되지 않았습니다. 해당 도구가 설치되고, 실행 중이며, 검색 가능한지 확인하세요.</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">계속 진행하려면 EULA(최종 사용자 사용권 계약) 약관에 동의해야 합니다.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
-        <target state="new">Loading required tools information completed</target>
+        <target state="translated">필요한 도구 정보 로드 완료</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredTools">
         <source xml:lang="en">Loading required tools information</source>
-        <target state="new">Loading required tools information</target>
+        <target state="translated">필요한 도구 정보 로드</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AgreementTitle">
         <source xml:lang="en">Accept terms of use</source>
-        <target state="new">Accept terms of use</target>
+        <target state="translated">사용 약관에 동의</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolDoesNotMeetVersionRequirement">
         <source xml:lang="en">'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.</source>
-        <target state="new">'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.</target>
+        <target state="translated">'{0}'[{1}]이(가) 최소 버전 요구 사항을 충족하지 않습니다. 해당 도구를 제거하고 Azure Data Studio를 다시 시작하세요.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstalledTools">
         <source xml:lang="en">All required tools are installed now.</source>
-        <target state="new">All required tools are installed now.</target>
+        <target state="translated">이제 모든 필수 도구가 설치되었습니다.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.PendingInstallation">
         <source xml:lang="en">Following tools: {0} were still not discovered. Please make sure that they are installed, running and discoverable</source>
-        <target state="new">Following tools: {0} were still not discovered. Please make sure that they are installed, running and discoverable</target>
+        <target state="translated">{0} 도구가 아직 검색되지 않았습니다. 해당 도구가 설치되고, 실행 중이며, 검색 가능한지 확인하세요.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformation">
         <source xml:lang="en">'{0}' was not discovered and automated installation is not currently supported. Install '{0}' manually or ensure it is started and discoverable. Once done please restart Azure Data Studio. See [{1}] .</source>
-        <target state="new">'{0}' was not discovered and automated installation is not currently supported. Install '{0}' manually or ensure it is started and discoverable. Once done please restart Azure Data Studio. See [{1}] .</target>
+        <target state="translated">'{0}'이(가) 검색되지 않았고 현재 자동화된 설치가 지원되지 않습니다. '{0}'을(를) 수동으로 설치하거나 해당 항목이 시작되고 검색 가능한지 확인합니다. 완료되면 Azure Data Studio를 다시 시작하세요. [{1}] 항목을 참조하세요.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.VersionInformationDebugHint">
         <source xml:lang="en">You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'Azure Data CLI' output channels</source>
-        <target state="new">You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'Azure Data CLI' output channels</target>
+        <target state="translated">변경 내용을 선택하기 위해 도구를 수동으로 설치한 경우에는 Azure Data Studio를 다시 시작해야 합니다. '배포' 및 'Azure Data CLI' 출력 채널에서 추가적인 세부 정보를 찾을 수 있습니다.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallToolsHintOne">
         <source xml:lang="en">Tool: {0} is not installed, you can click the "{1}" button to install it.</source>
-        <target state="new">Tool: {0} is not installed, you can click the "{1}" button to install it.</target>
+        <target state="translated">{0} 도구가 설치되지 않았습니다. "{1}" 단추를 클릭하여 설치할 수 있습니다.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallToolsHintMany">
         <source xml:lang="en">Tools: {0} are not installed, you can click the "{1}" button to install them.</source>
-        <target state="new">Tools: {0} are not installed, you can click the "{1}" button to install them.</target>
+        <target state="translated">{0} 도구가 설치되지 않았습니다. "{1}" 단추를 클릭하여 설치할 수 있습니다.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.NoRequiredTool">
         <source xml:lang="en">No tools required</source>
-        <target state="new">No tools required</target>
+        <target state="translated">도구가 필요하지 않음</target>
       </trans-unit>
     </body>
   </file>
@@ -2280,23 +2180,23 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.DownloadAndLaunchTaskName">
         <source xml:lang="en">Download and launch installer, URL: {0}</source>
-        <target state="new">Download and launch installer, URL: {0}</target>
+        <target state="translated">설치 관리자 다운로드 및 시작, URL: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DownloadingText">
         <source xml:lang="en">Downloading from: {0}</source>
-        <target state="new">Downloading from: {0}</target>
+        <target state="translated">{0}에서 다운로드</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DownloadCompleteText">
         <source xml:lang="en">Successfully downloaded: {0}</source>
-        <target state="new">Successfully downloaded: {0}</target>
+        <target state="translated">다운로드함: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.LaunchingProgramText">
         <source xml:lang="en">Launching: {0}</source>
-        <target state="new">Launching: {0}</target>
+        <target state="translated">{0} 시작 중</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.ProgramLaunchedText">
         <source xml:lang="en">Successfully launched: {0}</source>
-        <target state="new">Successfully launched: {0}</target>
+        <target state="translated">시작함: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -2304,7 +2204,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.DockerDescription">
         <source xml:lang="en">Packages and runs applications in isolated containers</source>
-        <target state="new">Packages and runs applications in isolated containers</target>
+        <target state="translated">격리된 컨테이너에서 애플리케이션 패키지 및 실행</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DockerDisplayName">
         <source xml:lang="en">docker</source>
@@ -2316,7 +2216,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzCLIDescription">
         <source xml:lang="en">Manages Azure resources</source>
-        <target state="new">Manages Azure resources</target>
+        <target state="translated">Azure 리소스 관리</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzCLIDisplayName">
         <source xml:lang="en">Azure CLI</source>
@@ -2324,47 +2224,47 @@ Select a different subscription containing at least one server</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DeletingPreviousAzureCli.msi">
         <source xml:lang="en">deleting previously downloaded azurecli.msi if one exists …</source>
-        <target state="new">deleting previously downloaded azurecli.msi if one exists …</target>
+        <target state="translated">이전에 다운로드한 azurecli.msi 삭제 중(있는 경우)...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DownloadingAndInstallingAzureCli">
         <source xml:lang="en">downloading azurecli.msi and installing azure-cli …</source>
-        <target state="new">downloading azurecli.msi and installing azure-cli …</target>
+        <target state="translated">azurecli.msi를 다운로드하고 azure-cli를 설치하는 중…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DisplayingInstallationLog">
         <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
+        <target state="translated">설치 로그를 표시하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.UpdatingBrewRepository">
         <source xml:lang="en">updating your brew repository for azure-cli installation …</source>
-        <target state="new">updating your brew repository for azure-cli installation …</target>
+        <target state="translated">azure-cli 설치를 위해 brew 리포지토리를 업데이트하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.InstallingAzureCli">
         <source xml:lang="en">installing azure-cli …</source>
-        <target state="new">installing azure-cli …</target>
+        <target state="translated">azure-cli를 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetUpdate">
         <source xml:lang="en">updating repository information before installing azure-cli …</source>
-        <target state="new">updating repository information before installing azure-cli …</target>
+        <target state="translated">azure-cli를 설치하기 전에 리포지토리 정보를 업데이트하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetPackages">
         <source xml:lang="en">getting packages needed for azure-cli installation …</source>
-        <target state="new">getting packages needed for azure-cli installation …</target>
+        <target state="translated">azure-cli 설치에 필요한 패키지를 가져오는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for azure-cli …</source>
-        <target state="new">downloading and installing the signing key for azure-cli …</target>
+        <target state="translated">azure-cli의 서명 키를 다운로드하고 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AddingAzureCliRepositoryInformation">
         <source xml:lang="en">adding the azure-cli repository information …</source>
-        <target state="new">adding the azure-cli repository information …</target>
+        <target state="translated">azure-cli 리포지토리 정보를 추가하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetUpdateAgain">
         <source xml:lang="en">updating repository information again for azure-cli …</source>
-        <target state="new">updating repository information again for azure-cli …</target>
+        <target state="translated">azure-cli의 리포지토리 정보를 다시 업데이트하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.ScriptedInstall">
         <source xml:lang="en">download and invoking script to install azure-cli …</source>
-        <target state="new">download and invoking script to install azure-cli …</target>
+        <target state="translated">azure-cli를 설치하는 스크립트 다운로드 및 호출 중...</target>
       </trans-unit>
     </body>
   </file>
@@ -2372,59 +2272,23 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzdataDescription">
         <source xml:lang="en">Azure Data command line interface</source>
-        <target state="new">Azure Data command line interface</target>
+        <target state="translated">Azure 데이터 명령줄 인터페이스</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzdataDisplayName">
         <source xml:lang="en">Azure Data CLI</source>
-        <target state="new">Azure Data CLI</target>
+        <target state="translated">Azure Data CLI</target>
+      </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">이 리소스를 배포하려면 Azure Data CLI 확장을 설치해야 합니다. 확장 갤러리를 통해 설치한 후 다시 시도하세요.</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
-        <target state="new">Error retrieving version information. See output channel '{0}' for more details</target>
+        <target state="translated">버전 정보를 검색하는 동안 오류가 발생했습니다. 자세한 내용은 출력 채널 '{0}'을(를) 참조하세요.</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
-        <target state="new">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="new">deleting previously downloaded Azdata.msi if one exists …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="new">downloading Azdata.msi and installing azdata-cli …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="new">tapping into the brew repository for azdata-cli …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="new">updating the brew repository for azdata-cli installation …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="new">installing azdata …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="new">getting packages needed for azdata installation …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="new">downloading and installing the signing key for azdata …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="new">adding the azdata repository information …</target>
+        <target state="translated">버전 정보를 검색하는 동안 오류가 발생했습니다. {0}잘못된 출력이 수신되었습니다. 버전 명령 출력 '{1}'을(를) 가져옵니다. </target>
       </trans-unit>
     </body>
   </file>
@@ -2432,51 +2296,51 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzdataDescription">
         <source xml:lang="en">Azure Data command line interface</source>
-        <target state="new">Azure Data command line interface</target>
+        <target state="translated">Azure 데이터 명령줄 인터페이스</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzdataDisplayName">
         <source xml:lang="en">Azure Data CLI</source>
-        <target state="new">Azure Data CLI</target>
+        <target state="translated">Azure Data CLI</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
         <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="new">deleting previously downloaded Azdata.msi if one exists …</target>
+        <target state="translated">이전에 다운로드한 Azdata.msi를 삭제하는 중(있는 경우)...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
         <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="new">downloading Azdata.msi and installing azdata-cli …</target>
+        <target state="translated">Azdata.msi를 다운로드하고 azdata-cli를 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
         <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
+        <target state="translated">설치 로그를 표시하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
         <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="new">tapping into the brew repository for azdata-cli …</target>
+        <target state="translated">azdata-cli의 brew 리포지토리를 활용하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
         <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="new">updating the brew repository for azdata-cli installation …</target>
+        <target state="translated">azdata-cli 설치를 위해 brew 리포지토리를 업데이트하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
         <source xml:lang="en">installing azdata …</source>
-        <target state="new">installing azdata …</target>
+        <target state="translated">azdata를 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
         <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
+        <target state="translated">리포지토리 정보를 업데이트하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
         <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="new">getting packages needed for azdata installation …</target>
+        <target state="translated">azdata 설치에 필요한 패키지를 가져오는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="new">downloading and installing the signing key for azdata …</target>
+        <target state="translated">azdata의 서명 키를 다운로드하고 설치하는 중...</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
         <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="new">adding the azdata repository information …</target>
+        <target state="translated">azdata 리포지토리 정보를 추가하는 중...</target>
       </trans-unit>
     </body>
   </file>
@@ -2484,7 +2348,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="deploymentDialog.deploymentOptions">
         <source xml:lang="en">Deployment options</source>
-        <target state="new">Deployment options</target>
+        <target state="translated">배포 옵션</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/schema-compare.ko.xlf
+++ b/resources/xlf/ko/schema-compare.ko.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">확인</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">원본</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">대상</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">파일</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">데이터 계층 애플리케이션 파일(.dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">형식</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">서버</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">스키마 비교</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">다른 원본 스키마를 선택했습니다. 비교를 확인하려면 비교를 누르세요.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">다른 대상 스키마를 선택했습니다. 비교를 확인하려면 비교를 누르세요.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">다른 원본 및 대상 스키마를 선택했습니다. 비교를 확인하려면 비교를 누르세요.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">원본 파일</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">대상 파일</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">원본 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">대상 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">원본 서버</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">대상 서버</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">기본값</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">열기</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">원본 파일 선택</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">대상 파일 선택</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">다시 설정</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">개체 유형 포함</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">세부 정보 비교</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">대상을 업데이트하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">비교를 눌러 비교를 새로 고칩니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">대상에 변경 내용을 배포하는 스크립트 생성</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">스크립트 변경 내용 없음</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">대상에 변경 내용 적용</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">적용할 변경 내용 없음</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">포함/제외 작업은 영향을 받는 종속성을 계산하는 데 잠시 걸릴 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">삭제</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">변경</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">추가</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">원본과 대상 간의 비교</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">비교를 초기화하는 중입니다. 시간이 약간 걸릴 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">두 스키마를 비교하려면 먼저 원본 스키마 및 대상 스키마를 선택한 다음, 비교를 누릅니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">스키마 차이를 찾을 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">형식</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">원본 이름</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">포함</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">작업</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">대상 이름</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">대상이 데이터베이스이면 스크립트 생성이 사용하도록 설정됩니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">대상이 데이터베이스이면 적용이 사용하도록 설정됩니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">{0}을(를) 제외할 수 없습니다. {1} 같은 포함된 종속 항목이 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">{0}을(를) 포함할 수 없습니다. {1} 같은 제외된 종속 항목이 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">{0}을(를) 제외할 수 없습니다. 포함된 종속 항목이 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">{0}을(를) 포함할 수 없습니다. 제외된 종속 항목이 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">비교</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">중지</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">스크립트 생성</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">옵션</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">적용</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">방향 전환</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">원본과 대상 전환</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">원본 선택</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">대상 선택</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">.scmp 파일 열기</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">.scmp 파일에 저장된 원본, 대상 및 옵션 로드</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">.scmp 파일 저장</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">원본 및 대상, 옵션 및 제외된 요소 저장</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">저장</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">{0}에 연결하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">연결 선택</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,7 +663,7 @@
         <target state="translated">데이터베이스 역할</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
+        <source xml:lang="en">Database Triggers</source>
         <target state="translated">데이터베이스 트리거</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">외부 파일 형식</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">외부 스트림</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">외부 스트리밍 작업</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">외부 테이블</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">파일 그룹</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">파일</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">시그니처</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">저장 프로시저</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">대칭 키</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">데이터베이스에 게시할 때 테이블 열 순서의 차이를 무시할지 또는 업데이트할지를 지정합니다.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">원본</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">대상</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">파일</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">데이터 계층 애플리케이션 파일(.dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">형식</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">서버</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">활성 연결 없음</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">스키마 비교</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">다른 원본 스키마를 선택했습니다. 비교를 확인하려면 비교를 누르세요.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">다른 대상 스키마를 선택했습니다. 비교를 확인하려면 비교를 누르세요.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">다른 원본 및 대상 스키마를 선택했습니다. 비교를 확인하려면 비교를 누르세요.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">열기</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">기본값</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">세부 정보 비교</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">대상을 업데이트하시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">비교를 눌러 비교를 새로 고칩니다.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">대상에 변경 내용을 배포하는 스크립트 생성</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">스크립트 변경 내용 없음</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">대상에 변경 내용 적용</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">적용할 변경 내용 없음</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">삭제</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">변경</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">추가</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">스키마 비교</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">원본</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">대상</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">비교를 초기화하는 중입니다. 시간이 약간 걸릴 수 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">두 스키마를 비교하려면 먼저 원본 스키마 및 대상 스키마를 선택한 다음, 비교를 누릅니다.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">스키마 차이를 찾을 수 없습니다.</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">스키마 비교 실패: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">형식</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">원본 이름</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">포함</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">작업</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">대상 이름</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">대상이 데이터베이스이면 스크립트 생성이 사용하도록 설정됩니다.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">대상이 데이터베이스이면 적용이 사용하도록 설정됩니다.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">비교</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">비교</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">중지</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">중지</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">scmp 저장 실패: '{0}'</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">스키마 비교 취소 실패: '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">스크립트 생성</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">스크립트 생성 실패: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">옵션</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">옵션</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">적용</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">스키마 비교 적용 실패 '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">방향 전환</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">원본과 대상 전환</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">원본 선택</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">대상 선택</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">.scmp 파일 열기</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">.scmp 파일에 저장된 원본, 대상 및 옵션 로드</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">열기</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">scmp 열기 실패: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">.scmp 파일 저장</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">원본 및 대상, 옵션 및 제외된 요소 저장</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">저장</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">scmp 저장 실패: '{0}'</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ko/sql.ko.xlf
+++ b/resources/xlf/ko/sql.ko.xlf
@@ -1,2559 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">이미지 복사가 지원되지 않습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">시작</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">시작 표시</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">시작(&amp;S)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">QueryHistory</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">쿼리 기록 캡처가 사용하도록 설정되어 있는지 여부입니다. false이면 실행된 쿼리가 캡처되지 않습니다.</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">보기</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">쿼리 기록(&amp;Q)</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">쿼리 기록</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">{0}에 연결하는 중</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">명령 {0} 실행 중</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">새 쿼리 {0}을(를) 여는 중</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">서버 정보가 제공되지 않았으므로 연결할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">{0} 오류로 인해 URL을 열 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">이렇게 하면 서버 {0}에 연결됩니다.</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">연결하시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">열기(&amp;O)</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">쿼리 파일 연결 중</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">1개 이상의 작업이 진행 중입니다. 그래도 작업을 종료하시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">미리 보기 기능을 사용하면 새로운 기능 및 개선 사항에 대한 모든 권한을 제공함으로써 Azure Data Studio에서 환경이 개선됩니다. [여기]({0})에서 미리 보기 기능에 관해 자세히 알아볼 수 있습니다. 미리 보기 기능을 사용하시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">예(추천)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">아니요, 다시 표시 안 함</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">쿼리 기록 전환</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">삭제</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">모든 기록 지우기</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">쿼리 열기</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">쿼리 실행</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">쿼리 기록 캡처 전환</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">쿼리 기록 캡처 일시 중지</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">쿼리 기록 캡처 시작</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">표시할 쿼리가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">쿼리 기록</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">오류</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">경고</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">정보</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">무시</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">이 데이터 공급자에 대해 사용하지 않도록 설정한 다른 형식으로 결과를 저장하고 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">공급자가 등록되지 않은 경우 데이터를 직렬화할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">알 수 없는 오류로 인해 serialization에 실패했습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">adminservice와 상호 작용하려면 연결이 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">등록된 처리기 없음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">파일 선택</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">평가 서비스와 상호 작용하려면 연결이 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">등록된 처리기 없음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">결과 표 및 메시지</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">글꼴 패밀리를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">글꼴 두께를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">글꼴 크기(픽셀)를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">문자 간격(픽셀)을 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">행 높이(픽셀)를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">셀 안쪽 여백(픽셀)을 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">초기 결과의 열 너비를 자동으로 조정합니다. 열 개수가 많거나 셀이 크면 성능 문제가 발생할 수 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">자동으로 크기가 조정되는 열의 최대 너비(픽셀)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">보기</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">데이터베이스 연결</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">데이터 원본 연결</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">데이터 원본 그룹</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">시작 구성</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">Azure Data Studio 시작 시 서버 보기를 표시하려면 True(기본값), 마지막으로 열었던 보기를 표시하려면 False</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">연결 끊기</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">새로 고침</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">미리 보기 기능</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">해제되지 않은 미리 보기 기능 사용</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">시작 시 연결 대화 상자 표시</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">사용되지 않는 API 알림</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">사용되지 않는 API 사용 알림 사용/사용 안 함</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">문제</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">진행 중인 작업 {0}개</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">보기</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">작업</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">작업(&amp;T)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">연결 목록에 저장할 최근에 사용한 최대 연결 수입니다.</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">사용할 기본 SQL 엔진입니다. 해당 엔진은 .sql 파일의 기본 언어 공급자와 새 연결을 만들 때 사용할 기본 공급자를 구동합니다.</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">연결 대화 상자가 열리거나 붙여넣기가 수행되면 클립보드의 내용을 구문 분석하려고 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">개체 탐색기 뷰렛에서 사용되는 서버 그룹 색상표입니다.</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">개체 탐색기 뷰렛에서 서버 그룹을 자동으로 확장합니다.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(미리 보기) 동적 노드 필터링과 같은 새로운 기능 지원을 사용하여 서버 보기 및 연결 대화 상자에 새 비동기 서버 트리를 사용합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">계정 유형 식별자</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(옵션) UI에서 명령을 나타내는 데 사용되는 아이콘입니다. 파일 경로 또는 테마 지정 가능 구성입니다.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">밝은 테마를 사용하는 경우의 아이콘 경로</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">어두운 테마를 사용하는 경우의 아이콘 경로</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">계정 공급자에게 아이콘을 제공합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">시작 시 데이터 SQL 편집 창 표시</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Y축 최솟값</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Y축 최댓값</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Y축 레이블</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">X축 최솟값</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">X축 최댓값</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">X축 레이블</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">리소스 뷰어</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">차트 데이터 세트의 데이터 속성을 나타냅니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">결과 세트의 각 열에 대해 행 0의 값을 개수와 열 이름으로 표시합니다. 예를 들어, '1 Healthy', '3 Unhealthy'가 지원됩니다. 여기서 'Healthy'는 열 이름이고 1은 행 1, 셀 1의 값입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">단순 테이블에 결과를 표시합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">이미지(예: ggplot2를 사용하여 R 쿼리에서 반환한 이미지)를 표시합니다.</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">어떤 형식이 필요한가요? JPEG, PNG 또는 다른 형식인가요?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">16진수, base64 또는 다른 형식으로 인코딩되어 있나요?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">관리</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">대시보드</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">이 탭에 표시할 웹 보기입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">이 탭에 표시할 controlhost입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">이 탭에 표시할 위젯 목록입니다.</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">위젯 목록은 확장용 위젯 컨테이너 내에 있어야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">이 탭에 표시되는 위젯 또는 웹 보기의 목록입니다.</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">위젯이나 웹 보기는 확장용 위젯 컨테이너 내부에 있어야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">이 컨테이너의 고유 식별자입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">탭에 표시될 컨테이너입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">사용자가 대시보드 추가할 단일 또는 다중 대시보드 컨테이너를 적용합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">확장용으로 지정된 대시보드 컨테이너에 ID가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">대시보드 컨테이너에 확장용으로 지정된 컨테이너가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">공란 1개에 정확히 1개의 대시보드 컨테이너를 정의해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">확장용 대시보드 컨테이너에 알 수 없는 컨테이너 형식이 정의되었습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">이 탐색 영역의 고유 식별자입니다. 모든 요청에서 확장으로 전달됩니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(옵션) UI에서 이 탐색 섹션을 나타내는 데 사용되는 아이콘입니다. 파일 경로 또는 테마 지정 가능 구성입니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">밝은 테마를 사용하는 경우의 아이콘 경로</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">어두운 테마를 사용하는 경우의 아이콘 경로</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">사용자에게 표시할 탐색 섹션의 제목입니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">이 탐색 섹션에 표시할 컨테이너입니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">이 탐색 섹션에 표시할 대시보드 컨테이너 목록입니다.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">탐색 섹션에 확장용으로 지정된 제목이 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">탐색 섹션에 확장용으로 지정된 컨테이너가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">공란 1개에 정확히 1개의 대시보드 컨테이너를 정의해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION 내의 NAV_SECTION은 확장용으로 유효하지 않은 컨테이너입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">이 탭에 표시할 모델 지원 보기입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">백업</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">복원</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">복원</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">Azure Portal에서 열기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">연결 끊김</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">필요한 연결 공급자 '{0}'을(를) 찾을 수 없으므로 확장할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">사용자가 취소함</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">방화벽 대화 상자를 취소함</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">JobManagementService와 상호 작용하려면 연결이 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">등록된 처리기 없음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">파일 브라우저를 로드하는 동안 오류가 발생했습니다.</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">파일 브라우저 오류</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">공급자의 일반 ID</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">공급자의 표시 이름</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">공급자의 Notebook 커널 별칭</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">서버 유형의 아이콘 경로</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">연결 옵션</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">이 탭의 고유 식별자입니다. 모든 요청에서 확장으로 전달됩니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">사용자에게 표시할 탭의 제목입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">사용자에게 표시할 이 탭에 대한 설명입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">이 항목을 표시하기 위해 true여야 하는 조건</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">이 탭과 호환되는 연결 형식을 정의합니다. 설정하지 않으면 기본 연결 형식은 'MSSQL'입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">이 탭에 표시할 컨테이너입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">이 탭을 항상 표시할지 또는 사용자가 추가할 때만 표시할지입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">이 탭을 연결 형식의 홈 탭으로 사용할지 여부입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">이 탭이 속한 그룹의 고유 식별자이며 홈 그룹의 값은 home입니다.</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(선택 사항) UI에서 이 탭을 나타내는 데 사용되는 아이콘입니다. 파일 경로 또는 테마 지정 가능 구성입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">밝은 테마를 사용하는 경우의 아이콘 경로</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">어두운 테마를 사용하는 경우의 아이콘 경로</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">사용자가 대시보드 추가할 단일 또는 다중 탭을 적용합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">확장용으로 지정한 제목이 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">표시하도록 지정한 설명이 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">확장용으로 지정한 컨테이너가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">공란 1개에 정확히 1개의 대시보드 컨테이너를 정의해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">이 탭 그룹의 고유 식별자입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">탭 그룹의 제목입니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">사용자가 대시보드에 추가할 하나 이상의 탭 그룹을 제공합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">탭 그룹에 ID가 지정되지 않았습니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">탭 그룹에 제목을 지정하지 않았습니다.</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">관리</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">모니터링</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">성능</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">보안</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">문제 해결</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">설정</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">데이터베이스 탭</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">데이터베이스</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">성공</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">실패</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">연결 오류</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">Kerberos 오류로 인해 연결이 실패했습니다.</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">Kerberos 구성 도움말이 {0}에 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">이전에 연결된 경우 kinit을 다시 실행해야 할 수 있습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">닫기</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">계정 추가...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">사용자가 계정 새로 고침을 취소했습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">쿼리 결과</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">쿼리 편집기</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">새 쿼리</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">쿼리 편집기</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">true이면 결과를 CSV로 저장할 때 열 머리글이 포함됩니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">CSV로 저장할 때 값 사이에 사용할 사용자 지정 구분 기호</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">결과를 CSV로 저장할 때 행을 분리하는 데 사용하는 문자</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">결과를 CSV로 저장할 때 텍스트 필드를 묶는 데 사용하는 문자</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">결과를 CSV로 저장할 때 사용되는 파일 인코딩</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">true이면 결과를 XML로 저장할 때 XML 출력에 형식이 지정됩니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">결과를 XML로 저장할 때 사용되는 파일 인코딩</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">결과 스트리밍을 사용하도록 설정합니다. 몇 가지 사소한 시각적 문제가 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">결과 뷰에서 결과를 복사하기 위한 구성 옵션</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">결과 뷰에서 여러 줄 결과를 복사하기 위한 구성 옵션</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(실험적) 결과에 최적화된 테이블을 사용합니다. 일부 기능이 누락되거나 작동 중입니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">개별 일괄 처리에 대한 실행 시간 표시 여부</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">메시지 자동 줄 바꿈</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">쿼리 결과에서 차트 뷰어를 열 때 사용할 기본 차트 유형</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">탭 색 지정이 사용하지 않도록 설정됩니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">각 편집기 탭의 상단 테두리는 관련 서버 그룹과 일치하도록 칠해집니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">각 편집기 탭의 배경색이 관련 서버 그룹과 일치합니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">활성 연결의 서버 그룹을 기준으로 탭 색상 지정 방법을 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">제목에 있는 탭에 연결 정보를 표시할지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">생성된 SQL 파일 저장 여부 확인</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">바로 가기 텍스트를 프로시저 호출로 실행하려면 키 바인딩 workbench.action.query.shortcut{0}을(를) 설정하세요. 쿼리 편집기에서 선택한 텍스트가 매개 변수로 전달됩니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">뷰 템플릿 지정</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">세션 템플릿 지정</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Profiler 필터</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Create로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Drop으로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">상위 1,000개 선택</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Execute로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Alter로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">데이터 편집</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">상위 1,000개 선택</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Take 10</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Create로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Execute로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Alter로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Drop으로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">새로 고침</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">행 커밋 실패: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">다음에서 쿼리 실행 시작: </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">쿼리 "{0}" 실행을 시작함</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">줄 {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">쿼리 취소 실패: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">셀 업데이트 실패: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">Notebook 관리자를 만들 때 URI가 전달되지 않았습니다.</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">Notebook 공급자가 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Notebook 편집기</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">새 Notebook</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">새 Notebook</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">작업 영역 설정 및 열기</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">SQL 커널: 셀에서 오류가 발생하면 Notebook 실행을 중지합니다.</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(미리 보기) 현재 Notebook 공급자의 모든 커널을 표시합니다.</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">Notebook이 Azure Data Studio 명령을 실행하도록 허용합니다.</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">두 번 클릭을 사용하여 Notebook에서 텍스트 셀 편집</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">기본적으로 텍스트 셀에 대해 서식 있는 텍스트 보기 모드 설정</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(미리 보기) 연결 이름을 Notebook 메타데이터에 저장합니다.</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">Notebook markdown 미리 보기에서 사용되는 줄 높이를 제어합니다. 해당 숫자는 글꼴 크기에 상대적입니다.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">보기</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">Notebook 검색</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">전체 텍스트 검색 및 빠른 열기에서 glob 패턴을 구성하여 파일 및 폴더를 제외합니다. `#files.exclude#` 설정에서 모든 glob 패턴을 상속합니다. [여기](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)에서 glob 패턴에 대해 자세히 알아보세요.</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">파일 경로를 일치시킬 GLOB 패턴입니다. 패턴을 사용하거나 사용하지 않도록 설정하려면 true 또는 false로 설정하세요.</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">일치하는 파일의 형제에 대한 추가 검사입니다. $(basename)을 일치하는 파일 이름에 대한 변수로 사용하세요.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">이 설정은 사용되지 않으며 이제 "search.usePCRE2"로 대체됩니다.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">사용되지 않습니다. 고급 regex 기능을 지원하려면 "search.usePCRE2"를 사용해 보세요.</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">사용하도록 설정하면 searchService 프로세스가 1시간의 비활성 상태 이후 종료되지 않고 계속 유지됩니다. 메모리에 파일 검색 캐시가 유지됩니다.</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">파일을 검색할 때 '.gitignore' 파일 및 '.ignore' 파일을 사용할지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">파일을 검색할 때 전역 '.gitignore' 및 '.ignore' 파일을 사용할지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">Quick Open에 대한 파일 결과에 전역 기호 검색 결과를 포함할지 여부입니다.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">Quick Open에 대한 파일 결과에 최근에 연 파일의 결과를 포함할지 여부입니다.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">기록 항목은 사용된 필터 값을 기준으로 관련성별로 정렬됩니다. 관련성이 더 높은 항목이 먼저 표시됩니다.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">기록이 최신순으로 정렬됩니다. 가장 최근에 열람한 항목부터 표시됩니다.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">필터링할 때 빠른 열기에서 편집기 기록의 정렬 순서를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">검색하는 동안 symlink를 누를지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">패턴이 모두 소문자인 경우 대/소문자를 구분하지 않고 검색하고, 그렇지 않으면 대/소문자를 구분하여 검색합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">macOS에서 검색 보기가 공유 클립보드 찾기를 읽거나 수정할지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">검색을 사이드바의 보기로 표시할지 또는 가로 간격을 늘리기 위해 패널 영역의 패널로 표시할지를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">이 설정은 더 이상 사용되지 않습니다. 대신 검색 보기의 컨텍스트 메뉴를 사용하세요.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">결과가 10개 미만인 파일이 확장됩니다. 다른 파일은 축소됩니다.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">검색 결과를 축소 또는 확장할지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">일치하는 항목을 선택하거나 바꿀 때 미리 보기 바꾸기를 열지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">검색 결과의 줄 번호를 표시할지 여부를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">텍스트 검색에서 PCRE2 regex 엔진을 사용할지 여부입니다. 사용하도록 설정하면 lookahead 및 backreferences와 같은 몇 가지 고급 regex 기능을 사용할 수 있습니다. 하지만 모든 PCRE2 기능이 지원되지는 않으며, JavaScript에서도 지원되는 기능만 지원됩니다.</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">사용되지 않습니다. PCRE2는 PCRE2에서만 지원하는 regex 기능을 사용할 경우 자동으로 사용됩니다.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">검색 보기가 좁을 때는 오른쪽에, 그리고 검색 보기가 넓을 때는 콘텐츠 바로 뒤에 작업 모음을 배치합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">작업 모음을 항상 오른쪽에 배치합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">검색 보기에서 행의 작업 모음 위치를 제어합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">입력할 때 모든 파일을 검색합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">활성 편집기에 선택 항목이 없을 경우 커서에 가장 가까운 단어에서 시드 검색을 사용합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">검색 보기에 포커스가 있을 때 작업 영역 검색 쿼리를 편집기의 선택한 텍스트로 업데이트합니다. 이 동작은 클릭 시 또는 `workbench.views.search.focus` 명령을 트리거할 때 발생합니다.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">'#search.searchOnType#'이 활성화되면 입력되는 문자와 검색 시작 사이의 시간 시간을 밀리초 단위로 제어합니다. 'search.searchOnType'을 사용하지 않도록 설정하면 아무런 효과가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">두 번 클릭하면 커서 아래에 있는 단어가 선택됩니다.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">두 번 클릭하면 활성 편집기 그룹에 결과가 열립니다.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">두 번 클릭하면 측면의 편집기 그룹에 결과가 열리고, 편집기 그룹이 없으면 새로 만듭니다.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">검색 편집기에서 결과를 두 번 클릭하는 효과를 구성합니다.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">결과는 폴더 및 파일 이름의 알파벳 순으로 정렬됩니다.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">결과는 폴더 순서를 무시하고 파일 이름별 알파벳 순으로 정렬됩니다.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">결과는 파일 확장자의 알파벳 순으로 정렬됩니다.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">결과는 파일을 마지막으로 수정한 날짜의 내림차순으로 정렬됩니다.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">결과는 파일별 개수의 내림차순으로 정렬됩니다.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">결과는 파일별 개수의 오름차순으로 정렬됩니다.</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">검색 결과의 정렬 순서를 제어합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">새 쿼리</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">실행</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">설명</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">실제</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">연결 끊기</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">연결 변경</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">SQLCMD 사용</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">SQLCMD 사용 안 함</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">데이터베이스 선택</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">데이터베이스를 변경하지 못함</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">{0} 데이터베이스를 변경하지 못함</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">Notebook으로 내보내기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">닫기</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">작업</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">세부 정보 복사</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">서버 그룹 추가</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">서버 그룹 편집</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">확장</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">개체 탐색기 세션을 만들지 못함</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">여러 오류:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">계정 추가 오류</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">방화벽 규칙 오류</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">로드된 확장 중 일부는 사용되지 않는 API를 사용하고 있습니다. 개발자 도구 창의 콘솔 탭에서 자세한 정보를 확인하세요.</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">다시 표시 안 함</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">뷰의 식별자입니다. 'vscode.window.registerTreeDataProviderForView' API를 통해 데이터 공급자를 등록하는 데 사용합니다. 'onView:${id}' 이벤트를 'activationEvents'에 등록하여 확장 활성화를 트리거하는 데도 사용합니다.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">사용자가 읽을 수 있는 뷰 이름입니다. 표시됩니다.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">이 뷰를 표시하기 위해 true여야 하는 조건</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">뷰를 편집기에 적용합니다.</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">뷰를 작업 막대의 Data Explorer 컨테이너에 적용합니다.</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">뷰를 적용된 뷰 컨테이너에 적용합니다.</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">뷰 컨테이너 '{1}'에서 동일한 ID '{0}'의 여러 뷰를 등록할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">ID가 '{0}'인 뷰가 뷰 컨테이너 '{1}'에 이미 등록되어 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">뷰는 배열이어야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">속성 '{0}'은(는) 필수이며 'string' 형식이어야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">속성 '{0}'은(는) 생략할 수 있으며 'string' 형식이어야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">사용자 설정에서 {0}이(가) {1}(으)로 바뀌었습니다.</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">작업 영역 설정에서 {0}이(가) {1}(으)로 바뀌었습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">관리</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">세부 정보 표시</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">자세한 정보</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">저장된 모든 계정 지우기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">작업 토글</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">연결 상태</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">트리 공급자의 사용자 표시 이름</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">공급자 ID는 트리 데이터 공급자를 등록할 때와 동일해야 하며 'connectionDialog/'로 시작해야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">쿼리 결과를 대시보드에 차트로 표시합니다.</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">'열 이름'을 색에 매핑합니다. 예를 들어, 이 열에 빨간색을 사용하려면 'column1': red를 추가합니다. </target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">차트 범례의 기본 위치 및 표시 여부를 나타냅니다. 이 항목은 쿼리의 열 이름이며, 각 차트 항목의 레이블에 매핑됩니다.</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">dataDirection이 horizontal인 경우, 이 값을 true로 설정하면 범례의 첫 번째 열 값을 사용합니다.</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">dataDirection이 vertical인 경우, 이 값을 true로 설정하면 범례의 열 이름을 사용합니다.</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">데이터를 열(세로)에서 읽어올지 행(가로)에서 읽어올지를 정의합니다. 시계열에서는 방향이 세로여야 하므로 무시됩니다.</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">showTopNData를 설정한 경우 차트에 상위 N개 데이터만 표시합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">대시보드에 사용되는 위젯</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">작업 표시</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">리소스 뷰어</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">리소스 식별자입니다.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">사용자가 읽을 수 있는 뷰 이름입니다. 표시됩니다.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">리소스 아이콘의 경로입니다.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">리소스 뷰에 리소스 제공</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">속성 '{0}'은(는) 필수이며 'string' 형식이어야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">속성 '{0}'은(는) 생략할 수 있으며 'string' 형식이어야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">리소스 뷰어 트리</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">대시보드에 사용되는 위젯</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">대시보드에 사용되는 위젯</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">대시보드에 사용되는 위젯</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">이 항목을 표시하기 위해 true여야 하는 조건</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">위젯의 헤더를 숨길지 여부를 나타냅니다. 기본값은 false입니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">컨테이너의 제목</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">표의 구성 요소 행</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">표에 있는 구성 요소의 rowspan입니다. 기본값은 1입니다. 표의 행 수로 설정하려면 '*'를 사용합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">표의 구성 요소 열</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">표에 있는 구성 요소의 colspan입니다. 기본값은 1입니다. 표의 열 수로 설정하려면 '*'를 사용합니다.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">이 탭의 고유 식별자입니다. 모든 요청에서 확장으로 전달됩니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">확장 탭을 알 수 없거나 설치하지 않았습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">속성 위젯 사용 또는 사용 안 함</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">표시할 속성 값</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">속성의 표시 이름</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">데이터베이스 정보 개체의 값</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">무시할 특정 값 지정</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">복구 모델</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">마지막 데이터베이스 백업</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">마지막 로그 백업</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">호환성 수준</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">소유자</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">데이터베이스 대시보드 페이지를 사용자 지정합니다.</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">검색</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">데이터베이스 대시보드 탭을 사용자 지정합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">속성 위젯 사용 또는 사용 안 함</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">표시할 속성 값</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">속성의 표시 이름</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">서버 정보 개체의 값</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">버전</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">버전</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">컴퓨터 이름</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">OS 버전</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">검색</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">서버 대시보드 페이지를 사용자 지정합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">서버 대시보드 탭을 사용자 지정합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">관리</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">'icon' 속성은 생략하거나, '{dark, light}' 같은 문자열 또는 리터럴이어야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">서버 또는 데이터베이스를 쿼리하고 여러 방법(차트, 요약 개수 등)으로 결과를 표시할 수 있는 위젯을 추가합니다.</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">인사이트의 결과를 캐싱하는 데 사용되는 고유 식별자입니다.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">실행할 SQL 쿼리입니다. 정확히 1개의 결과 집합을 반환해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[옵션] 쿼리를 포함하는 파일의 경로입니다. '쿼리'를 설정하지 않은 경우에 사용합니다.</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[옵션] 자동 새로 고침 간격(분)입니다. 설정하지 않으면 자동 새로 고침이 수행되지 않습니다.</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">사용할 작업</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">작업의 대상 데이터베이스입니다. '${ columnName }' 형식을 사용하여 데이터 기반 열 이름을 사용할 수 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">작업의 대상 서버입니다. '${ columnName }' 형식을 사용하여 데이터 기반 열 이름을 사용할 수 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">작업의 대상 사용자입니다. '${ columnName }' 형식을 사용하여 데이터 기반 열 이름을 사용할 수 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">인사이트의 식별자</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">대시보드 팔레트에 인사이트를 적용합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">백업</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">백업을 사용하려면 미리 보기 기능을 사용하도록 설정해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL Database에 대해 백업 명령이 지원되지 않습니다.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">서버 컨텍스트에서 백업 명령이 지원되지 않습니다. 데이터베이스를 선택하고 다시 시도하세요.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">복원</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">복원을 사용하려면 미리 보기 기능을 사용하도록 설정해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL Database에 대해 복원 명령이 지원되지 않습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">권장 사항 표시</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">확장 설치</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">확장 제작...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">연결하지 못한 데이터 세션 편집</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">대시보드 확장 열기</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">현재 설치된 대시보드 확장이 없습니다. 확장 관리자로 가서 권장되는 확장을 살펴보세요.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">선택한 경로</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">파일 형식</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">삭제</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">인사이트 플라이아웃에 전달된 연결 프로필이 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">인사이트 오류</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">쿼리 파일을 읽는 동안 오류가 발생했습니다. </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">인사이트 구성을 구문 분석하는 동안 오류가 발생했습니다. 쿼리 배열/문자열이나 쿼리 파일을 찾을 수 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Azure 계정</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Azure 테넌트</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">연결 표시</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">서버</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">표시할 작업 기록이 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">작업 기록</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">작업 오류</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">목록 지우기</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">최근 연결 목록을 삭제함</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">목록에서 모든 연결을 삭제하시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">삭제</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">현재 연결 문자열 가져오기</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">연결 문자열을 사용할 수 없음</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">사용 가능한 활성 연결이 없음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">새로 고침</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">연결 편집</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">연결 끊기</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">새 연결</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">새 서버 그룹</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">서버 그룹 편집</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">활성 연결 표시</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">모든 연결 표시</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">최근 연결</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">연결 삭제</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">그룹 삭제</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">실행</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">오류를 나타내며 편집 내용 삭제 실패: </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">중지</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">SQL 창 표시</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">SQL 창 닫기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">연결되지 않음</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">{0} 서버에서 XEvent Profiler 세션이 예기치 않게 중지되었습니다.</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">새로운 세션을 시작하는 동안 오류가 발생했습니다.</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">{0}의 XEvent Profiler 세션에서 이벤트가 손실되었습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">로드 중</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">로드 완료</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">서버 그룹</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">서버 그룹 이름</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">그룹 이름이 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">그룹 설명</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">그룹 색</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">계정 추가 오류</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">항목</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">값</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">인사이트 세부 정보</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">속성</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">값</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">인사이트</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">항목</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">항목 세부 정보</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">자동 OAuth를 시작할 수 없습니다. 자동 OAuth가 이미 진행 중입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">이벤트 기준 정렬</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">열 기준 정렬</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">모두 지우기</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">적용</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">필터</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">이 절 제거</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">필터 저장</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">필터 로드</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">절 추가</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">필드</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">연산자</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">값</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">Null임</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">Null이 아님</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">포함</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">포함하지 않음</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">다음으로 시작</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">다음으로 시작하지 않음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">CSV로 저장</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">JSON으로 저장</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Excel로 저장</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">XML로 저장</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">복사</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">복사(머리글 포함)</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">모두 선택</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">대시보드에 표시할 속성을 정의합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">속성의 레이블로 사용할 값</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">값을 위해 액세스할 개체의 값</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">무시할 값 지정</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">무시되거나 값이 없는 경우 표시할 기본값</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">대시보드 속성을 정의하기 위한 특성</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">특성의 ID</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">이 특성을 사용할 조건</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">비교할 필드</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">비교에 사용할 연산자</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">필드를 비교할 값</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">표시할 데이터베이스 페이지 속성</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">표시할 서버 페이지 속성</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">이 공급자가 대시보드를 지원함을 정의합니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">공급자 ID(예: MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">대시보드에 표시할 속성 값</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">잘못된 값</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2565,435 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">비어 있음</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">텍스트 레이블 숨기기</target>
       </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">열의 모든 확인란 선택: {0}</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">텍스트 레이블 표시</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">ID가 '{0}'인 등록된 트리 뷰가 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">편집 데이터 세션 초기화 실패: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">Notebook 공급자의 식별자입니다.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">이 Notebook 공급자에 등록해야 하는 파일 확장명</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">이 Notebook 공급자에서 표준이어야 하는 커널</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">Notebook 공급자를 적용합니다.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">'%%sql'과(와) 같은 셀 매직의 이름입니다.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">이 셀 매직이 셀에 포함되는 경우 사용되는 셀 언어</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">이 매직이 나타내는 선택적 실행 대상(예: Spark 및 SQL)</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">유효한 선택적 커널 세트(예: python3, pyspark, sql)</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">Notebook 언어를 적용합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">F5 바로 가기 키를 사용하려면 코드 셀을 선택해야 합니다. 실행할 코드 셀을 선택하세요.</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">명확한 결과를 얻으려면 코드 셀을 선택해야 합니다. 실행할 코드 셀을 선택하세요.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">최대 행 수:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">뷰 선택</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">세션 선택</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">세션 선택:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">뷰 선택:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">텍스트</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">레이블</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">값</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">세부 정보</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">경과 시간</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">행 개수</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0}개의 행</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">쿼리를 실행하는 중...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">실행 상태</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">선택 요약</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">평균: {0} 개수: {1} 합계: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">SQL 언어 선택</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">SQL 언어 공급자 변경</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">SQL 언어 버전</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">SQL 엔진 공급자 변경</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">{0} 엔진을 사용하는 연결이 존재합니다. 변경하려면 연결을 끊거나 연결을 변경하세요.</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">현재 활성 텍스트 편집기 없음</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">언어 공급자 선택</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">플롯 그래프 {0}을(를) 표시하는 동안 오류가 발생했습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">출력의 {0} 렌더러를 찾을 수 없습니다. MIME 형식이 {1}입니다.</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(안전) </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">상위 1,000개 선택</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Take 10</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Execute로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Alter로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">데이터 편집</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Create로 스크립트</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Drop으로 스크립트</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">유효한 providerId가 있는 NotebookProvider를 이 메서드에 전달해야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">유효한 providerId가 있는 NotebookProvider를 이 메서드에 전달해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">Notebook 공급자가 없음</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">관리자를 찾을 수 없음</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">{0} Notebook의 Notebook 관리자에 서버 관리자가 없습니다. 작업을 수행할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">{0} Notebook의 Notebook 관리자에 콘텐츠 관리자가 없습니다. 작업을 수행할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">{0} Notebook의 Notebook 관리자에 세션 관리자가 없습니다. 작업을 수행할 수 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">연결을 위한 Azure 계정 토큰을 가져오지 못함</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">연결이 허용되지 않음</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">이 연결을 취소하시겠습니까?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">닫기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">커널을 로드하는 중...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">커널을 변경하는 중...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">연결 대상 </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">커널 </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">컨텍스트를 로드하는 중...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">연결 변경</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">연결 선택</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">커널 없음</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">결과 지우기</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">신뢰할 수 있음</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">신뢰할 수 없음</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">셀 축소</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">셀 확장</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">없음</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">새 Notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">다음 문자열 찾기</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">이전 문자열 찾기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">쿼리 계획</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">새로 고침</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">{0}단계</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">목록에 있는 옵션이어야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">Box 선택</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">연결 형식</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">최근 연결</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">저장된 연결</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">연결 세부 정보</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">최근 연결</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">최근 연결 없음</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">저장된 연결</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">저장된 연결 없음</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">데이터를 사용할 수 없음</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">파일 브라우저 트리</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">모두 선택/모두 선택 취소</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">시작</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">필터 표시</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">끝</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">모두 선택</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">새 방화벽 규칙 만들기</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">검색</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0}개 결과</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">{0} 선택됨</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">오름차순 정렬</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">내림차순 정렬</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">확인</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">지우기</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">취소</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">클라이언트 IP 주소에서 서버에 액세스할 수 없습니다. Azure 계정에 로그인하고 액세스를 허용하는 새 방화벽 규칙을 만드세요.</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">방화벽 설정에 대한 자세한 정보</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">방화벽 규칙</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">내 클라이언트 IP 추가 </target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">내 서브넷 IP 범위 추가</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">필터 옵션</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">모든 파일</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">로드</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">다음 경로에서 쿼리 파일을 찾을 수 없습니다. 
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">로드 오류...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">이 계정의 자격 증명을 새로 고쳐야 합니다.</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">자세히 전환</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">자동 업데이트 확인을 사용하도록 설정합니다. Azure Data Studio에서 정기적으로 업데이트를 자동 확인합니다.</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">새로운 Azure Data Studio 버전을 Windows 백그라운드에 다운로드 및 설치하려면 사용하도록 설정</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">업데이트 후 릴리스 정보를 표시합니다. 릴리스 정보는 새 웹 브라우저 창에서 열립니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">대시보드 도구 모음 작업 메뉴</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">전자 필기장 셀 제목 메뉴</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">전자 필기장 제목 메뉴</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">전자 필기장 도구 모음 메뉴</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">dataexplorer 뷰 컨테이너 제목 작업 메뉴</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">dataexplorer 항목 상황에 맞는 메뉴</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">개체 탐색기 항목 상황에 맞는 메뉴</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">연결 대화 상자의 찾아보기 트리 상황에 맞는 메뉴</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">데이터 약식 표 항목 상황에 맞는 메뉴</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">확장을 다운로드하기 위한 보안 정책을 설정합니다.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">확장 정책에서 확장 설치를 허용하지 않습니다. 확장 정책을 변경하고 다시 시도하세요.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">VSIX의 {0} 확장 설치가 완료되었습니다. Azure Data Studio를 다시 로드하여 사용하도록 설정하세요.</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">Azure Data Studio를 다시 로드하여 이 확장의 제거를 완료하세요.</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">업데이트된 확장을 사용하도록 설정하려면 Azure Data Studio를 다시 로드하세요.</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">이 확장을 로컬에서 사용하려면 Azure Data Studio를 다시 로드하세요.</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">이 확장을 사용하려면 Azure Data Studio를 다시 로드하세요.</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">이 확장을 사용하지 않으려면 Azure Data Studio를 다시 로드하세요.</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">Azure Data Studio를 다시 로드하여 이 확장 {0}의 제거를 완료하세요.</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">{0}에서 이 확장을 사용하도록 설정하려면 Azure Data Studio를 다시 로드하세요.</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">{0} 확장 설치가 완료되었습니다. Azure Data Studio를 다시 로드하여 사용하도록 설정하세요.</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">Azure Data Studio를 다시 로드하고 {0} 확장의 재설치를 완료하세요.</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Marketplace</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">확장 권장 사항의 시나리오 유형을 제공해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">'Azure Data Studio '{1}'과(와) 호환되지 않으므로 확장 '{0}'을(를) 설치할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">새 쿼리</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">새 쿼리(&amp;&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">새 Notebook(&amp;&amp;N)</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">큰 파일을 열려고 할 때 다시 시작한 후 Azure Data Studio에 사용 가능한 메모리를 제어합니다. 명령줄에 '--max-memory=NEWSIZE'를 지정하는 것과 결과가 같습니다.</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">Azure Data Studio의 UI 언어를 {0}(으)로 변경하고 다시 시작하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">{0}에서 Azure Data Studio를 사용하려면 Azure Data Studio를 다시 시작해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">새 SQL 파일</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">새 Notebook</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">VSIX 패키지에서 확장 설치</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">목록에 있는 옵션이어야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">Box 선택</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">Notebook 표시</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">검색 결과</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">검색 경로를 찾을 수 없음: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebook</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">이미지 복사가 지원되지 않습니다.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">현재 쿼리에 포커스</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">쿼리 실행</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">현재 쿼리 실행</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">결과와 함께 쿼리 복사</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">쿼리 및 결과를 복사했습니다.</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">실제 계획에 따라 현재 쿼리 실행</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">쿼리 취소</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">IntelliSense 캐시 새로 고침</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">쿼리 결과 전환</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">쿼리와 결과 간 포커스 전환</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">바로 가기를 실행하려면 편집기 매개 변수가 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">쿼리 구문 분석</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">명령을 완료했습니다.</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">명령 실패: </target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">서버에 연결하세요.</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">같은 이름의 서버 그룹이 이미 있습니다.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">성공</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">실패</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">진행 중</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">시작되지 않음</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">취소됨</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">취소 중</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">대시보드에 사용되는 위젯</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">제공한 데이터로 차트를 표시할 수 없습니다.</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">대시보드에 사용되는 위젯</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">대시보드에 사용되는 위젯</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">대시보드에 사용되는 위젯</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">링크를 여는 동안 오류 발생: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">'{0}' 명령을 실행하는 동안 오류 발생: {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">{0} 오류를 나타내며 복사 실패</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">차트 표시</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">테이블 표시</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;편집하려면 두 번 클릭&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;여기에 콘텐츠를 추가...&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">'{0}' 노드를 새로 고치는 동안 오류가 발생했습니다. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">완료</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">스크립트 생성</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">다음</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">이전</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">탭이 초기화되지 않았습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated">이(가) 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">잘못된 입력입니다. 숫자 값이 필요합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">백업 파일 경로</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">대상 데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">복원</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">데이터베이스 복원</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">백업 파일</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">데이터베이스 복원</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">스크립트</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">원본</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">복원할 원본 위치</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">백업 파일 경로가 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">하나 이상의 파일 경로를 쉼표로 구분하여 입력하세요.</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">대상</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">복원 위치</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">복원 계획</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">복원할 백업 세트</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">데이터베이스 파일을 다음으로 복원</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">데이터베이스 파일 복원 세부 정보</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">논리적 파일 이름</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">파일 형식</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">원래 파일 이름</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">다음으로 복원</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">복원 옵션</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">비상 로그 백업</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">서버 연결</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">일반</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">파일</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">옵션</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">셀 복사</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">완료</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">복사 및 열기</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">사용자 코드</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">웹 사이트</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">{0} 인덱스가 잘못되었습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">서버 설명(옵션)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">고급 속성</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">삭제</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">nbformat v{0}.{1}이(가) 인식되지 않습니다.</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">이 파일에 유효한 Notebook 형식이 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">알 수 없는 셀 형식 {0}</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">출력 형식 {0}을(를) 인식할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">{0}의 데이터는 문자열 또는 문자열 배열이어야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">출력 형식 {0}을(를) 인식할 수 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">시작</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 관리 팩</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 관리 팩</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">SQL Server 관리 팩은 SQL Server를 관리하는 데 도움이 되는 인기 있는 데이터베이스 관리 확장 컬렉션입니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Azure Data Studio에 제공되는 다양한 기능의 쿼리 편집기를 사용하여 PowerShell 스크립트 작성 및 실행</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">데이터 가상화</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">SQL Server 2019로 데이터를 가상화하고 대화형 마법사를 사용하여 외부 테이블 만들기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">Azure Data Studio를 사용하여 Postgres 데이터베이스 연결, 쿼리 및 관리</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">{0}에 대한 지원이 이미 설치되어 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">{0}에 대한 추가 지원을 설치한 후 창이 다시 로드됩니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">{0}에 대한 추가 지원을 설치하는 중...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">ID가 {1}인 {0}에 대한 지원을 찾을 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">새 연결</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">새 쿼리</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">새 Notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">서버 배포</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">시작</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">새로 만들기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">열기...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">파일 열기...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">폴더 열기...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">둘러보기 시작</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">빠른 둘러보기 표시줄 닫기</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">Azure Data Studio를 빠르게 둘러보시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">환영합니다!</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">경로가 {1}인 {0} 폴더 열기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">설치</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">{0} 키맵 설치</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">{0}에 대한 추가 지원 설치</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">설치됨</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">{0} 키맵이 이미 설치되어 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">{0} 지원이 이미 설치되어 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">세부 정보</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">시작 페이지 배경색입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">이벤트 텍스트의 Profiler 편집기. 읽기 전용</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">결과를 저장하지 못했습니다. </target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">결과 파일 선택</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV(쉼표로 구분)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Excel 통합 문서</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">일반 텍스트</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">파일을 저장하는 중...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">{0}에 결과를 저장함</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">파일 열기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">텍스트 레이블 숨기기</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">텍스트 레이블 표시</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">뷰 모델용 modelview 코드 편집기입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">정보</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">경고</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">오류</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">세부 정보 표시</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">복사</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">닫기</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">뒤로</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">세부 정보 숨기기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">계정</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">연결된 계정</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">닫기</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">연결된 계정이 없습니다. 계정을 추가하세요.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">계정 추가</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">클라우드를 사용할 수 없습니다. [설정] -&gt; [Azure 계정 구성 검색] -&gt; [하나 이상의 클라우드 사용]으로 이동합니다.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">인증 공급자를 선택하지 않았습니다. 다시 시도하세요.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">예기치 않은 오류로 인해 실행하지 못했습니다. {0}	{1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">총 실행 시간: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">줄 {0}에서 쿼리 실행을 시작함</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">일괄 처리 {0} 실행을 시작함</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">일괄 처리 실행 시간: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">{0} 오류를 나타내며 복사 실패</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">시작</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">새 연결</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">새 쿼리</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">새 Notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">파일 열기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">파일 열기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">배포</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">새 배포...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">최근 항목</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">자세히...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">최근 폴더 없음</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">도움말</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">시작</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">설명서</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">문제 또는 기능 요청 보고</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">GitHub 리포지토리</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">릴리스 정보</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">시작 시 시작 페이지 표시</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">사용자 지정</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">확장</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">SQL Server 관리자 팩 등을 포함하여 필요한 확장 다운로드</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">바로 가기 키</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">즐겨 찾는 명령을 찾아 사용자 지정</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">색 테마</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">편집기 및 코드를 원하는 방식으로 표시</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">학습</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">모든 명령 찾기 및 실행</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">명령 팔레트({0})에서 명령을 빠른 액세스 및 검색</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">최신 릴리스의 새로운 기능 알아보기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">매월 새로운 기능을 보여주는 새로운 월간 블로그 게시물</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Twitter에서 팔로우</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">커뮤니티가 Azure Data Studio를 사용하는 방식과 엔지니어와 직접 대화하는 방법을 최신 상태로 유지하세요.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">연결 끊기</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">시작</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">새 세션</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">일시 중지</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">재개</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">중지</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">데이터 지우기</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">데이터를 지우시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">자동 스크롤: 켜기</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">자동 스크롤: 끄기</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">축소된 패널로 전환</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">열 편집</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">다음 문자열 찾기</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">이전 문자열 찾기</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Profiler 시작</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">필터...</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">필터 지우기</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">필터를 지우시겠습니까?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">이벤트(필터링됨): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">이벤트: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">이벤트 수</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">데이터를 사용할 수 없음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">결과</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">메시지</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">개체에 대해 스크립트 선택을 호출할 때 스크립트가 반환되지 않았습니다. </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">선택</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">만들기</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">삽입</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">업데이트</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">삭제</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">개체 {1}에서 {0}(으)로 스크립팅했으나 스크립트가 반환되지 않았습니다.</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">스크립트 실패</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">{0}(으)로 스크립팅했으나 스크립트가 반환되지 않았습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">테이블 헤더 배경색</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">테이블 헤더 전경색</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">목록/테이블이 활성 상태일 때 포커스가 있는 선택한 항목의 목록/테이블 배경색</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">셀 윤곽선의 색입니다.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">입력 상자 배경을 사용하지 않도록 설정했습니다.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">입력 상자 전경을 사용하지 않도록 설정했습니다.</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">포커스가 있는 경우 단추 윤곽선 색입니다.</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">확인란 전경을 사용하지 않도록 설정했습니다.</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">SQL 에이전트 테이블 배경색입니다.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">SQL 에이전트 테이블 셀 배경색입니다.</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">가리킨 경우 SQL 에이전트 테이블 배경색입니다.</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">SQL 에이전트 제목 배경색입니다.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">SQL 에이전트 테이블 셀 테두리 색입니다.</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">결과 메시지 오류 색입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">백업 이름</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">복구 모델</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">백업 유형</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">백업 파일</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">알고리즘</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">인증서 또는 비대칭 키</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">미디어</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">기존 미디어 세트에 백업</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">새 미디어 세트에 백업</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">기존 백업 세트에 추가</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">모든 기존 백업 세트 덮어쓰기</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">새 미디어 세트 이름</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">새 미디어 세트 설명</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">미디어에 쓰기 전에 체크섬 수행</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">완료되면 백업 확인</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">오류 발생 시 계속</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">만료</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">백업 보존 기간(일) 설정</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">복사 전용 백업</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">고급 구성</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">압축</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">백업 압축 설정</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">암호화</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">트랜잭션 로그</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">트랜잭션 로그 잘라내기</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">비상 로그 백업</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">안정성</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">미디어 이름이 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">사용 가능한 인증서 또는 비대칭 키가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">파일 추가</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">파일 제거</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">잘못된 입력입니다. 값은 0보다 크거나 같아야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">스크립트</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">백업</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">파일로 백업만 지원됩니다.</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">백업 파일 경로가 필요합니다.</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">이 데이터 공급자에 대해 사용하지 않도록 설정한 다른 형식으로 결과를 저장하고 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">공급자가 등록되지 않은 경우 데이터를 직렬화할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">알 수 없는 오류로 인해 serialization에 실패했습니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">보기 데이터를 제공할 수 있는 등록된 데이터 공급자가 없습니다.</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">테이블 헤더 배경색</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">새로 고침</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">테이블 헤더 전경색</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">모두 축소</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">목록/테이블이 활성 상태일 때 포커스가 있는 선택한 항목의 목록/테이블 배경색</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">오류 실행 명령 {1}: {0}. 이는 {1}을(를) 제공하는 확장으로 인해 발생할 수 있습니다.</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">셀 윤곽선의 색입니다.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">입력 상자 배경을 사용하지 않도록 설정했습니다.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">입력 상자 전경을 사용하지 않도록 설정했습니다.</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">포커스가 있는 경우 단추 윤곽선 색입니다.</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">확인란 전경을 사용하지 않도록 설정했습니다.</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">SQL 에이전트 테이블 배경색입니다.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">SQL 에이전트 테이블 셀 배경색입니다.</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">가리킨 경우 SQL 에이전트 테이블 배경색입니다.</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">SQL 에이전트 제목 배경색입니다.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">SQL 에이전트 테이블 셀 테두리 색입니다.</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">결과 메시지 오류 색입니다.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">활성 셀을 선택하고 다시 시도하세요.</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">로드된 확장 중 일부는 사용되지 않는 API를 사용하고 있습니다. 개발자 도구 창의 콘솔 탭에서 자세한 정보를 확인하세요.</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">셀 실행</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">실행 취소</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">마지막 실행 시 오류가 발생했습니다. 다시 실행하려면 클릭하세요.</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">다시 표시 안 함</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">작업을 취소하지 못했습니다.</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">스크립트</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">자세히 전환</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">로드</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">홈</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">"{0}" 섹션에 잘못된 내용이 있습니다. 확장 소유자에게 문의하세요.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">작업</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">경고</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">프록시</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">연산자</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">서버 속성</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">데이터베이스 속성</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">모두 선택/모두 선택 취소</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">필터 표시</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">확인</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">지우기</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">최근 연결</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">서버</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">서버</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">백업 파일</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">모든 파일</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">검색: 검색어를 입력하고 Enter 키를 눌러서 검색하세요. 취소하려면 Esc 키를 누르세요.</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">검색</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">데이터베이스를 변경하지 못함</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">마지막 발생</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">사용</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">응답 간격(초)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">범주 이름</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">전자 메일 주소</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">사용</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">계정 이름</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">자격 증명 이름</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">설명</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">사용</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">개체 로드</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">데이터베이스 로드</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">개체 로드가 완료되었습니다.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">데이터베이스 로드가 완료되었습니다.</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">형식 이름(t:, v:, f: 또는 sp:)으로 검색</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">데이터베이스 검색</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">개체를 로드할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">데이터베이스를 로드할 수 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">속성 로드</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">속성 로드 완료</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">대시보드 속성을 로드할 수 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">{0} 로드</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">{0} 로드 완료</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">자동 새로 고침: 꺼짐</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">최종 업데이트: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">표시할 결과 없음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">단계</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">CSV로 저장</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">JSON으로 저장</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Excel로 저장</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">XML로 저장</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">JSON으로 내보낼 때 결과 인코딩이 저장되지 않습니다. 파일이 만들어지면 원하는 인코딩으로 저장해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">백업 데이터 원본에서 파일로 저장하도록 지원하지 않습니다.</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">복사</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">복사(머리글 포함)</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">모두 선택</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">최대화</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">복원</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">차트</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">시각화 도우미</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">F5 바로 가기 키를 사용하려면 코드 셀을 선택해야 합니다. 실행할 코드 셀을 선택하세요.</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">명확한 결과를 얻으려면 코드 셀을 선택해야 합니다. 실행할 코드 셀을 선택하세요.</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">단계 ID</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">완료</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">단계 이름</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">메시지</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">스크립트 생성</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">다음</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">이전</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">탭이 초기화되지 않았습니다.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">찾기</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">ID가 '{0}'인 등록된 트리 뷰가 없습니다.</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">찾기</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">유효한 providerId가 있는 NotebookProvider를 이 메서드에 전달해야 합니다.</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">이전 검색 결과</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">Notebook 공급자가 없음</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">다음 검색 결과</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">관리자를 찾을 수 없음</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">{0} Notebook의 Notebook 관리자에 서버 관리자가 없습니다. 작업을 수행할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">{0} Notebook의 Notebook 관리자에 콘텐츠 관리자가 없습니다. 작업을 수행할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">{0} Notebook의 Notebook 관리자에 세션 관리자가 없습니다. 작업을 수행할 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">유효한 providerId가 있는 NotebookProvider를 이 메서드에 전달해야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">관리</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">세부 정보 표시</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">자세한 정보</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">저장된 모든 계정 지우기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">미리 보기 기능</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">해제되지 않은 미리 보기 기능 사용</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">시작 시 연결 대화 상자 표시</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">사용되지 않는 API 알림</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">사용되지 않는 API 사용 알림 사용/사용 안 함</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">연결하지 못한 데이터 세션 편집</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">연결되지 않음</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">{0} 서버에서 XEvent Profiler 세션이 예기치 않게 중지되었습니다.</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">새로운 세션을 시작하는 동안 오류가 발생했습니다.</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">{0}의 XEvent Profiler 세션에서 이벤트가 손실되었습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">작업 표시</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">리소스 뷰어</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">정보</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">경고</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">오류</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">세부 정보 표시</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">복사</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">닫기</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">많은 수의 검색 결과가 반환되었습니다. 처음 999개의 일치 항목만 강조 표시됩니다.</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">뒤로</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">결과 없음</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">세부 정보 숨기기</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">가로 막대</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">막대형</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">꺾은선형</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">원형</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">분산형</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">시계열</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">이미지</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">개수</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">테이블</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">도넛형</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">데이터 세트의 행을 차트로 가져오지 못했습니다.</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">차트 종류 '{0}'은(는) 지원되지 않습니다.</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">매개 변수</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated">이(가) 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">잘못된 입력입니다. 숫자 값이 필요합니다.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">연결 대상</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">{0} 인덱스가 잘못되었습니다.</target>
       </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">비어 있음</target>
+      </trans-unit>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">열의 모든 확인란 선택: {0}</target>
+      </trans-unit>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">작업 표시</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">로드</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">로드 완료</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">잘못된 값</target>
+      </trans-unit>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}. {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">로드 중</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">로드 완료</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">뷰 모델용 modelview 코드 편집기입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">{0} 형식의 구성 요소를 찾을 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">저장하지 않은 파일의 경우 편집기 유형을 변경할 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">상위 1,000개 선택</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Take 10</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Execute로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Alter로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">데이터 편집</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Create로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Drop으로 스크립트</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">개체에 대해 스크립트 선택을 호출할 때 스크립트가 반환되지 않았습니다. </target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">선택</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">만들기</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">삽입</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">업데이트</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">삭제</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">개체 {1}에서 {0}(으)로 스크립팅했으나 스크립트가 반환되지 않았습니다.</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">스크립트 실패</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">{0}(으)로 스크립팅했으나 스크립트가 반환되지 않았습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
         <target state="translated">연결 끊김</target>
       </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">저장되지 않은 연결</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">찾아보기(미리 보기)</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">목록을 필터링하려면 여기에 입력하세요.</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">연결 필터링</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">필터 적용</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">필터 제거</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">필터가 적용됨</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">필터가 제거됨</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">저장된 연결</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">저장된 연결</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">연결 브라우저 트리</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">이 확장은 Azure Data Studio에서 추천됩니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">다시 표시 안 함</target>
-      </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio에는 확장 권장 사항이 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio에는 데이터 시각화를 위한 확장 권장 사항이 있습니다.
-설치한 후에는 시각화 도우미 아이콘을 선택하여 쿼리 결과를 시각화할 수 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">모두 설치</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">권장 사항 표시</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">확장 권장 사항의 시나리오 유형을 제공해야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">이 기능 페이지는 미리 보기로 제공됩니다. 미리 보기 기능은 제품에 영구적으로 포함될 예정인 새로운 기능을 도입합니다. 이와 같은 기능은 안정적이지만 접근성 측면에서 추가적인 개선이 필요합니다. 해당 기능이 개발되는 동안 초기 피드백을 주시면 감사하겠습니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">미리 보기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">연결 만들기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">연결 대화 상자를 통해 데이터베이스 인스턴스에 연결합니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">쿼리 실행</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">쿼리 편집기를 통해 데이터와 상호 작용합니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">Notebook 만들기</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">네이티브 Notebook 편집기를 사용하여 새 Notebook을 빌드합니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">서버 배포</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">선택한 플랫폼에서 관계형 데이터 서비스의 새 인스턴스를 만듭니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">리소스</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">기록</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">위치</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">자세히 표시</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">시작 시 시작 페이지 표시</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">유용한 링크</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">시작</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Azure Data Studio에서 제공하는 기능을 검색하고 기능을 최대한 활용하는 방법을 알아봅니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">설명서</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">PowerShell, API 등의 빠른 시작, 방법 가이드, 참조 자료를 보려면 설명서 센터를 방문합니다.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Azure Data Studio 개요</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Azure Data Studio Notebook 소개 | 데이터 공개됨</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
         <target state="translated">확장</target>
       </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">모두 표시</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">세로 탭의 활성 탭 배경색</target>
       </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">자세한 정보 </target>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">대시보드의 테두리 색</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">대시보드 위젯 제목 색</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">대시보드 위젯 하위 텍스트 색</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">속성 컨테이너 구성 요소에 표시되는 속성 값의 색</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">속성 컨테이너 구성 요소에 표시되는 속성 이름의 색</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">도구 모음 오버플로 그림자 색</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">만든 날짜: </target>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">계정 유형 식별자</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Notebook 오류: </target>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(옵션) UI에서 명령을 나타내는 데 사용되는 아이콘입니다. 파일 경로 또는 테마 지정 가능 구성입니다.</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">작업 오류: </target>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">밝은 테마를 사용하는 경우의 아이콘 경로</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">고정됨</target>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">어두운 테마를 사용하는 경우의 아이콘 경로</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">최근 실행</target>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">계정 공급자에게 아이콘을 제공합니다.</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">지난 실행</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">적용 가능한 규칙 보기</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">{0}에 적용 가능한 규칙 보기</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">평가 호출</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">{0}의 평가 호출</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">스크립트로 내보내기</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">GitHub에서 모든 규칙 보기 및 자세히 알아보기</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">HTML 보고서 만들기</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">보고서가 저장되었습니다. 열어보시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">열기</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">{0} 데이터베이스는 모범 사례를 완전히 준수합니다. 잘하셨습니다!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">차트</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">작업</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">개체</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">예상 비용</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">예상 하위 트리 비용</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">실제 행 수</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">예상 행 수</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">실제 실행 수</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">예상 CPU 비용</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">예상 입출력 비용</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">병렬</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">실제 다시 바인딩 횟수</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">예상 다시 바인딩 횟수</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">실제 되감기 횟수</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">예상 되감기 횟수</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">분할됨</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">상위 작업</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">연결이 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">연결 추가</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">계정 추가...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;기본값&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">로드 중...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">서버 그룹</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;기본값&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">새 그룹 추가...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;저장 안 함&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0}이(가) 필요합니다.</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0}이(가) 잘립니다.</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">암호 저장</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">계정</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">계정 자격 증명 새로 고침</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Azure AD 테넌트</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">이름(옵션)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">고급...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">계정을 선택해야 합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">파일 및 파일 그룹</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">전체</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">차등</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">트랜잭션 로그</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">디스크</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">기본 서버 설정 사용</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">백업 압축</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">백업 압축 안 함</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">서버 인증서</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">비대칭 키</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">Notebook/Book이 포함된 폴더를 열지 않았습니다. </target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">Notebook 열기</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">결과 집합에는 모든 일치 항목의 하위 집합만 포함됩니다. 결과 범위를 좁히려면 검색을 더 세분화하세요.</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">검색 진행 중... - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">'{0}'에 '{1}'을(를) 제외한 결과 없음 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">'{0}'에 결과 없음 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">'{0}'을(를) 제외하는 결과가 없음 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">결과가 없습니다. 구성된 제외에 대한 설정을 검토하고 gitignore 파일을 확인하세요. - </target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">다시 검색</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">검색 취소</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">모든 파일에서 다시 검색</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">설정 열기</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">검색에서 {1}개의 파일에 {0}개의 결과를 반환했습니다.</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">축소 및 확장 전환</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">검색 취소</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">모두 확장</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">모두 축소</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">검색 결과 지우기</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">SQL Server, Azure 등에서 연결을 연결, 쿼리 및 관리합니다.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">다음</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">한 곳에서 사용자 Notebook 또는 Notebook 컬렉션을 만드는 작업을 시작합니다.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">확장</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Microsoft 및 타사 커뮤니티에서 개발한 확장을 설치하여 Azure Data Studio 기능을 확장합니다.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">설정</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">기본 설정에 따라 Azure Data Studio를 사용자 지정합니다. 자동 저장 및 탭 크기 같은 설정을 구성하고, 바로 가기 키를 개인 설정하고, 원하는 색 테마로 전환할 수 있습니다.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">시작 페이지</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">시작 페이지에서 주요 기능, 최근에 연 파일 및 추천 확장을 검색합니다. Azure Data Studio를 시작하는 방법에 관한 자세한 내용은 비디오 및 설명서를 확인하세요.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">마침</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">사용자 시작 둘러보기</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">시작 둘러보기 숨기기</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">자세한 정보</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">도움말</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">행 삭제</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">현재 행 되돌리기</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">메시지 패널</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">복사</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">모두 복사</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">Azure Portal에서 열기</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">로드</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">백업 이름</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">로드 완료</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">복구 모델</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">백업 유형</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">백업 파일</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">알고리즘</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">인증서 또는 비대칭 키</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">미디어</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">기존 미디어 세트에 백업</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">새 미디어 세트에 백업</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">기존 백업 세트에 추가</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">모든 기존 백업 세트 덮어쓰기</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">새 미디어 세트 이름</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">새 미디어 세트 설명</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">미디어에 쓰기 전에 체크섬 수행</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">완료되면 백업 확인</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">오류 발생 시 계속</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">만료</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">백업 보존 기간(일) 설정</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">복사 전용 백업</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">고급 구성</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">압축</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">백업 압축 설정</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">암호화</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">트랜잭션 로그</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">트랜잭션 로그 잘라내기</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">비상 로그 백업</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">안정성</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">미디어 이름이 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">사용 가능한 인증서 또는 비대칭 키가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">파일 추가</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">파일 제거</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">잘못된 입력입니다. 값은 0보다 크거나 같아야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">스크립트</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">백업</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">파일로 백업만 지원됩니다.</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">백업 파일 경로가 필요합니다.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">코드 또는 텍스트 셀을 추가하려면</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ 코드</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">또는</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ 텍스트</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">클릭</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">백업</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">StdIn:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">백업을 사용하려면 미리 보기 기능을 사용하도록 설정해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">백업 명령은 데이터베이스 컨텍스트 외부에서 지원되지 않습니다. 데이터베이스를 선택하고 다시 시도하세요.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL Database에 대해 백업 명령이 지원되지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">백업</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">코드 셀 콘텐츠 확장</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">데이터베이스</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">코드 셀 콘텐츠 축소</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">파일 및 파일 그룹</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">전체</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">차등</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">트랜잭션 로그</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">디스크</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">기본 서버 설정 사용</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">백업 압축</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">백업 압축 안 함</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">서버 인증서</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">비대칭 키</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">XML 실행 계획</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">결과 표</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">셀 추가</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">코드 셀</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">텍스트 셀</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">아래로 셀 이동</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">위로 셀 이동</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">삭제</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">셀 추가</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">코드 셀</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">텍스트 셀</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">SQL 커널 오류</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">Notebook 셀을 실행하려면 연결을 선택해야 합니다.</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">상위 {0}개 행을 표시합니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">마지막 실행</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">다음 실행</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">사용</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">상태</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">범주</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">실행 가능</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">일정</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">마지막 실행 결과</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">이전 실행</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">이 작업에 사용할 수 있는 단계가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">오류: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">{0} 형식의 구성 요소를 찾을 수 없습니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">찾기</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">찾기</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">이전 검색 결과</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">다음 검색 결과</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">닫기</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">많은 수의 검색 결과가 반환되었습니다. 처음 999개의 일치 항목만 강조 표시됩니다.</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">결과 없음</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">스키마</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">형식</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">쿼리 실행</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">출력의 {0}렌더러를 찾을 수 없습니다. MIME 형식이 {1}입니다.</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">안전 </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">선택기 {0}에 대한 구성 요소를 찾을 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">구성 요소 {0} 렌더링 중 오류 발생</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">로드 중...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">로드 중...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">편집</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">끝내기</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">새로 고침</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">작업 표시</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">위젯 삭제</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">클릭하여 고정 해제</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">클릭하여 고정</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">설치된 기능 열기</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">위젯 축소</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">위젯 확장</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0}은(는) 알 수 없는 컨테이너입니다.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">이름</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">대상 데이터베이스</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">마지막 실행</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">다음 실행</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">상태</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">마지막 실행 결과</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">이전 실행</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">이 작업에 사용할 수 있는 단계가 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">오류: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Notebook 오류: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">로드 오류...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">작업 표시</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">일치하는 항목 없음</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">검색 목록을 1개 항목으로 필터링함</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">검색 목록을 {0}개 항목으로 필터링함</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">실패</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">성공</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">다시 시도</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">취소됨</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">진행 중</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">알 수 없는 상태</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">실행 중</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">스레드 대기 중</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">다시 시도 대기 중</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">유휴 상태</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">일시 중지됨</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[사용되지 않음]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">예</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">아니요</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">예약되지 않음</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">실행 안 함</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">굵게</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">기울임꼴</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">밑줄</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">강조 표시</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">코드</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">링크</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">목록</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">순서가 지정된 목록</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">이미지</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Markdown 미리 보기 토글 - 끄기</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">제목</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">제목 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">제목 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">제목 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">단락</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">링크 삽입</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">이미지 삽입</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">서식 있는 텍스트 보기</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">분할 보기</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Markdown 보기</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">인사이트 만들기</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">활성 편집기가 SQL 편집기가 아니므로 인사이트를 만들 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">내 위젯</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">차트 구성</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">이미지로 복사</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">저장할 차트를 찾을 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">이미지로 저장</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">{0} 경로에 차트를 저장함</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">차트</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">가로 막대</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">막대형</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">꺾은선형</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">원형</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">분산형</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">시계열</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">이미지</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">개수</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">테이블</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">도넛형</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">데이터 세트의 행을 차트로 가져오지 못했습니다.</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">차트 종류 '{0}'은(는) 지원되지 않습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">기본 제공 차트</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">표시할 차트의 최대 행 수입니다. 경고:이 수를 늘리면 성능에 영향을 줄 수 있습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">닫기</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">같은 이름의 서버 그룹이 이미 있습니다.</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">시리즈 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">테이블에 유효한 이미지가 포함되어 있지 않습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">기본 제공 차트의 최대 행 수가 초과되어 첫 번째 {0}행만 사용됩니다. 값을 구성하려면 사용자 설정을 열고 'builtinCharts.maxRowCount'를 검색할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">다시 표시 안 함</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">{0}에 연결하는 중</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">명령 {0} 실행 중</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">새 쿼리 {0}을(를) 여는 중</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">서버 정보가 제공되지 않았으므로 연결할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">{0} 오류로 인해 URL을 열 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">이렇게 하면 서버 {0}에 연결됩니다.</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">연결하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">열기(&amp;O)</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">쿼리 파일 연결 중</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">사용자 설정에서 {0}이(가) {1}(으)로 바뀌었습니다.</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">작업 영역 설정에서 {0}이(가) {1}(으)로 바뀌었습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">연결 목록에 저장할 최근에 사용한 최대 연결 수입니다.</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">사용할 기본 SQL 엔진입니다. 해당 엔진은 .sql 파일의 기본 언어 공급자와 새 연결을 만들 때 사용할 기본 공급자를 구동합니다.</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">연결 대화 상자가 열리거나 붙여넣기가 수행되면 클립보드의 내용을 구문 분석하려고 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">연결 상태</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">공급자의 일반 ID</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">공급자의 표시 이름</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">공급자의 Notebook 커널 별칭</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">서버 유형의 아이콘 경로</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">연결 옵션</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">트리 공급자의 사용자 표시 이름</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">공급자 ID는 트리 데이터 공급자를 등록할 때와 동일해야 하며 'connectionDialog/'로 시작해야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">이 컨테이너의 고유 식별자입니다.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">탭에 표시될 컨테이너입니다.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">사용자가 대시보드 추가할 단일 또는 다중 대시보드 컨테이너를 적용합니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">확장용으로 지정된 대시보드 컨테이너에 ID가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">대시보드 컨테이너에 확장용으로 지정된 컨테이너가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">공란 1개에 정확히 1개의 대시보드 컨테이너를 정의해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">확장용 대시보드 컨테이너에 알 수 없는 컨테이너 형식이 정의되었습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">이 탭에 표시할 controlhost입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">"{0}" 섹션에 잘못된 내용이 있습니다. 확장 소유자에게 문의하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">이 탭에 표시되는 위젯 또는 웹 보기의 목록입니다.</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">위젯이나 웹 보기는 확장용 위젯 컨테이너 내부에 있어야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">이 탭에 표시할 모델 지원 보기입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">이 탐색 영역의 고유 식별자입니다. 모든 요청에서 확장으로 전달됩니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(옵션) UI에서 이 탐색 섹션을 나타내는 데 사용되는 아이콘입니다. 파일 경로 또는 테마 지정 가능 구성입니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">밝은 테마를 사용하는 경우의 아이콘 경로</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">어두운 테마를 사용하는 경우의 아이콘 경로</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">사용자에게 표시할 탐색 섹션의 제목입니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">이 탐색 섹션에 표시할 컨테이너입니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">이 탐색 섹션에 표시할 대시보드 컨테이너 목록입니다.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">탐색 섹션에 확장용으로 지정된 제목이 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">탐색 섹션에 확장용으로 지정된 컨테이너가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">공란 1개에 정확히 1개의 대시보드 컨테이너를 정의해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION 내의 NAV_SECTION은 확장용으로 유효하지 않은 컨테이너입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">이 탭에 표시할 웹 보기입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">이 탭에 표시할 위젯 목록입니다.</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">위젯 목록은 확장용 위젯 컨테이너 내에 있어야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">편집</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">끝내기</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">새로 고침</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">작업 표시</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">위젯 삭제</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">클릭하여 고정 해제</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">클릭하여 고정</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">설치된 기능 열기</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">위젯 축소</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">위젯 확장</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0}은(는) 알 수 없는 컨테이너입니다.</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">인사이트 만들기</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">이 탭의 고유 식별자입니다. 모든 요청에서 확장으로 전달됩니다.</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">활성 편집기가 SQL 편집기가 아니므로 인사이트를 만들 수 없습니다.</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">사용자에게 표시할 탭의 제목입니다.</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">내 위젯</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">사용자에게 표시할 이 탭에 대한 설명입니다.</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">차트 구성</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">이 항목을 표시하기 위해 true여야 하는 조건</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">이미지로 복사</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">이 탭과 호환되는 연결 형식을 정의합니다. 설정하지 않으면 기본 연결 형식은 'MSSQL'입니다.</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">저장할 차트를 찾을 수 없습니다.</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">이 탭에 표시할 컨테이너입니다.</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">이미지로 저장</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">이 탭을 항상 표시할지 또는 사용자가 추가할 때만 표시할지입니다.</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">이 탭을 연결 형식의 홈 탭으로 사용할지 여부입니다.</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">{0} 경로에 차트를 저장함</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">이 탭이 속한 그룹의 고유 식별자이며 홈 그룹의 값은 home입니다.</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(선택 사항) UI에서 이 탭을 나타내는 데 사용되는 아이콘입니다. 파일 경로 또는 테마 지정 가능 구성입니다.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">밝은 테마를 사용하는 경우의 아이콘 경로</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">어두운 테마를 사용하는 경우의 아이콘 경로</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">사용자가 대시보드 추가할 단일 또는 다중 탭을 적용합니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">확장용으로 지정한 제목이 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">표시하도록 지정한 설명이 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">확장용으로 지정한 컨테이너가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">공란 1개에 정확히 1개의 대시보드 컨테이너를 정의해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">이 탭 그룹의 고유 식별자입니다.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">탭 그룹의 제목입니다.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">사용자가 대시보드에 추가할 하나 이상의 탭 그룹을 제공합니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">탭 그룹에 ID가 지정되지 않았습니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">탭 그룹에 제목을 지정하지 않았습니다.</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">관리</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">모니터링</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">성능</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">보안</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">문제 해결</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">설정</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">데이터베이스 탭</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">데이터베이스</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">코드 추가</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">관리</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">텍스트 추가</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">대시보드</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">파일 만들기</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">관리</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">내용 {0}을(를) 표시할 수 없습니다.</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">'icon' 속성은 생략하거나, '{dark, light}' 같은 문자열 또는 리터럴이어야 합니다.</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">셀 추가</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">대시보드에 표시할 속성을 정의합니다.</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">코드 셀</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">속성의 레이블로 사용할 값</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">텍스트 셀</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">값을 위해 액세스할 개체의 값</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">모두 실행</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">무시할 값 지정</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">셀</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">무시되거나 값이 없는 경우 표시할 기본값</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">코드</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">대시보드 속성을 정의하기 위한 특성</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">텍스트</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">특성의 ID</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">셀 실행</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">이 특성을 사용할 조건</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; 이전</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">비교할 필드</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">다음 &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">비교에 사용할 연산자</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">이 모델에서 URI가 {0}인 셀을 찾을 수 없습니다.</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">필드를 비교할 값</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">셀 실행 실패 - 자세한 내용은 현재 선택한 셀의 출력 오류를 참조하세요.</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">표시할 데이터베이스 페이지 속성</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">표시할 서버 페이지 속성</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">이 공급자가 대시보드를 지원함을 정의합니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">공급자 ID(예: MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">대시보드에 표시할 속성 값</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">이 항목을 표시하기 위해 true여야 하는 조건</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">위젯의 헤더를 숨길지 여부를 나타냅니다. 기본값은 false입니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">컨테이너의 제목</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">표의 구성 요소 행</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">표에 있는 구성 요소의 rowspan입니다. 기본값은 1입니다. 표의 행 수로 설정하려면 '*'를 사용합니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">표의 구성 요소 열</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">표에 있는 구성 요소의 colspan입니다. 기본값은 1입니다. 표의 열 수로 설정하려면 '*'를 사용합니다.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">이 탭의 고유 식별자입니다. 모든 요청에서 확장으로 전달됩니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">확장 탭을 알 수 없거나 설치하지 않았습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">데이터베이스 속성</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">속성 위젯 사용 또는 사용 안 함</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">표시할 속성 값</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">속성의 표시 이름</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">데이터베이스 정보 개체의 값</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">무시할 특정 값 지정</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">복구 모델</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">마지막 데이터베이스 백업</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">마지막 로그 백업</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">호환성 수준</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">소유자</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">데이터베이스 대시보드 페이지를 사용자 지정합니다.</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">검색</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">데이터베이스 대시보드 탭을 사용자 지정합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">서버 속성</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">속성 위젯 사용 또는 사용 안 함</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">표시할 속성 값</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">속성의 표시 이름</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">서버 정보 개체의 값</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">버전</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">버전</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">컴퓨터 이름</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">OS 버전</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">검색</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">서버 대시보드 페이지를 사용자 지정합니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">서버 대시보드 탭을 사용자 지정합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">홈</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">데이터베이스를 변경하지 못함</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">작업 표시</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">일치하는 항목 없음</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">검색 목록을 1개 항목으로 필터링함</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">검색 목록을 {0}개 항목으로 필터링함</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">스키마</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">형식</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">개체 로드</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">데이터베이스 로드</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">개체 로드가 완료되었습니다.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">데이터베이스 로드가 완료되었습니다.</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">형식 이름(t:, v:, f: 또는 sp:)으로 검색</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">데이터베이스 검색</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">개체를 로드할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">데이터베이스를 로드할 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">쿼리 실행</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">{0} 로드</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">{0} 로드 완료</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">자동 새로 고침: 꺼짐</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">최종 업데이트: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">표시할 결과 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">서버 또는 데이터베이스를 쿼리하고 여러 방법(차트, 요약 개수 등)으로 결과를 표시할 수 있는 위젯을 추가합니다.</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">인사이트의 결과를 캐싱하는 데 사용되는 고유 식별자입니다.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">실행할 SQL 쿼리입니다. 정확히 1개의 결과 집합을 반환해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[옵션] 쿼리를 포함하는 파일의 경로입니다. '쿼리'를 설정하지 않은 경우에 사용합니다.</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[옵션] 자동 새로 고침 간격(분)입니다. 설정하지 않으면 자동 새로 고침이 수행되지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">사용할 작업</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">작업의 대상 데이터베이스입니다. '${ columnName }' 형식을 사용하여 데이터 기반 열 이름을 사용할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">작업의 대상 서버입니다. '${ columnName }' 형식을 사용하여 데이터 기반 열 이름을 사용할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">작업의 대상 사용자입니다. '${ columnName }' 형식을 사용하여 데이터 기반 열 이름을 사용할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">인사이트의 식별자</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">대시보드 팔레트에 인사이트를 적용합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">제공한 데이터로 차트를 표시할 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">쿼리 결과를 대시보드에 차트로 표시합니다.</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">'열 이름'을 색에 매핑합니다. 예를 들어, 이 열에 빨간색을 사용하려면 'column1': red를 추가합니다. </target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">차트 범례의 기본 위치 및 표시 여부를 나타냅니다. 이 항목은 쿼리의 열 이름이며, 각 차트 항목의 레이블에 매핑됩니다.</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">dataDirection이 horizontal인 경우, 이 값을 true로 설정하면 범례의 첫 번째 열 값을 사용합니다.</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">dataDirection이 vertical인 경우, 이 값을 true로 설정하면 범례의 열 이름을 사용합니다.</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">데이터를 열(세로)에서 읽어올지 행(가로)에서 읽어올지를 정의합니다. 시계열에서는 방향이 세로여야 하므로 무시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">showTopNData를 설정한 경우 차트에 상위 N개 데이터만 표시합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Y축 최솟값</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Y축 최댓값</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Y축 레이블</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">X축 최솟값</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">X축 최댓값</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">X축 레이블</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">차트 데이터 세트의 데이터 속성을 나타냅니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">결과 세트의 각 열에 대해 행 0의 값을 개수와 열 이름으로 표시합니다. 예를 들어, '1 Healthy', '3 Unhealthy'가 지원됩니다. 여기서 'Healthy'는 열 이름이고 1은 행 1, 셀 1의 값입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">이미지(예: ggplot2를 사용하여 R 쿼리에서 반환한 이미지)를 표시합니다.</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">어떤 형식이 필요한가요? JPEG, PNG 또는 다른 형식인가요?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">16진수, base64 또는 다른 형식으로 인코딩되어 있나요?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">단순 테이블에 결과를 표시합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">속성 로드</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">속성 로드 완료</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">대시보드 속성을 로드할 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">데이터베이스 연결</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">데이터 원본 연결</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">데이터 원본 그룹</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">저장된 연결은 추가된 날짜를 기준으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">저장된 연결은 표시 이름을 기준으로 사전순으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">저장된 연결 및 연결 그룹의 정렬 순서를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">시작 구성</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">Azure Data Studio 시작 시 서버 보기를 표시하려면 True(기본값), 마지막으로 열었던 보기를 표시하려면 False</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">뷰의 식별자입니다. 'vscode.window.registerTreeDataProviderForView' API를 통해 데이터 공급자를 등록하는 데 사용합니다. 'onView:${id}' 이벤트를 'activationEvents'에 등록하여 확장 활성화를 트리거하는 데도 사용합니다.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">사용자가 읽을 수 있는 뷰 이름입니다. 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">이 뷰를 표시하기 위해 true여야 하는 조건</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">뷰를 편집기에 적용합니다.</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">뷰를 작업 막대의 Data Explorer 컨테이너에 적용합니다.</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">뷰를 적용된 뷰 컨테이너에 적용합니다.</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">뷰 컨테이너 '{1}'에서 동일한 ID '{0}'의 여러 뷰를 등록할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">ID가 '{0}'인 뷰가 뷰 컨테이너 '{1}'에 이미 등록되어 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">뷰는 배열이어야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">속성 '{0}'은(는) 필수이며 'string' 형식이어야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">속성 '{0}'은(는) 생략할 수 있으며 'string' 형식이어야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">서버</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">연결 표시</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">연결 끊기</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">새로 고침</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">시작 시 데이터 SQL 편집 창 표시</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">실행</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">오류를 나타내며 편집 내용 삭제 실패: </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">중지</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">SQL 창 표시</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">SQL 창 닫기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">최대 행 수:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">행 삭제</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">현재 행 되돌리기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">CSV로 저장</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">JSON으로 저장</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Excel로 저장</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">XML로 저장</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">복사</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">복사(머리글 포함)</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">모두 선택</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">대시보드 탭({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">제목</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">설명</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">대시보드 인사이트({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">시기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">갤러리에서 확장 정보를 가져옵니다.</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">확장 ID</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">'{0}' 확장을 찾을 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">권장 사항 표시</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">확장 설치</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">확장 제작...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">다시 표시 안 함</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio에는 확장 권장 사항이 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio에는 데이터 시각화를 위한 확장 권장 사항이 있습니다.
+설치한 후에는 시각화 도우미 아이콘을 선택하여 쿼리 결과를 시각화할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">모두 설치</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">권장 사항 표시</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">확장 권장 사항의 시나리오 유형을 제공해야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">이 확장은 Azure Data Studio에서 추천됩니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">작업</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">경고</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">프록시</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">연산자</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">마지막 발생</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">사용</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">응답 간격(초)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">범주 이름</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">적용 가능한 규칙 보기</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">단계 ID</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">{0}에 적용 가능한 규칙 보기</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">단계 이름</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">평가 호출</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">{0}의 평가 호출</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">스크립트로 내보내기</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">GitHub에서 모든 규칙 보기 및 자세히 알아보기</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">HTML 보고서 만들기</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">보고서가 저장되었습니다. 열어보시겠습니까?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">열기</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">취소</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">메시지</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">데이터</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">연결</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">쿼리 편집기</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">대시보드</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">단계</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">대시보드 탭({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">제목</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">설명</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">대시보드 인사이트({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">이름</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">시기</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">마지막 실행</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">다음 실행</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">사용</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">상태</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">범주</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">실행 가능</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">일정</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">마지막 실행 결과</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">이전 실행</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">이 작업에 사용할 수 있는 단계가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">오류: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">테이블에 유효한 이미지가 포함되어 있지 않습니다.</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">만든 날짜: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Notebook 오류: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">작업 오류: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">고정됨</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">최근 실행</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">지난 실행</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">자세히</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">편집</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">대상 데이터베이스</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">닫기</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">마지막 실행</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">셀 변환</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">다음 실행</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">위 셀 실행</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">상태</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">아래 셀 실행</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">마지막 실행 결과</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">위에 코드 삽입</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">이전 실행</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">아래에 코드 삽입</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">이 작업에 사용할 수 있는 단계가 없습니다.</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">위에 텍스트 삽입</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">오류: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">아래에 텍스트 삽입</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">셀 축소</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">셀 확장</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">매개 변수 셀 만들기</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">매개 변수 셀 제거</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">결과 지우기</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Notebook 오류: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">Notebook 세션을 시작하는 동안 오류가 발생했습니다.</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">알 수 없는 이유로 서버가 시작되지 않았습니다.</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">전자 메일 주소</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">{0} 커널을 찾을 수 없습니다. 대신 기본 커널이 사용됩니다.</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">사용</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">시리즈 {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">계정 이름</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">닫기</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">자격 증명 이름</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="ko">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated"># 삽입된 매개 변수
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">설명</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">이 커널에 대해 셀을 실행하려면 연결을 선택하세요.</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">셀을 삭제하지 못했습니다.</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">커널을 변경하지 못했습니다. {0} 커널이 사용됩니다. 오류: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">오류로 인해 커널을 변경하지 못했습니다. {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">{0} 컨텍스트를 변경하지 못했습니다.</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">{0} 세션을 시작할 수 없습니다.</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">Notebook을 닫는 동안 클라이언트 세션 오류가 발생했습니다. {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">{0} 공급자의 Notebook 관리자를 찾을 수 없습니다.</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">사용</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">자세히</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">편집</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">닫기</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">셀 변환</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">위 셀 실행</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">아래 셀 실행</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">위에 코드 삽입</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">아래에 코드 삽입</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">위에 텍스트 삽입</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">아래에 텍스트 삽입</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">셀 축소</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">셀 확장</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">매개 변수 셀 만들기</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">매개 변수 셀 제거</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">결과 지우기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">셀 추가</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">코드 셀</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">텍스트 셀</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">아래로 셀 이동</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">위로 셀 이동</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">삭제</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">셀 추가</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">코드 셀</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">텍스트 셀</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">매개 변수</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">활성 셀을 선택하고 다시 시도하세요.</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">셀 실행</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">실행 취소</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">마지막 실행 시 오류가 발생했습니다. 다시 실행하려면 클릭하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">코드 셀 콘텐츠 확장</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">코드 셀 콘텐츠 축소</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">굵게</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">기울임꼴</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">밑줄</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">강조 표시</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">코드</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">링크</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">목록</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">순서가 지정된 목록</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">이미지</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Markdown 미리 보기 토글 - 끄기</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">제목</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">제목 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">제목 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">제목 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">단락</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">링크 삽입</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">이미지 삽입</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">서식 있는 텍스트 보기</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">분할 보기</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Markdown 보기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">출력의 {0}렌더러를 찾을 수 없습니다. MIME 형식이 {1}입니다.</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">안전 </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">선택기 {0}에 대한 구성 요소를 찾을 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">구성 요소 {0} 렌더링 중 오류 발생</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">코드 또는 텍스트 셀을 추가하려면</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ 코드</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">또는</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ 텍스트</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">클릭</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">코드 셀 추가</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">텍스트 셀 추가</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">StdIn:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;편집하려면 두 번 클릭&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;여기에 콘텐츠를 추가...&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">찾기</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">찾기</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">이전 검색 결과</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">다음 검색 결과</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">닫기</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">많은 수의 검색 결과가 반환되었습니다. 처음 999개의 일치 항목만 강조 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">결과 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">코드 추가</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">텍스트 추가</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">파일 만들기</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">내용 {0}을(를) 표시할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">셀 추가</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">코드 셀</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">텍스트 셀</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">모두 실행</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">셀</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">코드</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">텍스트</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">셀 실행</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; 이전</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">다음 &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">이 모델에서 URI가 {0}인 셀을 찾을 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">셀 실행 실패 - 자세한 내용은 현재 선택한 셀의 출력 오류를 참조하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">새 Notebook</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">새 Notebook</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">작업 영역 설정 및 열기</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">SQL 커널: 셀에서 오류가 발생하면 Notebook 실행을 중지합니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(미리 보기) 현재 Notebook 공급자의 모든 커널을 표시합니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">Notebook이 Azure Data Studio 명령을 실행하도록 허용합니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">두 번 클릭을 사용하여 Notebook에서 텍스트 셀 편집</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">텍스트는 서식 있는 텍스트로 표시됩니다(이 텍스트는 WYSIWYG라고도 함).</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">Markdown은 왼쪽에 표시되고, 오른쪽에는 렌더링된 텍스트의 미리 보기가 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">텍스트가 Markdown으로 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">텍스트 셀에 사용되는 기본 편집 모드</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(미리 보기) 연결 이름을 Notebook 메타데이터에 저장합니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">Notebook markdown 미리 보기에서 사용되는 줄 높이를 제어합니다. 해당 숫자는 글꼴 크기에 상대적입니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(미리 보기) diff 편집기에서 렌더링된 전자 필기장을 표시합니다.</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">전자 필기장 서식 있는 텍스트 편집기의 실행 취소 기록에 저장된 최대 변경 내용 수입니다.</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">Notebook 검색</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">전체 텍스트 검색 및 빠른 열기에서 glob 패턴을 구성하여 파일 및 폴더를 제외합니다. `#files.exclude#` 설정에서 모든 glob 패턴을 상속합니다. [여기](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)에서 glob 패턴에 대해 자세히 알아보세요.</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">파일 경로를 일치시킬 GLOB 패턴입니다. 패턴을 사용하거나 사용하지 않도록 설정하려면 true 또는 false로 설정하세요.</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">일치하는 파일의 형제에 대한 추가 검사입니다. $(basename)을 일치하는 파일 이름에 대한 변수로 사용하세요.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">이 설정은 사용되지 않으며 이제 "search.usePCRE2"로 대체됩니다.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">사용되지 않습니다. 고급 regex 기능을 지원하려면 "search.usePCRE2"를 사용해 보세요.</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">사용하도록 설정하면 searchService 프로세스가 1시간의 비활성 상태 이후 종료되지 않고 계속 유지됩니다. 메모리에 파일 검색 캐시가 유지됩니다.</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">파일을 검색할 때 '.gitignore' 파일 및 '.ignore' 파일을 사용할지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">파일을 검색할 때 전역 '.gitignore' 및 '.ignore' 파일을 사용할지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">Quick Open에 대한 파일 결과에 전역 기호 검색 결과를 포함할지 여부입니다.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">Quick Open에 대한 파일 결과에 최근에 연 파일의 결과를 포함할지 여부입니다.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">기록 항목은 사용된 필터 값을 기준으로 관련성별로 정렬됩니다. 관련성이 더 높은 항목이 먼저 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">기록이 최신순으로 정렬됩니다. 가장 최근에 열람한 항목부터 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">필터링할 때 빠른 열기에서 편집기 기록의 정렬 순서를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">검색하는 동안 symlink를 누를지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">패턴이 모두 소문자인 경우 대/소문자를 구분하지 않고 검색하고, 그렇지 않으면 대/소문자를 구분하여 검색합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">macOS에서 검색 보기가 공유 클립보드 찾기를 읽거나 수정할지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">검색을 사이드바의 보기로 표시할지 또는 가로 간격을 늘리기 위해 패널 영역의 패널로 표시할지를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">이 설정은 더 이상 사용되지 않습니다. 대신 검색 보기의 컨텍스트 메뉴를 사용하세요.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">결과가 10개 미만인 파일이 확장됩니다. 다른 파일은 축소됩니다.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">검색 결과를 축소 또는 확장할지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">일치하는 항목을 선택하거나 바꿀 때 미리 보기 바꾸기를 열지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">검색 결과의 줄 번호를 표시할지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">텍스트 검색에서 PCRE2 regex 엔진을 사용할지 여부입니다. 사용하도록 설정하면 lookahead 및 backreferences와 같은 몇 가지 고급 regex 기능을 사용할 수 있습니다. 하지만 모든 PCRE2 기능이 지원되지는 않으며, JavaScript에서도 지원되는 기능만 지원됩니다.</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">사용되지 않습니다. PCRE2는 PCRE2에서만 지원하는 regex 기능을 사용할 경우 자동으로 사용됩니다.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">검색 보기가 좁을 때는 오른쪽에, 그리고 검색 보기가 넓을 때는 콘텐츠 바로 뒤에 작업 모음을 배치합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">작업 모음을 항상 오른쪽에 배치합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">검색 보기에서 행의 작업 모음 위치를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">입력할 때 모든 파일을 검색합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">활성 편집기에 선택 항목이 없을 경우 커서에 가장 가까운 단어에서 시드 검색을 사용합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">검색 보기에 포커스가 있을 때 작업 영역 검색 쿼리를 편집기의 선택한 텍스트로 업데이트합니다. 이 동작은 클릭 시 또는 `workbench.views.search.focus` 명령을 트리거할 때 발생합니다.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">'#search.searchOnType#'이 활성화되면 입력되는 문자와 검색 시작 사이의 시간 시간을 밀리초 단위로 제어합니다. 'search.searchOnType'을 사용하지 않도록 설정하면 아무런 효과가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">두 번 클릭하면 커서 아래에 있는 단어가 선택됩니다.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">두 번 클릭하면 활성 편집기 그룹에 결과가 열립니다.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">두 번 클릭하면 측면의 편집기 그룹에 결과가 열리고, 편집기 그룹이 없으면 새로 만듭니다.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">검색 편집기에서 결과를 두 번 클릭하는 효과를 구성합니다.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">결과는 폴더 및 파일 이름의 알파벳 순으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">결과는 폴더 순서를 무시하고 파일 이름별 알파벳 순으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">결과는 파일 확장자의 알파벳 순으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">결과는 파일을 마지막으로 수정한 날짜의 내림차순으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">결과는 파일별 개수의 내림차순으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">결과는 파일별 개수의 오름차순으로 정렬됩니다.</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">검색 결과의 정렬 순서를 제어합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">커널을 로드하는 중...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">커널을 변경하는 중...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">연결 대상 </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">커널 </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">컨텍스트를 로드하는 중...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">연결 변경</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">연결 선택</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">커널 없음</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">커널이 지원되지 않으므로 이 전자 필기장을 매개 변수로 실행할 수 없습니다. 지원되는 커널 및 형식을 사용하세요. [자세한 정보] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">이 전자 필기장은 매개 변수 셀이 추가될 때까지 매개 변수를 사용하여 실행할 수 없습니다. [자세히 알아보기] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">매개 변수 셀에 추가된 매개 변수가 있을 때까지 이 전자 필기장을 매개 변수로 실행할 수 없습니다. [자세한 정보] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">결과 지우기</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">신뢰할 수 있음</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">신뢰할 수 없음</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">셀 축소</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">셀 확장</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">매개 변수를 사용하여 실행</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">없음</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">새 Notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">다음 문자열 찾기</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">이전 문자열 찾기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">검색 결과</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">검색 경로를 찾을 수 없음: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">Notebook/Book이 포함된 폴더를 열지 않았습니다. </target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">Notebook 열기</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">결과 집합에는 모든 일치 항목의 하위 집합만 포함됩니다. 결과 범위를 좁히려면 검색을 더 세분화하세요.</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">검색 진행 중... - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">'{0}'에 '{1}'을(를) 제외한 결과 없음 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">'{0}'에 결과 없음 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">'{0}'을(를) 제외하는 결과가 없음 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">결과가 없습니다. 구성된 제외에 대한 설정을 검토하고 gitignore 파일을 확인하세요. - </target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">다시 검색</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">모든 파일에서 다시 검색</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">설정 열기</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">검색에서 {1}개의 파일에 {0}개의 결과를 반환했습니다.</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">축소 및 확장 전환</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">검색 취소</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">모두 확장</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">모두 축소</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">검색 결과 지우기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">검색: 검색어를 입력하고 Enter 키를 눌러서 검색하세요. 취소하려면 Esc 키를 누르세요.</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">검색</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">이 모델에서 URI가 {0}인 셀을 찾을 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">셀 실행 실패 - 자세한 내용은 현재 선택한 셀의 출력 오류를 참조하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">출력을 보려면 이 셀을 실행하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">이 보기는 비어 있습니다. 셀 삽입 단추를 클릭하여 이 보기에 셀을 추가합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">{0} 오류를 나타내며 복사 실패</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">차트 표시</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">테이블 표시</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">출력의 {0} 렌더러를 찾을 수 없습니다. MIME 형식이 {1}입니다.</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(안전) </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">플롯 그래프 {0}을(를) 표시하는 동안 오류가 발생했습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">연결이 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">연결 추가</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">개체 탐색기 뷰렛에서 사용되는 서버 그룹 색상표입니다.</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">개체 탐색기 뷰렛에서 서버 그룹을 자동으로 확장합니다.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(미리 보기) 동적 노드 필터링과 같은 새로운 기능 지원을 사용하여 서버 보기 및 연결 대화 상자에 새 비동기 서버 트리를 사용합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">데이터</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">쿼리 편집기</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">대시보드</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">기본 제공 차트</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">뷰 템플릿 지정</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">세션 템플릿 지정</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Profiler 필터</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">연결 끊기</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">새 세션</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">일시 중지</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">재개</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">중지</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">데이터 지우기</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">데이터를 지우시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">자동 스크롤: 켜기</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">자동 스크롤: 끄기</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">축소된 패널로 전환</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">열 편집</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">다음 문자열 찾기</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">이전 문자열 찾기</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Profiler 시작</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">필터...</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">필터 지우기</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">필터를 지우시겠습니까?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">뷰 선택</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">세션 선택</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">세션 선택:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">뷰 선택:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">텍스트</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">레이블</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">값</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">세부 정보</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">찾기</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">찾기</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">이전 검색 결과</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">다음 검색 결과</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">닫기</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">많은 수의 검색 결과가 반환되었습니다. 처음 999개의 일치 항목만 강조 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">결과 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">이벤트 텍스트의 Profiler 편집기. 읽기 전용</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">이벤트(필터링됨): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">이벤트: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">이벤트 수</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">CSV로 저장</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">JSON으로 저장</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Excel로 저장</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">XML로 저장</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">JSON으로 내보낼 때 결과 인코딩이 저장되지 않습니다. 파일이 만들어지면 원하는 인코딩으로 저장해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">백업 데이터 원본에서 파일로 저장하도록 지원하지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">복사</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">복사(머리글 포함)</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">모두 선택</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">최대화</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">복원</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">차트</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">시각화 도우미</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">SQL 언어 선택</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">SQL 언어 공급자 변경</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">SQL 언어 버전</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">SQL 엔진 공급자 변경</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">{0} 엔진을 사용하는 연결이 존재합니다. 변경하려면 연결을 끊거나 연결을 변경하세요.</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">현재 활성 텍스트 편집기 없음</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">언어 공급자 선택</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">XML 실행 계획</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">결과 표</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">필터링/정렬에 대한 최대 행 수가 초과되었습니다. 업데이트하려면 사용자 설정으로 이동하여 'queryEditor.results.inMemoryDataProcessingThreshold' 설정을 변경할 수 있습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">현재 쿼리에 포커스</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">쿼리 실행</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">현재 쿼리 실행</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">결과와 함께 쿼리 복사</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">쿼리 및 결과를 복사했습니다.</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">실제 계획에 따라 현재 쿼리 실행</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">쿼리 취소</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">IntelliSense 캐시 새로 고침</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">쿼리 결과 전환</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">쿼리와 결과 간 포커스 전환</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">바로 가기를 실행하려면 편집기 매개 변수가 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">쿼리 구문 분석</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">명령을 완료했습니다.</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">명령 실패: </target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">서버에 연결하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">메시지 패널</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">복사</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">모두 복사</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">쿼리 결과</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">새 쿼리</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">쿼리 편집기</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">true이면 결과를 CSV로 저장할 때 열 머리글이 포함됩니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">CSV로 저장할 때 값 사이에 사용할 사용자 지정 구분 기호</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">결과를 CSV로 저장할 때 행을 분리하는 데 사용하는 문자</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">결과를 CSV로 저장할 때 텍스트 필드를 묶는 데 사용하는 문자</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">결과를 CSV로 저장할 때 사용되는 파일 인코딩</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">true이면 결과를 XML로 저장할 때 XML 출력에 형식이 지정됩니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">결과를 XML로 저장할 때 사용되는 파일 인코딩</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">결과 스트리밍을 사용하도록 설정합니다. 몇 가지 사소한 시각적 문제가 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">결과 뷰에서 결과를 복사하기 위한 구성 옵션</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">결과 뷰에서 여러 줄 결과를 복사하기 위한 구성 옵션</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(실험적) 결과에 최적화된 테이블을 사용합니다. 일부 기능이 누락되거나 작동 중입니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">메모리에서 필터링 및 정렬할 수 있는 최대 행 수를 제어합니다. 숫자를 초과하는 경우 정렬과 필터링이 비활성화됩니다. 경고: 이 항목을 늘리면 성능에 영향을 미칠 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">결과를 저장한 후 Azure Data Studio의 파일을 열지 여부입니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">개별 일괄 처리에 대한 실행 시간 표시 여부</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">메시지 자동 줄 바꿈</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">쿼리 결과에서 차트 뷰어를 열 때 사용할 기본 차트 유형</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">탭 색 지정이 사용하지 않도록 설정됩니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">각 편집기 탭의 상단 테두리는 관련 서버 그룹과 일치하도록 칠해집니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">각 편집기 탭의 배경색이 관련 서버 그룹과 일치합니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">활성 연결의 서버 그룹을 기준으로 탭 색상 지정 방법을 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">제목에 있는 탭에 연결 정보를 표시할지 여부를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">생성된 SQL 파일 저장 여부 확인</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">keybinding workbench.action.query.shortcut{0}를 설정하여 프로시저 호출 또는 쿼리 실행으로 바로 가기 텍스트를 실행합니다. 쿼리 편집기에서 선택한 모든 텍스트는 쿼리 끝에 매개 변수로 전달되거나 {arg}로 참조할 수 있습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">새 쿼리</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">실행</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">설명</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">실제</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">연결 끊기</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">연결 변경</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">SQLCMD 사용</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">SQLCMD 사용 안 함</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">데이터베이스 선택</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">데이터베이스를 변경하지 못함</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">데이터베이스 {0}을(를) 변경하지 못함</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">Notebook으로 내보내기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">결과</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">메시지</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">경과 시간</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">행 개수</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0}개의 행</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">쿼리를 실행하는 중...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">실행 상태</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">선택 요약</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">평균: {0} 개수: {1} 합계: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">결과 표 및 메시지</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">글꼴 패밀리를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">글꼴 두께를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">글꼴 크기(픽셀)를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">문자 간격(픽셀)을 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">행 높이(픽셀)를 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">셀 안쪽 여백(픽셀)을 제어합니다.</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">초기 결과의 열 너비를 자동으로 조정합니다. 열 개수가 많거나 셀이 크면 성능 문제가 발생할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">자동으로 크기가 조정되는 열의 최대 너비(픽셀)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">쿼리 기록 전환</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">삭제</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">모든 기록 지우기</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">쿼리 열기</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">쿼리 실행</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">쿼리 기록 캡처 전환</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">쿼리 기록 캡처 일시 중지</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">쿼리 기록 캡처 시작</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">성공</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">실패</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">표시할 쿼리가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">쿼리 기록</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">QueryHistory</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">쿼리 기록 캡처가 사용하도록 설정되어 있는지 여부입니다. false이면 실행된 쿼리가 캡처되지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">모든 기록 지우기</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">쿼리 기록 캡처 일시 중지</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">쿼리 기록 캡처 시작</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">보기</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">쿼리 기록(&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">쿼리 기록</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">쿼리 계획</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">작업</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">개체</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">예상 비용</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">예상 하위 트리 비용</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">실제 행 수</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">예상 행 수</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">실제 실행 수</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">예상 CPU 비용</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">예상 입출력 비용</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">병렬</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">실제 다시 바인딩 횟수</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">예상 다시 바인딩 횟수</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">실제 되감기 횟수</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">예상 되감기 횟수</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">분할됨</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">상위 작업</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">리소스 뷰어</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">새로 고침</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">링크를 여는 동안 오류 발생: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">'{0}' 명령을 실행하는 동안 오류 발생: {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">리소스 뷰어 트리</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">리소스 식별자입니다.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">사용자가 읽을 수 있는 뷰 이름입니다. 표시됩니다.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">리소스 아이콘의 경로입니다.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">리소스 뷰에 리소스 제공</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">속성 '{0}'은(는) 필수이며 'string' 형식이어야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">속성 '{0}'은(는) 생략할 수 있으며 'string' 형식이어야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">복원</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">복원</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">복원을 사용하려면 미리 보기 기능을 사용하도록 설정해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">복원 명령은 서버 컨텍스트 외부에서 지원되지 않습니다. 서버 또는 데이터베이스를 선택하고 다시 시도하세요.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL Database에 대해 복원 명령이 지원되지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">복원</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Create로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Drop으로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">상위 1,000개 선택</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Execute로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Alter로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">데이터 편집</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">상위 1,000개 선택</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Take 10</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Create로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Execute로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Alter로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Drop으로 스크립트</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">새로 고침</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">'{0}' 노드를 새로 고치는 동안 오류가 발생했습니다. {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">진행 중인 작업 {0}개</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">보기</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">작업</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">작업(&amp;T)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">작업 토글</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">성공</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">실패</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">진행 중</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">시작되지 않음</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">취소됨</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">취소 중</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">표시할 작업 기록이 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">작업 기록</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">작업 오류</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">작업을 취소하지 못했습니다.</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">스크립트</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">보기 데이터를 제공할 수 있는 등록된 데이터 공급자가 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">새로 고침</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">모두 축소</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">오류 실행 명령 {1}: {0}. 이는 {1}을(를) 제공하는 확장으로 인해 발생할 수 있습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">닫기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">미리 보기 기능을 사용하면 새로운 기능 및 개선 사항에 대한 모든 권한을 제공함으로써 Azure Data Studio에서 환경이 개선됩니다. [여기]({0})에서 미리 보기 기능에 관해 자세히 알아볼 수 있습니다. 미리 보기 기능을 사용하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">예(추천)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">아니요, 다시 표시 안 함</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">이 기능 페이지는 미리 보기로 제공됩니다. 미리 보기 기능은 제품에 영구적으로 포함될 예정인 새로운 기능을 도입합니다. 이와 같은 기능은 안정적이지만 접근성 측면에서 추가적인 개선이 필요합니다. 해당 기능이 개발되는 동안 초기 피드백을 주시면 감사하겠습니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">미리 보기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">연결 만들기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">연결 대화 상자를 통해 데이터베이스 인스턴스에 연결합니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">쿼리 실행</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">쿼리 편집기를 통해 데이터와 상호 작용합니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">Notebook 만들기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">네이티브 Notebook 편집기를 사용하여 새 Notebook을 빌드합니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">서버 배포</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">선택한 플랫폼에서 관계형 데이터 서비스의 새 인스턴스를 만듭니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">리소스</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">기록</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">이름</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">위치</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">자세히 표시</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">시작 시 시작 페이지 표시</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">유용한 링크</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Azure Data Studio에서 제공하는 기능을 검색하고 기능을 최대한 활용하는 방법을 알아봅니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">설명서</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">PowerShell, API 등의 빠른 시작, 방법 가이드, 참조 자료를 보려면 설명서 센터를 방문합니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">비디오</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Azure Data Studio 개요</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Azure Data Studio Notebook 소개 | 데이터 공개됨</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">확장</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">모두 표시</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">자세한 정보 </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">SQL Server, Azure 등에서 연결을 연결, 쿼리 및 관리합니다.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">다음</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">한 곳에서 사용자 Notebook 또는 Notebook 컬렉션을 만드는 작업을 시작합니다.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">확장</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Microsoft 및 타사 커뮤니티에서 개발한 확장을 설치하여 Azure Data Studio 기능을 확장합니다.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">설정</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">기본 설정에 따라 Azure Data Studio를 사용자 지정합니다. 자동 저장 및 탭 크기 같은 설정을 구성하고, 바로 가기 키를 개인 설정하고, 원하는 색 테마로 전환할 수 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">시작 페이지</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">시작 페이지에서 주요 기능, 최근에 연 파일 및 추천 확장을 검색합니다. Azure Data Studio를 시작하는 방법에 관한 자세한 내용은 비디오 및 설명서를 확인하세요.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">마침</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">사용자 시작 둘러보기</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">시작 둘러보기 숨기기</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">자세한 정보</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">도움말</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 관리 팩</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 관리 팩</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">SQL Server 관리 팩은 SQL Server를 관리하는 데 도움이 되는 인기 있는 데이터베이스 관리 확장 컬렉션입니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server 에이전트</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server 프로파일러</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">SQL Server 가져오기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server Dacpac</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Azure Data Studio에 제공되는 다양한 기능의 쿼리 편집기를 사용하여 PowerShell 스크립트 작성 및 실행</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">데이터 가상화</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">SQL Server 2019로 데이터를 가상화하고 대화형 마법사를 사용하여 외부 테이블 만들기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">Azure Data Studio를 사용하여 Postgres 데이터베이스 연결, 쿼리 및 관리</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">{0}에 대한 지원이 이미 설치되어 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">{0}에 대한 추가 지원을 설치한 후 창이 다시 로드됩니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">{0}에 대한 추가 지원을 설치하는 중...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">ID가 {1}인 {0}에 대한 지원을 찾을 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">새 연결</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">새 쿼리</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">새 Notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">서버 배포</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">새로 만들기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">열기...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">파일 열기...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">폴더 열기...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">둘러보기 시작</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">빠른 둘러보기 표시줄 닫기</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">Azure Data Studio를 빠르게 둘러보시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">환영합니다!</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">경로가 {1}인 {0} 폴더 열기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">설치</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">{0} 키맵 설치</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">{0}에 대한 추가 지원 설치</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">설치됨</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">{0} 키맵이 이미 설치되어 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">{0} 지원이 이미 설치되어 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">세부 정보</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">시작 페이지 배경색입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">새 연결</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">새 쿼리</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">새 Notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">파일 열기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">파일 열기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">배포</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">새 배포...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">최근 항목</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">자세히...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">최근 폴더 없음</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">도움말</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">설명서</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">문제 또는 기능 요청 보고</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">GitHub 리포지토리</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">릴리스 정보</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">시작 시 시작 페이지 표시</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">사용자 지정</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">확장</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">SQL Server 관리자 팩 등을 포함하여 필요한 확장 다운로드</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">바로 가기 키</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">즐겨 찾는 명령을 찾아 사용자 지정</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">색 테마</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">편집기 및 코드를 원하는 방식으로 표시</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">학습</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">모든 명령 찾기 및 실행</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">명령 팔레트({0})에서 명령을 빠른 액세스 및 검색</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">최신 릴리스의 새로운 기능 알아보기</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">매월 새로운 기능을 보여주는 새로운 월간 블로그 게시물</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Twitter에서 팔로우</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">커뮤니티가 Azure Data Studio를 사용하는 방식과 엔지니어와 직접 대화하는 방법을 최신 상태로 유지하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">계정</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">연결된 계정</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">닫기</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">연결된 계정이 없습니다. 계정을 추가하세요.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">계정 추가</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">클라우드를 사용할 수 없습니다. [설정] -&gt; [Azure 계정 구성 검색] -&gt; [하나 이상의 클라우드 사용]으로 이동합니다.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">인증 공급자를 선택하지 않았습니다. 다시 시도하세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">계정 추가 오류</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">이 계정의 자격 증명을 새로 고쳐야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">닫기</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">계정 추가...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">사용자가 계정 새로 고침을 취소했습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Azure 계정</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Azure 테넌트</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">복사 및 열기</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">사용자 코드</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">웹 사이트</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">자동 OAuth를 시작할 수 없습니다. 자동 OAuth가 이미 진행 중입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">adminservice와 상호 작용하려면 연결이 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">등록된 처리기 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">평가 서비스와 상호 작용하려면 연결이 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">등록된 처리기 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">고급 속성</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">삭제</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">서버 설명(옵션)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">목록 지우기</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">최근 연결 목록을 삭제함</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">목록에서 모든 연결을 삭제하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">삭제</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">현재 연결 문자열 가져오기</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">연결 문자열을 사용할 수 없음</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">사용 가능한 활성 연결이 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">찾아보기</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">목록을 필터링하려면 여기에 입력하세요.</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">연결 필터링</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">필터 적용</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">필터 제거</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">필터가 적용됨</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">필터가 제거됨</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">저장된 연결</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">저장된 연결</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">연결 브라우저 트리</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">연결 오류</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">Kerberos 오류로 인해 연결이 실패했습니다.</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">Kerberos 구성 도움말이 {0}에 있습니다.</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">이전에 연결된 경우 kinit을 다시 실행해야 할 수 있습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">연결 형식</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">최근 항목</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">연결 세부 정보</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">연결</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">최근 연결</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">최근 연결 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">연결을 위한 Azure 계정 토큰을 가져오지 못함</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">연결이 허용되지 않음</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">이 연결을 취소하시겠습니까?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">계정 추가...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;기본값&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">로드 중...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">서버 그룹</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;기본값&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">새 그룹 추가...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;저장 안 함&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0}이(가) 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0}이(가) 잘립니다.</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">암호 저장</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">계정</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">계정 자격 증명 새로 고침</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Azure AD 테넌트</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">이름(옵션)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">고급...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">계정을 선택해야 합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">연결 대상</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">연결 끊김</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">저장되지 않은 연결</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">대시보드 확장 열기</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">현재 설치된 대시보드 확장이 없습니다. 확장 관리자로 가서 권장되는 확장을 살펴보세요.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">{0}단계</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">완료</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">편집 데이터 세션 초기화 실패: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">닫기</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">작업</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">세부 정보 복사</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">오류</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">경고</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">정보</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">무시</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">선택한 경로</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">파일 형식</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">삭제</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">파일 선택</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">파일 브라우저 트리</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">파일 브라우저를 로드하는 동안 오류가 발생했습니다.</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">파일 브라우저 오류</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">모든 파일</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">셀 복사</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">인사이트 플라이아웃에 전달된 연결 프로필이 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">인사이트 오류</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">쿼리 파일을 읽는 동안 오류가 발생했습니다. </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">인사이트 구성을 구문 분석하는 동안 오류가 발생했습니다. 쿼리 배열/문자열이나 쿼리 파일을 찾을 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">항목</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">값</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">인사이트 세부 정보</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">속성</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">값</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">인사이트</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">항목</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">항목 세부 정보</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">다음 경로에서 쿼리 파일을 찾을 수 없습니다. 
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">실패</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">성공</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">다시 시도</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">취소됨</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">진행 중</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">알 수 없는 상태</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">실행 중</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">스레드 대기 중</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">다시 시도 대기 중</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">유휴 상태</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">일시 중지됨</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[사용되지 않음]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">예약되지 않음</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">실행 안 함</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">JobManagementService와 상호 작용하려면 연결이 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">등록된 처리기 없음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">Notebook 세션을 시작하는 동안 오류가 발생했습니다.</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">알 수 없는 이유로 서버가 시작되지 않았습니다.</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">{0} 커널을 찾을 수 없습니다. 대신 기본 커널이 사용됩니다.</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="ko">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="ko">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="ko">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">저장하지 않은 파일의 경우 편집기 유형을 변경할 수 없습니다.</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated"># 삽입된 매개 변수
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">이 커널에 대해 셀을 실행하려면 연결을 선택하세요.</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">셀을 삭제하지 못했습니다.</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">커널을 변경하지 못했습니다. {0} 커널이 사용됩니다. 오류: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">오류로 인해 커널을 변경하지 못했습니다. {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">{0} 컨텍스트를 변경하지 못했습니다.</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">{0} 세션을 시작할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">Notebook을 닫는 동안 클라이언트 세션 오류가 발생했습니다. {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">{0} 공급자의 Notebook 관리자를 찾을 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">Notebook 관리자를 만들 때 URI가 전달되지 않았습니다.</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">Notebook 공급자가 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">이름이 {0}인 보기가 이 전자 필기장에 이미 있습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">SQL 커널 오류</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">Notebook 셀을 실행하려면 연결을 선택해야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">상위 {0}개 행을 표시합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">서식있는 텍스트</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">분할 보기</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">nbformat v{0}.{1}이(가) 인식되지 않습니다.</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">이 파일에 유효한 Notebook 형식이 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">알 수 없는 셀 형식 {0}</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">출력 형식 {0}을(를) 인식할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">{0}의 데이터는 문자열 또는 문자열 배열이어야 합니다.</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">출력 형식 {0}을(를) 인식할 수 없습니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">Notebook 공급자의 식별자입니다.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">이 Notebook 공급자에 등록해야 하는 파일 확장명</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">이 Notebook 공급자에서 표준이어야 하는 커널</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">Notebook 공급자를 적용합니다.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">'%%sql'과(와) 같은 셀 매직의 이름입니다.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">이 셀 매직이 셀에 포함되는 경우 사용되는 셀 언어</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">이 매직이 나타내는 선택적 실행 대상(예: Spark 및 SQL)</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">유효한 선택적 커널 세트(예: python3, pyspark, sql)</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">Notebook 언어를 적용합니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">로드 중...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">새로 고침</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">연결 편집</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">연결 끊기</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">새 연결</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">새 서버 그룹</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">서버 그룹 편집</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">활성 연결 표시</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">모든 연결 표시</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">연결 삭제</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">그룹 삭제</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">개체 탐색기 세션을 만들지 못함</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">여러 오류:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">필요한 연결 공급자 '{0}'을(를) 찾을 수 없으므로 확장할 수 없습니다.</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">사용자가 취소함</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">방화벽 대화 상자를 취소함</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">로드 중...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">최근 연결</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">서버</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">서버</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">이벤트 기준 정렬</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">열 기준 정렬</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">모두 지우기</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">적용</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">필터</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">이 절 제거</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">필터 저장</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">필터 로드</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">절 추가</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">필드</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">연산자</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">값</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">Null임</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">Null이 아님</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">포함</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">포함하지 않음</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">다음으로 시작</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">다음으로 시작하지 않음</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">행 커밋 실패: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">다음에서 쿼리 실행 시작: </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">쿼리 "{0}" 실행을 시작함</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">줄 {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">쿼리 취소 실패: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">셀 업데이트 실패: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">예기치 않은 오류로 인해 실행하지 못했습니다. {0}	{1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">총 실행 시간: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">줄 {0}에서 쿼리 실행을 시작함</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">일괄 처리 {0} 실행을 시작함</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">일괄 처리 실행 시간: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">{0} 오류를 나타내며 복사 실패</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">결과를 저장하지 못했습니다. </target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">결과 파일 선택</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV(쉼표로 구분)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Excel 통합 문서</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">일반 텍스트</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">파일을 저장하는 중...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">{0}에 결과를 저장함</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">파일 열기</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">끝</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">새 방화벽 규칙 만들기</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">클라이언트 IP 주소에서 서버에 액세스할 수 없습니다. Azure 계정에 로그인하고 액세스를 허용하는 새 방화벽 규칙을 만드세요.</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">방화벽 설정에 대한 자세한 정보</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">방화벽 규칙</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">내 클라이언트 IP 추가 </target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">내 서브넷 IP 범위 추가</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">계정 추가 오류</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">방화벽 규칙 오류</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">백업 파일 경로</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">대상 데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">복원</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">데이터베이스 복원</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">백업 파일</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">데이터베이스 복원</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">스크립트</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">원본</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">복원할 원본 위치</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">백업 파일 경로가 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">하나 이상의 파일 경로를 쉼표로 구분하여 입력하세요.</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">데이터베이스</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">대상</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">복원 위치</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">복원 계획</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">복원할 백업 세트</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">데이터베이스 파일을 다음으로 복원</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">데이터베이스 파일 복원 세부 정보</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">논리적 파일 이름</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">파일 형식</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">원래 파일 이름</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">다음으로 복원</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">복원 옵션</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">비상 로그 백업</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">서버 연결</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">일반</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">파일</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">옵션</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">백업 파일</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">모든 파일</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">서버 그룹</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">확인</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">취소</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">서버 그룹 이름</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">그룹 이름이 필요합니다.</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">그룹 설명</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">그룹 색</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">서버 그룹 추가</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">서버 그룹 편집</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">1개 이상의 작업이 진행 중입니다. 그래도 작업을 종료하시겠습니까?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">예</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">아니요</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="ko">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">시작</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">시작 표시</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">시작(&amp;S)</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/admin-tool-ext-win.pt-BR.xlf
+++ b/resources/xlf/pt-br/admin-tool-ext-win.pt-BR.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/pt-br/agent.pt-BR.xlf
+++ b/resources/xlf/pt-br/agent.pt-BR.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">Novo Agendamento</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nome do Agendamento</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Agendamentos</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">Criar Proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">Editar Proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Geral</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">Nome do proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">Nome da credencial</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrição</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">Subsistema</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">Sistema operacional (CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">Instantâneo de Replicação</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">Leitor de Log de Transações de Replicação</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">Distribuidor de Replicação</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">Mesclagem de Replicação</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">Leitor de Fila de Replicação</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">Consulta do SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">Comando do SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">Pacote do SQL Server Integration Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">Ativo para os seguintes subsistemas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">Agendamentos de Trabalho</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">Agendamentos Disponíveis:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrição</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">Criar Operador</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">Editar Operador</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Geral</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notificações</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">Nome do Email</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">Nome do Email do Pager</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">Segunda-feira</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">Terça-feira</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">Quarta-feira</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">Quinta-feira</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">Sexta-feira  </target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">Sábado</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">Domingo</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">Início da jornada de trabalho</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">Fim da jornada de trabalho</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">Agenda do pager de plantão</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">Lista de alerta</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">Nome do alerta</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">Email</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">Pager</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">Geral</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">Agendamentos de Trabalho</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Etapas</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Agendamentos</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Alertas</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">Agendamentos Disponíveis:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Notificações</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">O nome do trabalho não pode ficar em branco.</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Proprietário</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">ID</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Categoria</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">Descrição</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">Lista de etapas do trabalho</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">Etapa</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">Em Caso de Sucesso</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">Em Caso de Falha</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">Nova Etapa</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">Editar Etapa</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">Excluir Etapa</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">Mover a Etapa para Cima</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">Mover a Etapa para Baixo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">Iniciar etapa</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">Ações a executar quando o trabalho for concluído</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">Email</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">Página</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">Escrever no log de eventos de aplicativos do Windows</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">Excluir o trabalho automaticamente</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">Lista de agendamentos</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">Escolha a Agenda</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Nome do Agendamento</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">Lista de alertas</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">Novo Alerta</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">Nome do Alerta</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">Novo Trabalho</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">Editar Trabalho</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">Mensagem de notificação adicional para enviar</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">Atraso entre respostas</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">Minutos de Atraso</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">Criar Operador</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">Editar Operador</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Geral</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notificações</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">Nome do Email</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">Nome do Email do Pager</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">Segunda-feira</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">Terça-feira</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">Quarta-feira</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">Quinta-feira</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">Sexta-feira  </target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">Sábado</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">Domingo</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">Início da jornada de trabalho</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">Fim da jornada de trabalho</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">Agenda do pager de plantão</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">Lista de alerta</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">Nome do alerta</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">Email</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">Pager</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">Falha na atualização do proxy '{0}'</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Geral</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">Proxy '{0}' atualizado com sucesso</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Etapas</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">Proxy '{0}' criado com sucesso</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">Agendamentos</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Alertas</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Notificações</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">O nome do trabalho não pode ficar em branco.</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Proprietário</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Categoria</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrição</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">Lista de etapas do trabalho</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">Etapa</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">Em Caso de Sucesso</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">Em Caso de Falha</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">Nova Etapa</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">Editar Etapa</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">Excluir Etapa</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">Mover a Etapa para Cima</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">Mover a Etapa para Baixo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">Iniciar etapa</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">Ações a executar quando o trabalho for concluído</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">Email</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">Página</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">Escrever no log de eventos de aplicativos do Windows</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">Excluir o trabalho automaticamente</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Lista de agendamentos</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Escolha a Agenda</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Remover agenda</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">Lista de alertas</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">Novo Alerta</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">Nome do Alerta</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">Novo Trabalho</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">Editar Trabalho</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">Falha na atualização da etapa '{0}'</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">O nome do trabalho deve ser fornecido</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">O nome da etapa deve ser fornecido</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">Falha na atualização da etapa '{0}'</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">O nome do trabalho deve ser fornecido</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">O nome da etapa deve ser fornecido</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">Este recurso está em desenvolvimento. Verifique se você gostaria de experimentar as últimas alterações liberadas.</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">O modelo foi atualizado com sucesso</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">Falha na atualização do modelo</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">O bloco de anotações deve ser salvo antes de ser agendado. Salve e tente agendar novamente.</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">Adicionar nova conexão</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">Selecionar uma conexão</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">Selecione uma conexão válida.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">Este recurso está em desenvolvimento. Verifique se você gostaria de experimentar as últimas alterações liberadas.</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">Criar Proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">Editar Proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Geral</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">Nome do proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">Nome da credencial</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrição</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">Subsistema</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">Sistema operacional (CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">Instantâneo de Replicação</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">Leitor de Log de Transações de Replicação</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">Distribuidor de Replicação</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">Mesclagem de Replicação</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">Leitor de Fila de Replicação</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">Consulta do SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">Comando do SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">Pacote do SQL Server Integration Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">Falha na atualização do proxy '{0}'</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">Proxy '{0}' atualizado com sucesso</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">Proxy '{0}' criado com sucesso</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">Novo trabalho do bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">Editar trabalho do bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Geral</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">Detalhes do bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">Caminho do bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">Banco de dados de armazenamento</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">Banco de dados de execução</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Selecionar banco de dados</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">Detalhes do trabalho</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Proprietário</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Lista de agendamentos</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Escolha a agenda</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Remover agenda</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrição</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">Selecione um bloco de anotações a ser agendado no PC</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">Selecione um banco de dados para armazenar todos os metadados e resultados do trabalho do bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">Selecione um banco de dados no qual as consultas de bloco de anotações serão executadas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">Quando o bloco de anotações for concluído</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">Quando o bloco de anotações falha</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">Quando o bloco de anotações é bem-sucedido</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">O nome do bloco de anotações deve ser fornecido</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">O caminho do modelo deve ser fornecido</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">Caminho do bloco de anotações inválido</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">Selecionar banco de dados de armazenamento</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">Banco de dados de execução</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">Já existe um trabalho com nome semelhante</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">Falha na atualização do bloco de anotações '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">Falha na criação do bloco de anotações '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">Bloco de anotações '{0}' atualizado com êxito</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">Bloco de anotações '{0}' criado com êxito</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/azurecore.pt-BR.xlf
+++ b/resources/xlf/pt-br/azurecore.pt-BR.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">Erro ao buscar os grupos de recursos para a conta {0} ({1}), assinatura {2} ({3}) e locatário {4} : {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">Erro ao buscar locais para a conta {0} ({1}) assinatura {2} ({3}) locatário {4} : {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">Consulta inválida</target>
@@ -379,8 +383,8 @@
         <target state="translated">SQL Server – Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
-        <target state="translated">PostgreSQL de Hiperescala habilitado para o Azure Arc</target>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
+        <target state="translated">Hiperescala de PostgreSQL habilitada para Azure Arc</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
         <source xml:lang="en">Unable to open link, missing required values</source>
@@ -411,16 +415,16 @@
         <target state="translated">Erro não identificado com a autenticação do Azure</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
-        <target state="translated">O locatário especificado com a ID '{0}' não foi encontrado.</target>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
+        <target state="translated">Locatário especificado com ID '{0}' não encontrado.</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
         <source xml:lang="en">Something failed with the authentication, or your tokens have been deleted from the system. Please try adding your account to Azure Data Studio again.</source>
         <target state="translated">Ocorreu um erro com a autenticação ou os tokens foram excluídos do sistema. Tente adicionar a sua conta no Azure Data Studio novamente.</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
-        <target state="translated">Houve uma falha na recuperação do token com um erro. Abra as ferramentas para desenvolvedores para exibir o erro</target>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
+        <target state="translated">A recuperação de token falhou com um erro. Abra ferramentas de desenvolvedor para exibir o erro</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
         <source xml:lang="en">No access token returned from Microsoft OAuth</source>
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">Falha ao obter a credencial para a conta {0}. Acesse a caixa de diálogo Contas e atualize a conta.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">Solicitações desta conta foram limitadas. Para tentar novamente, selecione um número menor de assinaturas.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">Ocorreu um erro ao carregar recursos do Azure: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Cluster do Azure Data Explorer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/big-data-cluster.pt-BR.xlf
+++ b/resources/xlf/pt-br/big-data-cluster.pt-BR.xlf
@@ -12,15 +12,15 @@
       </trans-unit>
       <trans-unit id="command.connectController.title">
         <source xml:lang="en">Connect to Existing Controller</source>
-        <target state="new">Connect to Existing Controller</target>
+        <target state="translated">Conectar-se ao Controlador Existente</target>
       </trans-unit>
       <trans-unit id="command.createController.title">
         <source xml:lang="en">Create New Controller</source>
-        <target state="new">Create New Controller</target>
+        <target state="translated">Criar Controlador</target>
       </trans-unit>
       <trans-unit id="command.removeController.title">
         <source xml:lang="en">Remove Controller</source>
-        <target state="new">Remove Controller</target>
+        <target state="translated">Remover Controlador</target>
       </trans-unit>
       <trans-unit id="command.refreshController.title">
         <source xml:lang="en">Refresh</source>
@@ -49,16 +49,136 @@
       <trans-unit id="bdc.view.welcome.connect">
         <source xml:lang="en">No SQL Big Data Cluster controllers registered. [Learn More](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
 [Connect Controller](command:bigDataClusters.command.connectController)</source>
-        <target state="new">No SQL Big Data Cluster controllers registered. [Learn More](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
-[Connect Controller](command:bigDataClusters.command.connectController)</target>
+        <target state="translated">Nenhum controlador do Cluster de Big Data do SQL registrado. [Saiba Mais](https://docs.microsoft.com/sql/big-data-cluster/big-data-cluster-overview)
+[Conectar Controlador](command:bigDataClusters.command.connectController)</target>
       </trans-unit>
       <trans-unit id="bdc.view.welcome.loading">
         <source xml:lang="en">Loading controllers...</source>
-        <target state="new">Loading controllers...</target>
+        <target state="translated">Carregando controladores...</target>
       </trans-unit>
       <trans-unit id="bdc.ignoreSslVerification.desc">
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">Ignorar os erros de verificação do SSL em relação aos pontos de extremidade do Cluster de Big Data do SQL Server, como o HDFS, o Spark e o Controlador, se for true</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">Cluster de Big Data do SQL Server</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">O Cluster de Big Data do SQL Server permite implantar clusters escalonáveis de contêineres do SQL Server, do Spark e do HDFS em execução no Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versão</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">Destino de implantação</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">Novo Cluster do Serviço de Kubernetes do Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">Cluster do Serviço de Kubernetes do Azure existente</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">Cluster do Kubernetes existente (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">Cluster do Red Hat OpenShift no Azure existente</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">Cluster do OpenShift existente</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">Configurações do cluster de Big Data do SQL Server</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">Nome do cluster</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">Nome de usuário do controlador</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">Senha</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">Confirmar a senha</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Configurações do Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">ID da assinatura</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">Usar minha assinatura padrão do Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">Nome do grupo de recursos</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">Região</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">Nome do cluster do AKS</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">Tamanho da VM</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">Contagem de VMs</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">Nome da classe de armazenamento</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">Capacidade de dados (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">Capacidade de logs (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">Aceito {0}, {1} e {2}.</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Política de Privacidade da Microsoft</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">Termos de Licença do azdata</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">Termos de Licença do SQL Server</target>
       </trans-unit>
     </body>
   </file>
@@ -254,299 +374,299 @@
     <body>
       <trans-unit id="bdc.dashboard.status">
         <source xml:lang="en">Status Icon</source>
-        <target state="new">Status Icon</target>
+        <target state="translated">Ícone de Status</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.instance">
         <source xml:lang="en">Instance</source>
-        <target state="new">Instance</target>
+        <target state="translated">Instância</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.state">
         <source xml:lang="en">State</source>
-        <target state="new">State</target>
+        <target state="translated">Estado</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.view">
         <source xml:lang="en">View</source>
-        <target state="new">View</target>
+        <target state="translated">Exibir</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.notAvailable">
         <source xml:lang="en">N/A</source>
-        <target state="new">N/A</target>
+        <target state="translated">N/D</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.healthStatusDetails">
         <source xml:lang="en">Health Status Details</source>
-        <target state="new">Health Status Details</target>
+        <target state="translated">Detalhes do Status da Integridade</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.metricsAndLogs">
         <source xml:lang="en">Metrics and Logs</source>
-        <target state="new">Metrics and Logs</target>
+        <target state="translated">Métricas e Logs</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.healthStatus">
         <source xml:lang="en">Health Status</source>
-        <target state="new">Health Status</target>
+        <target state="translated">Status da Integridade</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.nodeMetrics">
         <source xml:lang="en">Node Metrics</source>
-        <target state="new">Node Metrics</target>
+        <target state="translated">Métricas do Node</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.sqlMetrics">
         <source xml:lang="en">SQL Metrics</source>
-        <target state="new">SQL Metrics</target>
+        <target state="translated">Métricas do SQL</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.logs">
         <source xml:lang="en">Logs</source>
-        <target state="new">Logs</target>
+        <target state="translated">Logs</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewNodeMetrics">
         <source xml:lang="en">View Node Metrics {0}</source>
-        <target state="new">View Node Metrics {0}</target>
+        <target state="translated">Exibir Métricas do Node {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewSqlMetrics">
         <source xml:lang="en">View SQL Metrics {0}</source>
-        <target state="new">View SQL Metrics {0}</target>
+        <target state="translated">Exibir Métricas do SQL {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewLogs">
         <source xml:lang="en">View Kibana Logs {0}</source>
-        <target state="new">View Kibana Logs {0}</target>
+        <target state="translated">Exibir os Logs do Kibana {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.lastUpdated">
         <source xml:lang="en">Last Updated : {0}</source>
-        <target state="new">Last Updated : {0}</target>
+        <target state="translated">Última Atualização: {0}</target>
       </trans-unit>
       <trans-unit id="basicAuthName">
         <source xml:lang="en">Basic</source>
-        <target state="new">Basic</target>
+        <target state="translated">Básico</target>
       </trans-unit>
       <trans-unit id="integratedAuthName">
         <source xml:lang="en">Windows Authentication</source>
-        <target state="new">Windows Authentication</target>
+        <target state="translated">Autenticação do Windows</target>
       </trans-unit>
       <trans-unit id="addNewController">
         <source xml:lang="en">Add New Controller</source>
-        <target state="new">Add New Controller</target>
+        <target state="translated">Adicionar Novo Controlador</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
-        <target state="new">URL</target>
+        <target state="translated">URL</target>
       </trans-unit>
       <trans-unit id="username">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">Nome de usuário</target>
       </trans-unit>
       <trans-unit id="password">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">Senha</target>
       </trans-unit>
       <trans-unit id="rememberPassword">
         <source xml:lang="en">Remember Password</source>
-        <target state="new">Remember Password</target>
+        <target state="translated">Lembrar Senha</target>
       </trans-unit>
       <trans-unit id="clusterManagementUrl">
         <source xml:lang="en">Cluster Management URL</source>
-        <target state="new">Cluster Management URL</target>
+        <target state="translated">URL de Gerenciamento de Cluster</target>
       </trans-unit>
       <trans-unit id="textAuthCapital">
         <source xml:lang="en">Authentication type</source>
-        <target state="new">Authentication type</target>
+        <target state="translated">Tipo de autenticação</target>
       </trans-unit>
       <trans-unit id="hdsf.dialog.connection.section">
         <source xml:lang="en">Cluster Connection</source>
-        <target state="new">Cluster Connection</target>
+        <target state="translated">Conexão de Cluster</target>
       </trans-unit>
       <trans-unit id="add">
         <source xml:lang="en">Add</source>
-        <target state="new">Add</target>
+        <target state="translated">Adicionar</target>
       </trans-unit>
       <trans-unit id="cancel">
         <source xml:lang="en">Cancel</source>
-        <target state="new">Cancel</target>
+        <target state="translated">Cancelar</target>
       </trans-unit>
       <trans-unit id="ok">
         <source xml:lang="en">OK</source>
-        <target state="new">OK</target>
+        <target state="translated">OK</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.refresh">
         <source xml:lang="en">Refresh</source>
-        <target state="new">Refresh</target>
+        <target state="translated">Atualizar</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.troubleshoot">
         <source xml:lang="en">Troubleshoot</source>
-        <target state="new">Troubleshoot</target>
+        <target state="translated">Solucionar problemas</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.bdcOverview">
         <source xml:lang="en">Big Data Cluster overview</source>
-        <target state="new">Big Data Cluster overview</target>
+        <target state="translated">Visão geral do cluster de Big Data</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterDetails">
         <source xml:lang="en">Cluster Details</source>
-        <target state="new">Cluster Details</target>
+        <target state="translated">Detalhes do Cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterOverview">
         <source xml:lang="en">Cluster Overview</source>
-        <target state="new">Cluster Overview</target>
+        <target state="translated">Visão Geral do Cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.serviceEndpoints">
         <source xml:lang="en">Service Endpoints</source>
-        <target state="new">Service Endpoints</target>
+        <target state="translated">Pontos de Extremidade de Serviço</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterProperties">
         <source xml:lang="en">Cluster Properties</source>
-        <target state="new">Cluster Properties</target>
+        <target state="translated">Propriedades do Cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.clusterState">
         <source xml:lang="en">Cluster State</source>
-        <target state="new">Cluster State</target>
+        <target state="translated">Estado do Cluster</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.serviceName">
         <source xml:lang="en">Service Name</source>
-        <target state="new">Service Name</target>
+        <target state="translated">Nome do Serviço</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.service">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">Serviço</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.endpoint">
         <source xml:lang="en">Endpoint</source>
-        <target state="new">Endpoint</target>
+        <target state="translated">Ponto de Extremidade</target>
       </trans-unit>
       <trans-unit id="copiedEndpoint">
         <source xml:lang="en">Endpoint '{0}' copied to clipboard</source>
-        <target state="new">Endpoint '{0}' copied to clipboard</target>
+        <target state="translated">Ponto de extremidade '{0}' copiado para a área de transferência</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.copy">
         <source xml:lang="en">Copy</source>
-        <target state="new">Copy</target>
+        <target state="translated">Copiar</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewDetails">
         <source xml:lang="en">View Details</source>
-        <target state="new">View Details</target>
+        <target state="translated">Exibir Detalhes</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.viewErrorDetails">
         <source xml:lang="en">View Error Details</source>
-        <target state="new">View Error Details</target>
+        <target state="translated">Exibir Detalhes do Erro</target>
       </trans-unit>
       <trans-unit id="connectController.dialog.title">
         <source xml:lang="en">Connect to Controller</source>
-        <target state="new">Connect to Controller</target>
+        <target state="translated">Conectar ao Controlador</target>
       </trans-unit>
       <trans-unit id="mount.main.section">
         <source xml:lang="en">Mount Configuration</source>
-        <target state="new">Mount Configuration</target>
+        <target state="translated">Configuração da Montagem</target>
       </trans-unit>
       <trans-unit id="mount.task.name">
         <source xml:lang="en">Mounting HDFS folder on path {0}</source>
-        <target state="new">Mounting HDFS folder on path {0}</target>
+        <target state="translated">Montando a pasta do HDFS no caminho {0}</target>
       </trans-unit>
       <trans-unit id="refreshmount.task.name">
         <source xml:lang="en">Refreshing HDFS Mount on path {0}</source>
-        <target state="new">Refreshing HDFS Mount on path {0}</target>
+        <target state="translated">Atualizando a Montagem do HDFS no caminho {0}</target>
       </trans-unit>
       <trans-unit id="deletemount.task.name">
         <source xml:lang="en">Deleting HDFS Mount on path {0}</source>
-        <target state="new">Deleting HDFS Mount on path {0}</target>
+        <target state="translated">Excluindo a Montagem do HDFS no caminho {0}</target>
       </trans-unit>
       <trans-unit id="mount.task.submitted">
         <source xml:lang="en">Mount creation has started</source>
-        <target state="new">Mount creation has started</target>
+        <target state="translated">A criação da montagem foi iniciada</target>
       </trans-unit>
       <trans-unit id="refreshmount.task.submitted">
         <source xml:lang="en">Refresh mount request submitted</source>
-        <target state="new">Refresh mount request submitted</target>
+        <target state="translated">Solicitação de atualização de montagem enviada</target>
       </trans-unit>
       <trans-unit id="deletemount.task.submitted">
         <source xml:lang="en">Delete mount request submitted</source>
-        <target state="new">Delete mount request submitted</target>
+        <target state="translated">Solicitação de exclusão de montagem enviada</target>
       </trans-unit>
       <trans-unit id="mount.task.complete">
         <source xml:lang="en">Mounting HDFS folder is complete</source>
-        <target state="new">Mounting HDFS folder is complete</target>
+        <target state="translated">A montagem da pasta do HDFS está concluída</target>
       </trans-unit>
       <trans-unit id="mount.task.inprogress">
         <source xml:lang="en">Mounting is likely to complete, check back later to verify</source>
-        <target state="new">Mounting is likely to complete, check back later to verify</target>
+        <target state="translated">A montagem provavelmente será concluída. Volte mais tarde para verificar</target>
       </trans-unit>
       <trans-unit id="mount.dialog.title">
         <source xml:lang="en">Mount HDFS Folder</source>
-        <target state="new">Mount HDFS Folder</target>
+        <target state="translated">Montar a Pasta do HDFS</target>
       </trans-unit>
       <trans-unit id="mount.hdfsPath.title">
         <source xml:lang="en">HDFS Path</source>
-        <target state="new">HDFS Path</target>
+        <target state="translated">Caminho do HDFS</target>
       </trans-unit>
       <trans-unit id="mount.hdfsPath.info">
         <source xml:lang="en">Path to a new (non-existing) directory which you want to associate with the mount</source>
-        <target state="new">Path to a new (non-existing) directory which you want to associate with the mount</target>
+        <target state="translated">Caminho para um novo diretório (não existente) que você deseja associar com a montagem</target>
       </trans-unit>
       <trans-unit id="mount.remoteUri.title">
         <source xml:lang="en">Remote URI</source>
-        <target state="new">Remote URI</target>
+        <target state="translated">URI remoto</target>
       </trans-unit>
       <trans-unit id="mount.remoteUri.info">
         <source xml:lang="en">The URI to the remote data source. Example for ADLS: abfs://fs@saccount.dfs.core.windows.net/</source>
-        <target state="new">The URI to the remote data source. Example for ADLS: abfs://fs@saccount.dfs.core.windows.net/</target>
+        <target state="translated">O URI da fonte de dados remota. Exemplo para o ADLS: abfs://fs@saccount.dfs.core.windows.net/</target>
       </trans-unit>
       <trans-unit id="mount.credentials.title">
         <source xml:lang="en">Credentials</source>
-        <target state="new">Credentials</target>
+        <target state="translated">Credenciais</target>
       </trans-unit>
       <trans-unit id="mount.credentials.info">
         <source xml:lang="en">Mount credentials for authentication to remote data source for reads</source>
-        <target state="new">Mount credentials for authentication to remote data source for reads</target>
+        <target state="translated">Montar as credenciais para autenticação na fonte de dados remota para leituras</target>
       </trans-unit>
       <trans-unit id="refreshmount.dialog.title">
         <source xml:lang="en">Refresh Mount</source>
-        <target state="new">Refresh Mount</target>
+        <target state="translated">Atualizar Montagem</target>
       </trans-unit>
       <trans-unit id="deleteMount.dialog.title">
         <source xml:lang="en">Delete Mount</source>
-        <target state="new">Delete Mount</target>
+        <target state="translated">Excluir Montagem</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.loadingClusterStateCompleted">
         <source xml:lang="en">Loading cluster state completed</source>
-        <target state="new">Loading cluster state completed</target>
+        <target state="translated">Carregamento do estado do cluster concluído</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.loadingHealthStatusCompleted">
         <source xml:lang="en">Loading health status completed</source>
-        <target state="new">Loading health status completed</target>
+        <target state="translated">Carregamento do status da integridade concluído</target>
       </trans-unit>
       <trans-unit id="err.controller.username.required">
         <source xml:lang="en">Username is required</source>
-        <target state="new">Username is required</target>
+        <target state="translated">O nome de usuário é obrigatório</target>
       </trans-unit>
       <trans-unit id="err.controller.password.required">
         <source xml:lang="en">Password is required</source>
-        <target state="new">Password is required</target>
+        <target state="translated">A senha é obrigatória</target>
       </trans-unit>
       <trans-unit id="endpointsError">
         <source xml:lang="en">Unexpected error retrieving BDC Endpoints: {0}</source>
-        <target state="new">Unexpected error retrieving BDC Endpoints: {0}</target>
+        <target state="translated">Erro inesperado ao recuperar os pontos de Extremidade do BDC: {0}</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.noConnection">
         <source xml:lang="en">The dashboard requires a connection. Please click retry to enter your credentials.</source>
-        <target state="new">The dashboard requires a connection. Please click retry to enter your credentials.</target>
+        <target state="translated">O painel requer uma conexão. Clique em tentar novamente para inserir suas credenciais.</target>
       </trans-unit>
       <trans-unit id="bdc.dashboard.unexpectedError">
         <source xml:lang="en">Unexpected error occurred: {0}</source>
-        <target state="new">Unexpected error occurred: {0}</target>
+        <target state="translated">Erro inesperado: {0}</target>
       </trans-unit>
       <trans-unit id="mount.hdfs.loginerror1">
         <source xml:lang="en">Login to controller failed</source>
-        <target state="new">Login to controller failed</target>
+        <target state="translated">Falha ao entrar no controlador</target>
       </trans-unit>
       <trans-unit id="mount.hdfs.loginerror2">
         <source xml:lang="en">Login to controller failed: {0}</source>
-        <target state="new">Login to controller failed: {0}</target>
+        <target state="translated">Falha ao entrar no controlador: {0}</target>
       </trans-unit>
       <trans-unit id="mount.err.formatting">
         <source xml:lang="en">Bad formatting of credentials at {0}</source>
-        <target state="new">Bad formatting of credentials at {0}</target>
+        <target state="translated">Formatação incorreta de credenciais em {0}</target>
       </trans-unit>
       <trans-unit id="mount.task.error">
         <source xml:lang="en">Error mounting folder: {0}</source>
-        <target state="new">Error mounting folder: {0}</target>
+        <target state="translated">Erro na montagem da pasta: {0}</target>
       </trans-unit>
       <trans-unit id="mount.error.unknown">
         <source xml:lang="en">Unknown error occurred during the mount process</source>
-        <target state="new">Unknown error occurred during the mount process</target>
+        <target state="translated">Erro desconhecido durante o processo de montagem</target>
       </trans-unit>
     </body>
   </file>
@@ -566,7 +686,7 @@
       </trans-unit>
       <trans-unit id="bdc.error.getClusterConfig">
         <source xml:lang="en">Error retrieving cluster config from {0}</source>
-        <target state="new">Error retrieving cluster config from {0}</target>
+        <target state="translated">Erro ao recuperar a configuração do cluster do {0}</target>
       </trans-unit>
       <trans-unit id="bdc.error.getEndPoints">
         <source xml:lang="en">Error retrieving endpoints from {0}</source>
@@ -582,7 +702,7 @@
       </trans-unit>
       <trans-unit id="bdc.error.statusHdfs">
         <source xml:lang="en">Error getting mount status</source>
-        <target state="new">Error getting mount status</target>
+        <target state="translated">Erro ao obter o status de montagem</target>
       </trans-unit>
       <trans-unit id="bdc.error.refreshHdfs">
         <source xml:lang="en">Error refreshing mount</source>
@@ -602,7 +722,7 @@
       </trans-unit>
       <trans-unit id="bdc.dashboard.title">
         <source xml:lang="en">Big Data Cluster Dashboard -</source>
-        <target state="new">Big Data Cluster Dashboard -</target>
+        <target state="translated">Painel do Cluster de Big Data –</target>
       </trans-unit>
       <trans-unit id="textYes">
         <source xml:lang="en">Yes</source>
@@ -614,7 +734,7 @@
       </trans-unit>
       <trans-unit id="textConfirmRemoveController">
         <source xml:lang="en">Are you sure you want to remove '{0}'?</source>
-        <target state="new">Are you sure you want to remove '{0}'?</target>
+        <target state="translated">Tem certeza de que deseja remover '{0}'?</target>
       </trans-unit>
     </body>
   </file>
@@ -622,7 +742,7 @@
     <body>
       <trans-unit id="bdc.controllerTreeDataProvider.error">
         <source xml:lang="en">Unexpected error loading saved controllers: {0}</source>
-        <target state="new">Unexpected error loading saved controllers: {0}</target>
+        <target state="translated">Erro inesperado ao carregar os controladores salvos: {0}</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/cms.pt-BR.xlf
+++ b/resources/xlf/pt-br/cms.pt-BR.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">Carregando...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">Erro inesperado durante o carregamento de servidores salvos {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">Carregando...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">O Grupo de Servidores de Gerenciamento Central já tem um Servidor Registrado com o nome {0}</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Os Servidores de Banco de Dados SQL do Azure não podem ser usados como Servidores de Gerenciamento Central</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Os Servidores SQL do Azure não podem ser usados como Servidores de Gerenciamento Central</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/pt-br/dacpac.pt-BR.xlf
+++ b/resources/xlf/pt-br/dacpac.pt-BR.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Dacpac</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">Caminho completo para a pasta em que se encontram os arquivos .DACPAC e .BACPAC são salvos por padrão</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Servidor de Destino</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Servidor de Origem</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Banco de Dados de Origem</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Banco de Dados de Destino</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">Localização do Arquivo</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">Selecionar arquivo</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">Resumo das configurações</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versão</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">Configuração</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">Nome do Banco de Dados</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">Atualizar Banco de Dados Existente</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">Novo Banco de Dados</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">{0} das ações de implantação listadas podem resultar em perda de dados. Verifique se você tem um backup ou instantâneo disponível no caso de um problema com a implantação.</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">Prosseguir, apesar da possível perda de dados</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">Nenhuma perda de dados ocorrerá nas ações de implantação listadas.</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">Salvar</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">Localização do Arquivo</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">Versão (use x.x.x.x, em que x é um número)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">Implantar um arquivo .dacpac de aplicativo de camada de dados em uma instância do SQL Server [implantar Dacpac]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">Exportar o esquema e os dados de um banco de dados para o formato de arquivo lógico .bacpac [Exportar Bacpac]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">Nome do Banco de Dados</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">Atualizar Banco de Dados Existente</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">Novo Banco de Dados</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Banco de Dados de Destino</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">Servidor de Destino</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">Servidor de Origem</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">Banco de Dados de Origem</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Versão</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">Configuração</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">padrão</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">Assistente de Aplicativo em Camada de Dados</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">Gerar Script</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">Você pode exibir o status da geração de script na Exibição de Tarefas depois que o assistente for fechado. O script gerado será aberto quando concluído.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">padrão</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">Implantar plano de operações</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">Já existe um banco de dados com o mesmo nome na instância do SQL Server.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">Nome indefinido</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">O nome do arquivo não pode terminar com um ponto</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">O nome do arquivo não pode ser espaço em branco</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">Caracteres de arquivo inválidos</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">Este nome de arquivo está reservado para ser usado pelo Windows. Escolha outro nome e tente novamente.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">Nome de arquivo reservado. Escolha outro nome e tente novamente</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">O nome do arquivo não pode terminar com um espaço em branco</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">O nome do arquivo tem mais de 255 caracteres</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">Falha na geração do plano de implantação '{0}'</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">Falha na geração do script de implantação '{0}'</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">Falha na operação {0} '{1}'</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">Você pode exibir o status da geração de script na Exibição de Tarefas depois que o assistente for fechado. O script gerado será aberto quando concluído.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/import.pt-BR.xlf
+++ b/resources/xlf/pt-br/import.pt-BR.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">Configuração de Importação de Arquivo Simples</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[Opcional] Registre a saída da depuração no console (Exibir -&gt; Saída) e, em seguida, selecione o canal de saída apropriado no menu suspenso</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">{0} iniciado</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">Iniciando {0}</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">Falha ao iniciar {0}: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">Instalando {0} para {1}</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">Instalando serviço {0}</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">{0} instalado</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Baixando {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Baixando {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">Download de {0} concluído</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">{0} extraído ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">Fornecer Comentários</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">componente de serviço não pôde ser iniciado</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">O servidor no qual o banco de dados está</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">Banco de dados em que a tabela é criada</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">Localização de arquivo inválida. Tente um arquivo de entrada diferente</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Procurar</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">Local do arquivo a ser importado</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">Nome da nova tabela</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">Esquema da tabela</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">Importar Dados</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Próximo</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">Nome da Coluna</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">Tipo de Dados</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">Chave Primária</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">Permitir Valores Nulos</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">Esta operação analisou a estrutura do arquivo de entrada para gerar a visualização abaixo para as primeiras 50 linhas.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">Esta operação não teve êxito. Tente um arquivo de entrada diferente.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">Importar informações</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ Dados inseridos na tabela corretamente.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">Esta operação analisou a estrutura do arquivo de entrada para gerar a visualização abaixo para as primeiras 50 linhas.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">Esta operação não teve êxito. Tente um arquivo de entrada diferente.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Atualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">Importar Dados</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Próximo</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">Nome da Coluna</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">Tipo de Dados</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">Chave Primária</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">Permitir Valores Nulos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">O servidor no qual o banco de dados está</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">Banco de dados em que a tabela é criada</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">Procurar</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">Local do arquivo a ser importado</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">Nome da nova tabela</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">Esquema da tabela</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">Conecte-se a um servidor antes de usar este assistente.</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">A extensão de importação SQL Server não dá suporte a este tipo de conexão</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">Importar novo arquivo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">Fornecer Comentários</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">componente de serviço não pôde ser iniciado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">Serviço Iniciado</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">Iniciando serviço</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">Falha ao iniciar o Serviço de importação{0}</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">Instalando o serviço {0} em {1}</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">Instalando Serviço</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Instalado</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">Baixando {0}</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">Baixando Serviço</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">Feito!</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/notebook.pt-BR.xlf
+++ b/resources/xlf/pt-br/notebook.pt-BR.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Caminho local para uma instalação do Python preexistente usada por Notebooks.</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">Não mostrar aviso para atualizar Python.</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">A quantidade de tempo (em minutos) de espera antes de desligar um servidor depois de fechar todos os blocos de anotações. (Digite 0 para não desligar)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Substitua as configurações padrão do editor no editor de Notebook. As configurações incluem a cor da tela de fundo, a cor e a borda da linha atual</target>
@@ -32,7 +40,7 @@
       </trans-unit>
       <trans-unit id="notebook.trustedBooks.description">
         <source xml:lang="en">Notebooks contained in these books will automatically be trusted.</source>
-        <target state="new">Notebooks contained in these books will automatically be trusted.</target>
+        <target state="translated">Os Notebooks contidos nesses livros serão automaticamente confiáveis.</target>
       </trans-unit>
       <trans-unit id="notebook.maxBookSearchDepth.description">
         <source xml:lang="en">Maximum depth of subdirectories to search for Books (Enter 0 for infinite)</source>
@@ -40,15 +48,19 @@
       </trans-unit>
       <trans-unit id="notebook.collapseBookItems.description">
         <source xml:lang="en">Collapse Book items at root level in the Notebooks Viewlet</source>
-        <target state="new">Collapse Book items at root level in the Notebooks Viewlet</target>
+        <target state="translated">Recolher itens do Livro no nível raiz no Viewlet dos Notebooks</target>
       </trans-unit>
       <trans-unit id="notebook.remoteBookDownloadTimeout.description">
         <source xml:lang="en">Download timeout in milliseconds for GitHub books</source>
-        <target state="new">Download timeout in milliseconds for GitHub books</target>
+        <target state="translated">Baixar o tempo limite em milissegundos para os livros do GitHub</target>
       </trans-unit>
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
-        <target state="new">Notebooks that are pinned by the user for the current workspace</target>
+        <target state="translated">Os Notebooks que são fixados pelo usuário para o workspace atual</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,72 +151,84 @@
         <target state="translated">Jupyter Books</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">Salvar Book</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Salvar Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="new">Trust Book</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Confiar Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">Pesquisar Book</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Pesquisar no Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
-        <target state="new">Notebooks</target>
+        <target state="translated">Notebooks</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="new">Provided Books</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">Livros Jupyter fornecidos</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
-        <target state="new">Pinned notebooks</target>
+        <target state="translated">Notebooks fixados</target>
       </trans-unit>
       <trans-unit id="title.PreviewLocalizedBook">
         <source xml:lang="en">Get localized SQL Server 2019 guide</source>
-        <target state="new">Get localized SQL Server 2019 guide</target>
+        <target state="translated">Obtenha o guia do SQL Server 2019 localizado</target>
       </trans-unit>
       <trans-unit id="title.openJupyterBook">
         <source xml:lang="en">Open Jupyter Book</source>
-        <target state="new">Open Jupyter Book</target>
+        <target state="translated">Abrir Livro do Jupyter</target>
       </trans-unit>
       <trans-unit id="title.closeJupyterBook">
         <source xml:lang="en">Close Jupyter Book</source>
-        <target state="new">Close Jupyter Book</target>
+        <target state="translated">Fechar o Livro do Jupyter</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="new">Close Jupyter Notebook</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">Fechar Bloco de Anotações</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">Remover Bloco de Anotações</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">Adicionar Bloco de Anotações</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">Adicionar Arquivo de Marcação</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
-        <target state="new">Reveal in Books</target>
+        <target state="translated">Revelar nos Livros</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="new">Create Book (Preview)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Criar Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
-        <target state="new">Open Notebooks in Folder</target>
+        <target state="translated">Abrir Notebooks na Pasta</target>
       </trans-unit>
       <trans-unit id="title.openRemoteJupyterBook">
         <source xml:lang="en">Add Remote Jupyter Book</source>
-        <target state="new">Add Remote Jupyter Book</target>
+        <target state="translated">Adicionar Livro do Jupyter Remoto</target>
       </trans-unit>
       <trans-unit id="title.pinNotebook">
         <source xml:lang="en">Pin Notebook</source>
-        <target state="new">Pin Notebook</target>
+        <target state="translated">Fixar Notebook</target>
       </trans-unit>
       <trans-unit id="title.unpinNotebook">
         <source xml:lang="en">Unpin Notebook</source>
-        <target state="new">Unpin Notebook</target>
+        <target state="translated">Desafixar Notebook</target>
       </trans-unit>
       <trans-unit id="title.moveTo">
         <source xml:lang="en">Move to ...</source>
-        <target state="new">Move to ...</target>
+        <target state="translated">Mover para...</target>
       </trans-unit>
     </body>
   </file>
@@ -212,11 +236,11 @@
     <body>
       <trans-unit id="ensureDirOutputMsg">
         <source xml:lang="en">... Ensuring {0} exists</source>
-        <target state="new">... Ensuring {0} exists</target>
+        <target state="translated">... Verificando se {0} existe</target>
       </trans-unit>
       <trans-unit id="executeCommandProcessExited">
         <source xml:lang="en">Process exited with error code: {0}. StdErr Output: {1}</source>
-        <target state="new">Process exited with error code: {0}. StdErr Output: {1}</target>
+        <target state="translated">O processo foi encerrado com o código de erro: {0}. Saída de StdErr: {1}</target>
       </trans-unit>
     </body>
   </file>
@@ -224,11 +248,11 @@
     <body>
       <trans-unit id="managePackages.localhost">
         <source xml:lang="en">localhost</source>
-        <target state="new">localhost</target>
+        <target state="translated">localhost</target>
       </trans-unit>
       <trans-unit id="managePackages.packageNotFound">
         <source xml:lang="en">Could not find the specified package</source>
-        <target state="new">Could not find the specified package</target>
+        <target state="translated">Não foi possível localizar o pacote especificado</target>
       </trans-unit>
     </body>
   </file>
@@ -248,293 +272,333 @@
       </trans-unit>
       <trans-unit id="noBDCConnectionError">
         <source xml:lang="en">Spark kernels require a connection to a SQL Server Big Data Cluster master instance.</source>
-        <target state="new">Spark kernels require a connection to a SQL Server Big Data Cluster master instance.</target>
+        <target state="translated">Os kernels do Spark exigem uma conexão com uma instância mestra do cluster de Big Data do SQL Server.</target>
       </trans-unit>
       <trans-unit id="providerNotValidError">
         <source xml:lang="en">Non-MSSQL providers are not supported for spark kernels.</source>
-        <target state="new">Non-MSSQL providers are not supported for spark kernels.</target>
+        <target state="translated">Não há suporte para provedores não MSSQL em kernels do Spark.</target>
       </trans-unit>
       <trans-unit id="allFiles">
         <source xml:lang="en">All Files</source>
-        <target state="new">All Files</target>
+        <target state="translated">Todos os Arquivos</target>
       </trans-unit>
       <trans-unit id="labelSelectFolder">
         <source xml:lang="en">Select Folder</source>
-        <target state="new">Select Folder</target>
+        <target state="translated">Selecionar Pasta</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="new">Select Book</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Selecionar Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
-        <target state="new">Folder already exists. Are you sure you want to delete and replace this folder?</target>
+        <target state="translated">A pasta já existe. Tem certeza de que deseja excluir e substituir essa pasta?</target>
       </trans-unit>
       <trans-unit id="openNotebookCommand">
         <source xml:lang="en">Open Notebook</source>
-        <target state="new">Open Notebook</target>
+        <target state="translated">Abrir Notebook</target>
       </trans-unit>
       <trans-unit id="openMarkdownCommand">
         <source xml:lang="en">Open Markdown</source>
-        <target state="new">Open Markdown</target>
+        <target state="translated">Abrir Markdown</target>
       </trans-unit>
       <trans-unit id="openExternalLinkCommand">
         <source xml:lang="en">Open External Link</source>
-        <target state="new">Open External Link</target>
+        <target state="translated">Abrir Link Externo</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="new">Book is now trusted in the workspace.</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">O Livro Jupyter agora é confiável no espaço de trabalho.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="new">Book is already trusted in this workspace.</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">O Livro Jupyter já é confiável neste espaço de trabalho.</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="new">Book is no longer trusted in this workspace</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">O Livro Jupyter não é mais confiável neste espaço de trabalho</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="new">Book is already untrusted in this workspace.</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">O Livro Jupyter já não é confiável neste espaço de trabalho.</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="new">Book {0} is now pinned in the workspace.</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">O Livro Jupyter {0} agora está fixado no espaço de trabalho.</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="new">Book {0} is no longer pinned in this workspace</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">O Livro Jupyter {0} agora não está mais fixado neste espaço de trabalho</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="new">Failed to find a Table of Contents file in the specified book.</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">Falha ao encontrar um arquivo de Índice no Livro Jupyter especificado.</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="new">No books are currently selected in the viewlet.</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">Nenhum Livro Jupyter está selecionado no momento no viewlet.</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="new">Select Book Section</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Selecione a Seção do Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
-        <target state="new">Add to this level</target>
+        <target state="translated">Adicionar a este nível</target>
       </trans-unit>
       <trans-unit id="missingFileError">
         <source xml:lang="en">Missing file : {0} from {1}</source>
-        <target state="new">Missing file : {0} from {1}</target>
+        <target state="translated">Arquivo ausente: {0} de {1}</target>
       </trans-unit>
       <trans-unit id="InvalidError.tocFile">
         <source xml:lang="en">Invalid toc file</source>
-        <target state="new">Invalid toc file</target>
+        <target state="translated">Arquivo de sumário inválido</target>
       </trans-unit>
       <trans-unit id="Invalid toc.yml">
         <source xml:lang="en">Error: {0} has an incorrect toc.yml file</source>
-        <target state="new">Error: {0} has an incorrect toc.yml file</target>
+        <target state="translated">Erro: {0} tem um arquivo toc.yml incorreto</target>
       </trans-unit>
       <trans-unit id="configFileError">
         <source xml:lang="en">Configuration file missing</source>
-        <target state="new">Configuration file missing</target>
+        <target state="translated">Arquivo de configuração ausente</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="new">Open book {0} failed: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Falha ao abrir o Livro Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="new">Failed to read book {0}: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">Falha ao ler o Livro Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
-        <target state="new">Open notebook {0} failed: {1}</target>
+        <target state="translated">Falha ao abrir o notebook {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openMarkdownError">
         <source xml:lang="en">Open markdown {0} failed: {1}</source>
-        <target state="new">Open markdown {0} failed: {1}</target>
+        <target state="translated">Falha ao abrir o markdown {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openUntitledNotebookError">
         <source xml:lang="en">Open untitled notebook {0} as untitled failed: {1}</source>
-        <target state="new">Open untitled notebook {0} as untitled failed: {1}</target>
+        <target state="translated">Abrir o notebook sem título {0} porque o sem título falhou: {1}</target>
       </trans-unit>
       <trans-unit id="openExternalLinkError">
         <source xml:lang="en">Open link {0} failed: {1}</source>
-        <target state="new">Open link {0} failed: {1}</target>
+        <target state="translated">Falha ao abrir o link {0}: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="new">Close book {0} failed: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Falha ao Fechar Livro Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
  The file has been renamed to {2} to prevent data loss.</source>
-        <target state="new">File {0} already exists in the destination folder {1} 
- The file has been renamed to {2} to prevent data loss.</target>
+        <target state="translated">O arquivo {0} já existe na pasta de destino {1} 
+ O arquivo foi renomeado para {2} para impedir a perda de dados.</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="new">Error while editing book {0}: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Erro ao editar o Livro Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="new">Error while selecting a book or a section to edit: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">Erro ao selecionar um Livro Jupyter ou uma seção para editar: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">Falha ao localizar a seção {0} em {1}.</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
-        <target state="new">URL</target>
+        <target state="translated">URL</target>
       </trans-unit>
       <trans-unit id="repoUrl">
         <source xml:lang="en">Repository URL</source>
-        <target state="new">Repository URL</target>
+        <target state="translated">URL do repositório</target>
       </trans-unit>
       <trans-unit id="location">
         <source xml:lang="en">Location</source>
-        <target state="new">Location</target>
+        <target state="translated">Localização</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="new">Add Remote Book</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">Adicionar Livro do Jupyter Remoto</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
-        <target state="new">GitHub</target>
+        <target state="translated">GitHub</target>
       </trans-unit>
       <trans-unit id="onsharedFile">
         <source xml:lang="en">Shared File</source>
-        <target state="new">Shared File</target>
+        <target state="translated">Arquivo Compartilhado</target>
       </trans-unit>
       <trans-unit id="releases">
         <source xml:lang="en">Releases</source>
-        <target state="new">Releases</target>
+        <target state="translated">Versões</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="new">Book</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Versão</target>
       </trans-unit>
       <trans-unit id="language">
         <source xml:lang="en">Language</source>
-        <target state="new">Language</target>
+        <target state="translated">Linguagem</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="new">No books are currently available on the provided link</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">Nenhum Livro Jupyter está disponível no momento no link fornecido</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
-        <target state="new">The url provided is not a Github release url</target>
+        <target state="translated">A URL fornecida não é uma URL de versão do Github</target>
       </trans-unit>
       <trans-unit id="search">
         <source xml:lang="en">Search</source>
-        <target state="new">Search</target>
+        <target state="translated">Pesquisar</target>
       </trans-unit>
       <trans-unit id="add">
         <source xml:lang="en">Add</source>
-        <target state="new">Add</target>
+        <target state="translated">Adicionar</target>
       </trans-unit>
       <trans-unit id="close">
         <source xml:lang="en">Close</source>
-        <target state="new">Close</target>
+        <target state="translated">Fechar</target>
       </trans-unit>
       <trans-unit id="invalidTextPlaceholder">
         <source xml:lang="en">-</source>
-        <target state="new">-</target>
+        <target state="translated">–</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="new">Remote Book download is in progress</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">O download do Livro Jupyter Remoto está em andamento</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="new">Remote Book download is complete</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">O download do Livro Jupyter Remoto está concluído</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="new">Error while downloading remote Book</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">Erro ao baixar o Livro Jupyter remoto</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="new">Error while decompressing remote Book</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">Erro ao descompactar o Livro Jupyter remoto</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="new">Error while creating remote Book directory</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">Erro ao criar diretório remoto do Livro Jupyter</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="new">Downloading Remote Book</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">Baixando o Livro Jupyter Remoto</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
-        <target state="new">Resource not Found</target>
+        <target state="translated">Recurso Não Encontrado</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="new">Books not Found</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">Livros Jupyter não encontrados</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
-        <target state="new">Releases not Found</target>
+        <target state="translated">Versões Não Encontradas</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="new">The selected book is not valid</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">O Livro Jupyter selecionado não é válido</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
-        <target state="new">Http Request failed with error: {0} {1}</target>
+        <target state="translated">Houve uma falha na solicitação HTTP com o erro: {0} {1}</target>
       </trans-unit>
       <trans-unit id="msgDownloadLocation">
         <source xml:lang="en">Downloading to {0}</source>
-        <target state="new">Downloading to {0}</target>
+        <target state="translated">Baixando para {0}</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="new">New Group</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">Novo Livro Jupyter (Visualização)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="new">Groups are used to organize Notebooks.</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Os Livros Jupyter são usados para organizar Blocos de Anotações.</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="new">Browse locations...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">Saiba mais.</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="new">Select content folder</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">Pasta de conteúdo</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">Procurar</target>
       </trans-unit>
       <trans-unit id="create">
         <source xml:lang="en">Create</source>
-        <target state="new">Create</target>
+        <target state="translated">Criar</target>
       </trans-unit>
       <trans-unit id="name">
         <source xml:lang="en">Name</source>
-        <target state="new">Name</target>
+        <target state="translated">Nome</target>
       </trans-unit>
       <trans-unit id="saveLocation">
         <source xml:lang="en">Save location</source>
-        <target state="new">Save location</target>
+        <target state="translated">Salvar localização</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
-        <target state="new">Content folder (Optional)</target>
+        <target state="translated">Pasta de conteúdo (Opcional)</target>
       </trans-unit>
       <trans-unit id="msgContentFolderError">
         <source xml:lang="en">Content folder path does not exist</source>
-        <target state="new">Content folder path does not exist</target>
+        <target state="translated">O caminho da pasta de conteúdo não existe</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="new">Save location path does not exist</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">O caminho de localização para salvar não existe.</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">Erro ao tentar acessar: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">Novo Bloco de Anotações (Visualização)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">Nova Marcação (Visualização)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">Extensão de Arquivo</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">O arquivo já existe. Tem certeza de que deseja substituir este arquivo?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Título</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">Nome do Arquivo</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">O caminho do local salvo não é válido.</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">Arquivo {0} já existe na pasta de destino</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">Outra instalação do Python está em andamento no momento. Esperando a conclusão.</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">As sessões ativas do bloco de anotações do Python serão encerradas para serem atualizadas. Deseja continuar agora?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">O Python {0} agora está disponível no Azure Data Studio. A versão atual do Python (3.6.6) estará sem suporte em dezembro de 2021. Deseja atualizar para o Python {0} agora?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">O Python {0} será instalado e substituirá o Python 3.6.6. Alguns pacotes podem não ser mais compatíveis com a nova versão ou talvez precisem ser reinstalados. Um bloco de anotações será criado para ajudá-lo a reinstalar todos os pacotes pip. Deseja continuar com a atualização agora?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">Falha na instalação das dependências do Notebook com o erro: {0}</target>
@@ -598,11 +674,23 @@
       </trans-unit>
       <trans-unit id="msgPackageRetrievalFailed">
         <source xml:lang="en">Encountered an error when trying to retrieve list of installed packages: {0}</source>
-        <target state="new">Encountered an error when trying to retrieve list of installed packages: {0}</target>
+        <target state="translated">Foi encontrado um erro ao tentar recuperar a lista de pacotes instalados: {0}</target>
       </trans-unit>
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
-        <target state="new">Encountered an error when getting Python user path: {0}</target>
+        <target state="translated">Foi encontrado um erro ao obter o caminho do usuário do Python: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">Não perguntar novamente</target>
       </trans-unit>
     </body>
   </file>
@@ -610,35 +698,35 @@
     <body>
       <trans-unit id="configurePython.okButtonText">
         <source xml:lang="en">Install</source>
-        <target state="new">Install</target>
+        <target state="translated">Instalar</target>
       </trans-unit>
       <trans-unit id="configurePython.invalidLocationMsg">
         <source xml:lang="en">The specified install location is invalid.</source>
-        <target state="new">The specified install location is invalid.</target>
+        <target state="translated">O local de instalação especificado é inválido.</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonNotFoundMsg">
         <source xml:lang="en">No Python installation was found at the specified location.</source>
-        <target state="new">No Python installation was found at the specified location.</target>
+        <target state="translated">Não foi encontrada nenhuma instalação do Python na localização especificada.</target>
       </trans-unit>
       <trans-unit id="configurePython.wizardNameWithKernel">
         <source xml:lang="en">Configure Python to run {0} kernel</source>
-        <target state="new">Configure Python to run {0} kernel</target>
+        <target state="translated">Configurar o Python para executar o kernel {0}</target>
       </trans-unit>
       <trans-unit id="configurePython.wizardNameWithoutKernel">
         <source xml:lang="en">Configure Python to run kernels</source>
-        <target state="new">Configure Python to run kernels</target>
+        <target state="translated">Configurar o Python para executar kernels</target>
       </trans-unit>
       <trans-unit id="configurePython.page0Name">
         <source xml:lang="en">Configure Python Runtime</source>
-        <target state="new">Configure Python Runtime</target>
+        <target state="translated">Configurar Runtime do Python</target>
       </trans-unit>
       <trans-unit id="configurePython.page1Name">
         <source xml:lang="en">Install Dependencies</source>
-        <target state="new">Install Dependencies</target>
+        <target state="translated">Instalar Dependências</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonInstallDeclined">
         <source xml:lang="en">Python installation was declined.</source>
-        <target state="new">Python installation was declined.</target>
+        <target state="translated">A instalação do Python foi recusada.</target>
       </trans-unit>
     </body>
   </file>
@@ -678,55 +766,55 @@
     <body>
       <trans-unit id="configurePython.browseButtonText">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">Procurar</target>
       </trans-unit>
       <trans-unit id="configurePython.selectFileLabel">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">Selecionar</target>
       </trans-unit>
       <trans-unit id="configurePython.descriptionWithKernel">
         <source xml:lang="en">The {0} kernel requires a Python runtime to be configured and dependencies to be installed.</source>
-        <target state="new">The {0} kernel requires a Python runtime to be configured and dependencies to be installed.</target>
+        <target state="translated">O kernel {0} exige que um runtime do Python seja configurado e que as dependências sejam instaladas.</target>
       </trans-unit>
       <trans-unit id="configurePython.descriptionWithoutKernel">
         <source xml:lang="en">Notebook kernels require a Python runtime to be configured and dependencies to be installed.</source>
-        <target state="new">Notebook kernels require a Python runtime to be configured and dependencies to be installed.</target>
+        <target state="translated">Os kernels do Notebook exigem que o runtime do Python seja configurado e as dependências sejam instaladas.</target>
       </trans-unit>
       <trans-unit id="configurePython.installationType">
         <source xml:lang="en">Installation Type</source>
-        <target state="new">Installation Type</target>
+        <target state="translated">Tipo de Instalação</target>
       </trans-unit>
       <trans-unit id="configurePython.locationTextBoxText">
         <source xml:lang="en">Python Install Location</source>
-        <target state="new">Python Install Location</target>
+        <target state="translated">Localização da Instalação do Python</target>
       </trans-unit>
       <trans-unit id="configurePython.pythonConfigured">
         <source xml:lang="en">Python runtime configured!</source>
-        <target state="new">Python runtime configured!</target>
+        <target state="translated">Runtime do Python configurado.</target>
       </trans-unit>
       <trans-unit id="configurePythyon.dropdownPathLabel">
         <source xml:lang="en">{0} (Python {1})</source>
-        <target state="new">{0} (Python {1})</target>
+        <target state="translated">{0} (Python {1})</target>
       </trans-unit>
       <trans-unit id="configurePythyon.noVersionsFound">
         <source xml:lang="en">No supported Python versions found.</source>
-        <target state="new">No supported Python versions found.</target>
+        <target state="translated">Não foram encontradas versões do Python com suporte.</target>
       </trans-unit>
       <trans-unit id="configurePythyon.defaultPathLabel">
         <source xml:lang="en">{0} (Default)</source>
-        <target state="new">{0} (Default)</target>
+        <target state="translated">{0} (Padrão)</target>
       </trans-unit>
       <trans-unit id="configurePython.newInstall">
         <source xml:lang="en">New Python installation</source>
-        <target state="new">New Python installation</target>
+        <target state="translated">Nova instalação do Python</target>
       </trans-unit>
       <trans-unit id="configurePython.existingInstall">
         <source xml:lang="en">Use existing Python installation</source>
-        <target state="new">Use existing Python installation</target>
+        <target state="translated">Usar a instalação existente do Python</target>
       </trans-unit>
       <trans-unit id="configurePythyon.customPathLabel">
         <source xml:lang="en">{0} (Custom)</source>
-        <target state="new">{0} (Custom)</target>
+        <target state="translated">{0} (Personalizado)</target>
       </trans-unit>
     </body>
   </file>
@@ -734,27 +822,27 @@
     <body>
       <trans-unit id="configurePython.pkgNameColumn">
         <source xml:lang="en">Name</source>
-        <target state="new">Name</target>
+        <target state="translated">Nome</target>
       </trans-unit>
       <trans-unit id="configurePython.existingVersionColumn">
         <source xml:lang="en">Existing Version</source>
-        <target state="new">Existing Version</target>
+        <target state="translated">Versão Existente</target>
       </trans-unit>
       <trans-unit id="configurePython.requiredVersionColumn">
         <source xml:lang="en">Required Version</source>
-        <target state="new">Required Version</target>
+        <target state="translated">Versão Obrigatória</target>
       </trans-unit>
       <trans-unit id="configurePython.kernelLabel">
         <source xml:lang="en">Kernel</source>
-        <target state="new">Kernel</target>
+        <target state="translated">Kernel</target>
       </trans-unit>
       <trans-unit id="configurePython.requiredDependencies">
         <source xml:lang="en">Install required kernel dependencies</source>
-        <target state="new">Install required kernel dependencies</target>
+        <target state="translated">Instalar dependências do kernel obrigatórias</target>
       </trans-unit>
       <trans-unit id="msgUnsupportedKernel">
         <source xml:lang="en">Could not retrieve packages for kernel {0}</source>
-        <target state="new">Could not retrieve packages for kernel {0}</target>
+        <target state="translated">Não foi possível recuperar pacotes para o kernel {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -774,7 +862,7 @@
       </trans-unit>
       <trans-unit id="notebookStartProcessExitPremature">
         <source xml:lang="en">Notebook process exited prematurely with error code: {0}. StdErr Output: {1}</source>
-        <target state="new">Notebook process exited prematurely with error code: {0}. StdErr Output: {1}</target>
+        <target state="translated">O processo do Notebook foi encerrado prematuramente com o código de erro: {0}. Saída de StdErr: {1}</target>
       </trans-unit>
       <trans-unit id="jupyterError">
         <source xml:lang="en">Error sent from Jupyter: {0}</source>
@@ -806,23 +894,23 @@
       </trans-unit>
       <trans-unit id="notebook.couldNotFindKnoxGateway">
         <source xml:lang="en">Could not find Knox gateway endpoint</source>
-        <target state="new">Could not find Knox gateway endpoint</target>
+        <target state="translated">Não foi possível localizar o ponto de extremidade do gateway do Knox</target>
       </trans-unit>
       <trans-unit id="promptBDCUsername">
         <source xml:lang="en">{0}Please provide the username to connect to the BDC Controller:</source>
-        <target state="new">{0}Please provide the username to connect to the BDC Controller:</target>
+        <target state="translated">{0}Forneça o nome de usuário para se conectar ao Controlador do BDC:</target>
       </trans-unit>
       <trans-unit id="promptBDCPassword">
         <source xml:lang="en">Please provide the password to connect to the BDC Controller</source>
-        <target state="new">Please provide the password to connect to the BDC Controller</target>
+        <target state="translated">Forneça a senha para se conectar ao Controlador do BDC</target>
       </trans-unit>
       <trans-unit id="bdcConnectError">
         <source xml:lang="en">Error: {0}. </source>
-        <target state="new">Error: {0}. </target>
+        <target state="translated">Erro: {0}. </target>
       </trans-unit>
       <trans-unit id="clusterControllerConnectionRequired">
         <source xml:lang="en">A connection to the cluster controller is required to run Spark jobs</source>
-        <target state="new">A connection to the cluster controller is required to run Spark jobs</target>
+        <target state="translated">Uma conexão com o controlador de cluster é necessária para executar trabalhos do Spark</target>
       </trans-unit>
     </body>
   </file>
@@ -854,7 +942,7 @@
       </trans-unit>
       <trans-unit id="managePackages.deleteColumn">
         <source xml:lang="en">Delete</source>
-        <target state="new">Delete</target>
+        <target state="translated">Excluir</target>
       </trans-unit>
       <trans-unit id="managePackages.uninstallButtonText">
         <source xml:lang="en">Uninstall selected packages</source>
@@ -866,7 +954,7 @@
       </trans-unit>
       <trans-unit id="managePackages.location">
         <source xml:lang="en">Location</source>
-        <target state="new">Location</target>
+        <target state="translated">Localização</target>
       </trans-unit>
       <trans-unit id="managePackages.packageCount">
         <source xml:lang="en">{0} {1} packages found</source>
@@ -946,7 +1034,7 @@
     <body>
       <trans-unit id="managePackages.packageRequestError">
         <source xml:lang="en">Package info request failed with error: {0} {1}</source>
-        <target state="new">Package info request failed with error: {0} {1}</target>
+        <target state="translated">Falha na solicitação de informações do pacote com o erro: {0} {1}</target>
       </trans-unit>
     </body>
   </file>
@@ -954,15 +1042,15 @@
     <body>
       <trans-unit id="msgSampleCodeDataFrame">
         <source xml:lang="en">This sample code loads the file into a data frame and shows the first 10 results.</source>
-        <target state="new">This sample code loads the file into a data frame and shows the first 10 results.</target>
+        <target state="translated">Este código de exemplo carrega o arquivo em um quadro de dados e mostra os 10 primeiros resultados.</target>
       </trans-unit>
       <trans-unit id="noNotebookVisible">
         <source xml:lang="en">No notebook editor is active</source>
-        <target state="new">No notebook editor is active</target>
+        <target state="translated">Não há nenhum editor de notebook ativo</target>
       </trans-unit>
       <trans-unit id="notebookFiles">
         <source xml:lang="en">Notebooks</source>
-        <target state="new">Notebooks</target>
+        <target state="translated">Notebooks</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">Não há suporte para a ação {0} para esse manipulador</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">Não é possível abrir o link {0} porque somente os links HTTP e HTTPS são compatíveis</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">Não é possível abrir o link {0} porque somente os links HTTP, HTTPS e de arquivos são compatíveis</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/pt-br/profiler.pt-BR.xlf
+++ b/resources/xlf/pt-br/profiler.pt-BR.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/pt-br/resource-deployment.pt-BR.xlf
+++ b/resources/xlf/pt-br/resource-deployment.pt-BR.xlf
@@ -12,7 +12,7 @@
       </trans-unit>
       <trans-unit id="deploy-resource-command-name">
         <source xml:lang="en">New Deployment…</source>
-        <target state="new">New Deployment…</target>
+        <target state="translated">Nova Implantação…</target>
       </trans-unit>
       <trans-unit id="deploy-resource-command-category">
         <source xml:lang="en">Deployment</source>
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">Executar a imagem de contêiner do SQL Server com o Docker</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">Cluster de Big Data do SQL Server</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">O Cluster de Big Data do SQL Server permite implantar clusters escalonáveis de contêineres do SQL Server, do Spark e do HDFS em execução no Kubernetes</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">Versão</target>
@@ -44,43 +36,15 @@
       </trans-unit>
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
-        <target state="new">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="new">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">Destino de implantação</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">Novo Cluster do Serviço de Kubernetes do Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">Cluster do Serviço de Kubernetes do Azure existente</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">Cluster do Kubernetes existente (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="new">Existing Azure Red Hat OpenShift cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="new">Existing OpenShift cluster</target>
+        <target state="translated">SQL Server 2019</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
-        <target state="new">Deploy SQL Server 2017 container images</target>
+        <target state="translated">Implantar imagens de contêiner do SQL Server 2017</target>
       </trans-unit>
       <trans-unit id="docker-sql-2019-title">
         <source xml:lang="en">Deploy SQL Server 2019 container images</source>
-        <target state="new">Deploy SQL Server 2019 container images</target>
+        <target state="translated">Implantar imagens de contêiner do SQL Server 2019</target>
       </trans-unit>
       <trans-unit id="docker-container-name-field">
         <source xml:lang="en">Container name</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">Porta</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">Configurações do cluster de Big Data do SQL Server</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">Nome do cluster</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">Nome de usuário do controlador</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">Senha</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">Confirmar a senha</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Configurações do Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">ID da assinatura</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">Usar minha assinatura padrão do Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">Nome do grupo de recursos</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">Região</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">Nome do cluster do AKS</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">Tamanho da VM</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">Contagem de VMs</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">Nome da classe de armazenamento</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">Capacidade de dados (GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">Capacidade de logs (GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">SQL Server no Windows</target>
@@ -170,197 +70,185 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">Execute o SQL Server no Windows, selecione uma versão para começar.</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">Aceito {0}, {1} e {2}.</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
-        <target state="new">Microsoft Privacy Statement</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">Termos de Licença do azdata</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">Termos de Licença do SQL Server</target>
+        <target state="translated">Política de Privacidade da Microsoft</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
-        <target state="new">Deployment configuration</target>
+        <target state="translated">Configuração de implantação</target>
       </trans-unit>
       <trans-unit id="azdata-install-location-description">
         <source xml:lang="en">Location of the azdata package used for the install command</source>
-        <target state="new">Location of the azdata package used for the install command</target>
+        <target state="translated">Localização do pacote azdata usado para o comando de instalação</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-display-name">
         <source xml:lang="en">SQL Server on Azure Virtual Machine</source>
-        <target state="new">SQL Server on Azure Virtual Machine</target>
+        <target state="translated">SQL Server na Máquina Virtual do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-description">
         <source xml:lang="en">Create SQL virtual machines on Azure. Best for migrations and applications requiring OS-level access.</source>
-        <target state="new">Create SQL virtual machines on Azure. Best for migrations and applications requiring OS-level access.</target>
+        <target state="translated">Crie máquinas virtuais do SQL no Azure. Isso é ideal para migrações e aplicativos que exigem acesso ao nível do SO.</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-deploy-dialog-title">
         <source xml:lang="en">Deploy Azure SQL virtual machine</source>
-        <target state="new">Deploy Azure SQL virtual machine</target>
+        <target state="translated">Implantar a máquina virtual do SQL do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-deploy-dialog-action-text">
         <source xml:lang="en">Script to notebook</source>
-        <target state="new">Script to notebook</target>
+        <target state="translated">Script para o notebook</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement">
         <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="new">I accept {0}, {1} and {2}.</target>
+        <target state="translated">Aceito {0}, {1} e {2}.</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement-sqlvm-eula">
         <source xml:lang="en">Azure SQL VM License Terms</source>
-        <target state="new">Azure SQL VM License Terms</target>
+        <target state="translated">Termos de Licença da VM do SQL do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-agreement-azdata-eula">
         <source xml:lang="en">azdata License Terms</source>
-        <target state="new">azdata License Terms</target>
+        <target state="translated">Termos de Licença do azdata</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-azure-account-page-label">
         <source xml:lang="en">Azure information</source>
-        <target state="new">Azure information</target>
+        <target state="translated">Informações do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-azure-location-label">
         <source xml:lang="en">Azure locations</source>
-        <target state="new">Azure locations</target>
+        <target state="translated">Locais do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-information-page-label">
         <source xml:lang="en">VM information</source>
-        <target state="new">VM information</target>
+        <target state="translated">Informações da VM</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-image-label">
         <source xml:lang="en">Image</source>
-        <target state="new">Image</target>
+        <target state="translated">Imagem</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-image-sku-label">
         <source xml:lang="en">VM image SKU</source>
-        <target state="new">VM image SKU</target>
+        <target state="translated">SKU da imagem de VM</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-publisher-label">
         <source xml:lang="en">Publisher</source>
-        <target state="new">Publisher</target>
+        <target state="translated">Editor</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vmname-label">
         <source xml:lang="en">Virtual machine name</source>
-        <target state="new">Virtual machine name</target>
+        <target state="translated">Nome da máquina virtual</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vmsize-label">
         <source xml:lang="en">Size</source>
-        <target state="new">Size</target>
+        <target state="translated">Tamanho</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-page-lable">
         <source xml:lang="en">Storage account</source>
-        <target state="new">Storage account</target>
+        <target state="translated">Conta de armazenamento</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-accountname-label">
         <source xml:lang="en">Storage account name</source>
-        <target state="new">Storage account name</target>
+        <target state="translated">Nome da conta de armazenamento</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-storage-sku-label">
         <source xml:lang="en">Storage account SKU type</source>
-        <target state="new">Storage account SKU type</target>
+        <target state="translated">Tipo de SKU da conta de armazenamento</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-administrator-account-page-label">
         <source xml:lang="en">Administrator account</source>
-        <target state="new">Administrator account</target>
+        <target state="translated">Conta de administrador</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-username-label">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">Nome de usuário</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-password-label">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">Senha</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-password-confirm-label">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">Confirmar a senha</target>
       </trans-unit>
       <trans-unit id="azure-sqlvm-vm-summary-page-label">
         <source xml:lang="en">Summary</source>
-        <target state="new">Summary</target>
+        <target state="translated">Resumo</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-display-name">
         <source xml:lang="en">Azure SQL Database</source>
-        <target state="new">Azure SQL Database</target>
+        <target state="translated">Banco de Dados SQL do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-description">
         <source xml:lang="en">Create a SQL database, database server, or elastic pool in Azure.</source>
-        <target state="new">Create a SQL database, database server, or elastic pool in Azure.</target>
+        <target state="translated">Crie um banco de dados SQL, um servidor de banco de dados ou um pool elástico no Azure.</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-portal-ok-button-text">
         <source xml:lang="en">Create in Azure portal</source>
-        <target state="new">Create in Azure portal</target>
+        <target state="translated">Criar no portal do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-notebook-ok-button-text">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">Selecionar</target>
       </trans-unit>
       <trans-unit id="resource-type-display-name">
         <source xml:lang="en">Resource Type</source>
-        <target state="new">Resource Type</target>
+        <target state="translated">Tipo de Recurso</target>
       </trans-unit>
       <trans-unit id="sql-azure-single-database-display-name">
         <source xml:lang="en">Single Database</source>
-        <target state="new">Single Database</target>
+        <target state="translated">Banco de Dados Individual</target>
       </trans-unit>
       <trans-unit id="sql-azure-elastic-pool-display-name">
         <source xml:lang="en">Elastic Pool</source>
-        <target state="new">Elastic Pool</target>
+        <target state="translated">Pool Elástico</target>
       </trans-unit>
       <trans-unit id="sql-azure-database-server-display-name">
         <source xml:lang="en">Database Server</source>
-        <target state="new">Database Server</target>
+        <target state="translated">Servidor de Banco de Dados</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement">
         <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="new">I accept {0}, {1} and {2}.</target>
+        <target state="translated">Aceito {0}, {1} e {2}.</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement-sqldb-eula">
         <source xml:lang="en">Azure SQL DB License Terms</source>
-        <target state="new">Azure SQL DB License Terms</target>
+        <target state="translated">Termos de Licença do BD SQL do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sqldb-agreement-azdata-eula">
         <source xml:lang="en">azdata License Terms</source>
-        <target state="new">azdata License Terms</target>
+        <target state="translated">Termos de Licença do azdata</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-display-name">
         <source xml:lang="en">Azure SQL managed instance</source>
-        <target state="new">Azure SQL managed instance</target>
+        <target state="translated">Instância gerenciada de SQL do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-display-description">
         <source xml:lang="en">Create a SQL Managed Instance in either Azure or a customer-managed environment</source>
-        <target state="new">Create a SQL Managed Instance in either Azure or a customer-managed environment</target>
+        <target state="translated">Criar uma Instância Gerenciada de SQL no Azure ou em um ambiente gerenciado pelo cliente</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-okButton-text">
         <source xml:lang="en">Open in Portal</source>
-        <target state="new">Open in Portal</target>
+        <target state="translated">Abrir no Portal</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-resource-type-option-label">
         <source xml:lang="en">Resource Type</source>
-        <target state="new">Resource Type</target>
+        <target state="translated">Tipo de Recurso</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-agreement">
         <source xml:lang="en">I accept {0} and {1}.</source>
-        <target state="new">I accept {0} and {1}.</target>
+        <target state="translated">Aceito {0} e {1}.</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-agreement-eula">
         <source xml:lang="en">Azure SQL MI License Terms</source>
-        <target state="new">Azure SQL MI License Terms</target>
+        <target state="translated">Termos de Licença da MI do SQL do Azure</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-help-text">
         <source xml:lang="en">Azure SQL Managed Instance provides full SQL Server access and feature compatibility for migrating SQL Servers to Azure, or developing new applications. {0}.</source>
-        <target state="new">Azure SQL Managed Instance provides full SQL Server access and feature compatibility for migrating SQL Servers to Azure, or developing new applications. {0}.</target>
+        <target state="translated">A Instância Gerenciada de SQL do Azure fornece acesso completo ao SQL Server e compatibilidade de recurso para migrar SQL Servers para o Azure ou desenvolver novos aplicativos. {0}.</target>
       </trans-unit>
       <trans-unit id="azure-sql-mi-help-text-learn-more">
         <source xml:lang="en">Learn More</source>
-        <target state="new">Learn More</target>
+        <target state="translated">Saiba Mais</target>
       </trans-unit>
     </body>
   </file>
@@ -368,227 +256,243 @@
     <body>
       <trans-unit id="azure.account">
         <source xml:lang="en">Azure Account</source>
-        <target state="new">Azure Account</target>
+        <target state="translated">Conta do Azure</target>
       </trans-unit>
       <trans-unit id="azure.account.subscription">
         <source xml:lang="en">Subscription (selected subset)</source>
-        <target state="new">Subscription (selected subset)</target>
+        <target state="translated">Assinatura (subconjunto selecionado)</target>
       </trans-unit>
       <trans-unit id="azure.account.subscriptionDescription">
         <source xml:lang="en">Change the currently selected subscriptions through the 'Select Subscriptions' action on an account listed in the 'Azure' tree view of the 'Connections' viewlet</source>
-        <target state="new">Change the currently selected subscriptions through the 'Select Subscriptions' action on an account listed in the 'Azure' tree view of the 'Connections' viewlet</target>
+        <target state="translated">Altere as assinaturas atualmente selecionadas por meio da ação 'Selecionar Assinaturas' em uma conta listada no modo de exibição de árvore 'Azure' do viewlet 'Conexões'</target>
       </trans-unit>
       <trans-unit id="azure.account.resourceGroup">
         <source xml:lang="en">Resource Group</source>
-        <target state="new">Resource Group</target>
+        <target state="translated">Grupo de Recursos</target>
       </trans-unit>
       <trans-unit id="azure.account.location">
         <source xml:lang="en">Azure Location</source>
-        <target state="new">Azure Location</target>
+        <target state="translated">Localização do Azure</target>
       </trans-unit>
       <trans-unit id="filePicker.browse">
         <source xml:lang="en">Browse</source>
-        <target state="new">Browse</target>
+        <target state="translated">Procurar</target>
       </trans-unit>
       <trans-unit id="button.label">
         <source xml:lang="en">Select</source>
-        <target state="new">Select</target>
+        <target state="translated">Selecionar</target>
       </trans-unit>
       <trans-unit id="kubeConfigClusterPicker.kubeConfigFilePath">
         <source xml:lang="en">Kube config file path</source>
-        <target state="new">Kube config file path</target>
+        <target state="translated">Caminho do arquivo de configuração de Kube</target>
       </trans-unit>
       <trans-unit id="kubeConfigClusterPicker.clusterContextNotFound">
         <source xml:lang="en">No cluster context information found</source>
-        <target state="new">No cluster context information found</target>
+        <target state="translated">Nenhuma informação de contexto de cluster encontrada</target>
       </trans-unit>
       <trans-unit id="azure.signin">
         <source xml:lang="en">Sign in…</source>
-        <target state="new">Sign in…</target>
+        <target state="translated">Entrar…</target>
       </trans-unit>
       <trans-unit id="azure.refresh">
         <source xml:lang="en">Refresh</source>
-        <target state="new">Refresh</target>
+        <target state="translated">Atualizar</target>
       </trans-unit>
       <trans-unit id="azure.yes">
         <source xml:lang="en">Yes</source>
-        <target state="new">Yes</target>
+        <target state="translated">Sim</target>
       </trans-unit>
       <trans-unit id="azure.no">
         <source xml:lang="en">No</source>
-        <target state="new">No</target>
+        <target state="translated">Não</target>
       </trans-unit>
       <trans-unit id="azure.resourceGroup.createNewResourceGroup">
         <source xml:lang="en">Create a new resource group</source>
-        <target state="new">Create a new resource group</target>
+        <target state="translated">Criar um novo grupo de recurso</target>
       </trans-unit>
       <trans-unit id="azure.resourceGroup.NewResourceGroupAriaLabel">
         <source xml:lang="en">New resource group name</source>
-        <target state="new">New resource group name</target>
+        <target state="translated">Nome do novo grupo de recursos</target>
       </trans-unit>
       <trans-unit id="deployCluster.Realm">
         <source xml:lang="en">Realm</source>
-        <target state="new">Realm</target>
+        <target state="translated">Realm</target>
       </trans-unit>
       <trans-unit id="UnknownFieldTypeError">
         <source xml:lang="en">Unknown field type: "{0}"</source>
-        <target state="new">Unknown field type: "{0}"</target>
+        <target state="translated">Tipo de campo desconhecido: "{0}"</target>
       </trans-unit>
       <trans-unit id="optionsSource.alreadyDefined">
         <source xml:lang="en">Options Source with id:{0} is already defined</source>
-        <target state="new">Options Source with id:{0} is already defined</target>
+        <target state="translated">A Fonte de Opções com a ID {0} já está definida</target>
       </trans-unit>
       <trans-unit id="valueProvider.alreadyDefined">
         <source xml:lang="en">Value Provider with id:{0} is already defined</source>
-        <target state="new">Value Provider with id:{0} is already defined</target>
+        <target state="translated">O Provedor de Valor com a ID {0} já está definido</target>
       </trans-unit>
       <trans-unit id="optionsSource.notDefined">
         <source xml:lang="en">No Options Source defined for id: {0}</source>
-        <target state="new">No Options Source defined for id: {0}</target>
+        <target state="translated">Nenhuma Fonte de Opções definida para a ID: {0}</target>
       </trans-unit>
       <trans-unit id="valueProvider.notDefined">
         <source xml:lang="en">No Value Provider defined for id: {0}</source>
-        <target state="new">No Value Provider defined for id: {0}</target>
+        <target state="translated">Nenhum Provedor de Valor foi definido para a ID: {0}</target>
       </trans-unit>
       <trans-unit id="getVariableValue.unknownVariableName">
         <source xml:lang="en">Attempt to get variable value for unknown variable:{0}</source>
-        <target state="new">Attempt to get variable value for unknown variable:{0}</target>
+        <target state="translated">Tentativa de obter o valor de variável para a variável desconhecida: {0}</target>
       </trans-unit>
       <trans-unit id="getIsPassword.unknownVariableName">
         <source xml:lang="en">Attempt to get isPassword for unknown variable:{0}</source>
-        <target state="new">Attempt to get isPassword for unknown variable:{0}</target>
+        <target state="translated">Tentativa de obter isPassword para uma variável desconhecida: {0}</target>
       </trans-unit>
       <trans-unit id="optionsNotDefined">
         <source xml:lang="en">FieldInfo.options was not defined for field type: {0}</source>
-        <target state="new">FieldInfo.options was not defined for field type: {0}</target>
+        <target state="translated">FieldInfo.options não foi definido para o tipo de campo: {0}</target>
       </trans-unit>
       <trans-unit id="optionsNotObjectOrArray">
         <source xml:lang="en">FieldInfo.options must be an object if it is not an array</source>
-        <target state="new">FieldInfo.options must be an object if it is not an array</target>
+        <target state="translated">FieldInfo.options precisa ser um objeto se não for uma matriz</target>
       </trans-unit>
       <trans-unit id="optionsTypeNotFound">
         <source xml:lang="en">When FieldInfo.options is an object it must have 'optionsType' property</source>
-        <target state="new">When FieldInfo.options is an object it must have 'optionsType' property</target>
+        <target state="translated">Quando FieldInfo.options for um objeto, ele precisará ter a propriedade 'optionsType'</target>
       </trans-unit>
       <trans-unit id="optionsTypeRadioOrDropdown">
         <source xml:lang="en">When optionsType is not {0} then it must be {1}</source>
-        <target state="new">When optionsType is not {0} then it must be {1}</target>
+        <target state="translated">Quando optionsType não for {0}, ele precisará ser {1}</target>
       </trans-unit>
       <trans-unit id="azdataEulaNotAccepted">
         <source xml:lang="en">Deployment cannot continue. Azure Data CLI license terms have not yet been accepted. Please accept the EULA to enable the features that requires Azure Data CLI.</source>
-        <target state="new">Deployment cannot continue. Azure Data CLI license terms have not yet been accepted. Please accept the EULA to enable the features that requires Azure Data CLI.</target>
+        <target state="translated">A implantação não pode continuar. Os termos de licença da CLI de Dados do Azure ainda não foram aceitos. Aceite os Termos de Licença para Software Microsoft para habilitar os recursos que exigem a CLI de Dados do Azure.</target>
       </trans-unit>
       <trans-unit id="azdataEulaDeclined">
         <source xml:lang="en">Deployment cannot continue. Azure Data CLI license terms were declined.You can either Accept EULA to continue or Cancel this operation</source>
-        <target state="new">Deployment cannot continue. Azure Data CLI license terms were declined.You can either Accept EULA to continue or Cancel this operation</target>
+        <target state="translated">A implantação não pode continuar. Os termos de licença da CLI de Dados do Azure foram recusados. Você pode aceitar os Termos de Licença para Software Microsoft para continuar ou cancelar esta operação</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
-        <target state="new">Accept EULA &amp; Select</target>
+        <target state="translated">Aceitar os Termos de Licença para Software Microsoft e Selecionar</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">A extensão '{0}' é necessária para implantar esse recurso, deseja instalá-lo agora?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Instalar</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">Instalando a Extensão '{0}'...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">Extensão desconhecida '{0}'</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
-        <target state="new">Select the deployment options</target>
+        <target state="translated">Selecione as opções de implantação</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceSearchPlaceholder">
         <source xml:lang="en">Filter resources...</source>
-        <target state="new">Filter resources...</target>
+        <target state="translated">Filtrar recursos...</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.tagsListViewTitle">
         <source xml:lang="en">Categories</source>
-        <target state="new">Categories</target>
+        <target state="translated">Categorias</target>
       </trans-unit>
       <trans-unit id="validation.multipleValidationErrors">
         <source xml:lang="en">There are some errors on this page, click 'Show Details' to view the errors.</source>
-        <target state="new">There are some errors on this page, click 'Show Details' to view the errors.</target>
+        <target state="translated">Há alguns erros nesta página. Clique em 'Mostrar Detalhes' para exibir os erros.</target>
       </trans-unit>
       <trans-unit id="ui.ScriptToNotebookButton">
         <source xml:lang="en">Script</source>
-        <target state="new">Script</target>
+        <target state="translated">Script</target>
       </trans-unit>
       <trans-unit id="ui.DeployButton">
         <source xml:lang="en">Run</source>
-        <target state="new">Run</target>
+        <target state="translated">Executar</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.ViewErrorDetail">
         <source xml:lang="en">View error detail</source>
-        <target state="new">View error detail</target>
+        <target state="translated">Exibir detalhe do erro</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.FailedToOpenNotebook">
         <source xml:lang="en">An error occurred opening the output notebook. {1}{2}.</source>
-        <target state="new">An error occurred opening the output notebook. {1}{2}.</target>
+        <target state="translated">Ocorreu um erro ao abrir o notebook de saída. {1}{2}.</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.BackgroundExecutionFailed">
         <source xml:lang="en">The task "{0}" has failed.</source>
-        <target state="new">The task "{0}" has failed.</target>
+        <target state="translated">Falha na tarefa "{0}".</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.TaskFailedWithNoOutputNotebook">
         <source xml:lang="en">The task "{0}" failed and no output Notebook was generated.</source>
-        <target state="new">The task "{0}" failed and no output Notebook was generated.</target>
+        <target state="translated">Houve uma falha na tarefa "{0}" e nenhum Notebook de saída foi gerado.</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryAll">
         <source xml:lang="en">All</source>
-        <target state="new">All</target>
+        <target state="translated">Tudo</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnPrem">
         <source xml:lang="en">On-premises</source>
-        <target state="new">On-premises</target>
+        <target state="translated">Local</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoriesSqlServer">
         <source xml:lang="en">SQL Server</source>
-        <target state="new">SQL Server</target>
+        <target state="translated">SQL Server</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnHybrid">
         <source xml:lang="en">Hybrid</source>
-        <target state="new">Hybrid</target>
+        <target state="translated">Híbrido</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnPostgreSql">
         <source xml:lang="en">PostgreSQL</source>
-        <target state="new">PostgreSQL</target>
+        <target state="translated">PostgreSQL</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.resourceTypeCategoryOnCloud">
         <source xml:lang="en">Cloud</source>
-        <target state="new">Cloud</target>
+        <target state="translated">Nuvem</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Description">
         <source xml:lang="en">Description</source>
-        <target state="new">Description</target>
+        <target state="translated">Descrição</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Tool">
         <source xml:lang="en">Tool</source>
-        <target state="new">Tool</target>
+        <target state="translated">Ferramenta</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Status">
         <source xml:lang="en">Status</source>
-        <target state="new">Status</target>
+        <target state="translated">Status</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Version">
         <source xml:lang="en">Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Versão</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.RequiredVersion">
         <source xml:lang="en">Required Version</source>
-        <target state="new">Required Version</target>
+        <target state="translated">Versão Obrigatória</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.discoverPathOrAdditionalInformation">
         <source xml:lang="en">Discovered Path or Additional Information</source>
-        <target state="new">Discovered Path or Additional Information</target>
+        <target state="translated">Caminho Descoberto ou Informações Adicionais</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.requiredTools">
         <source xml:lang="en">Required tools</source>
-        <target state="new">Required tools</target>
+        <target state="translated">Ferramentas necessárias</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.InstallTools">
         <source xml:lang="en">Install tools</source>
-        <target state="new">Install tools</target>
+        <target state="translated">Ferramentas de instalação</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Options">
         <source xml:lang="en">Options</source>
-        <target state="new">Options</target>
+        <target state="translated">Opções</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallingTool">
         <source xml:lang="en">Required tool '{0}' [ {1} ] is being installed now.</source>
-        <target state="new">Required tool '{0}' [ {1} ] is being installed now.</target>
+        <target state="translated">A ferramenta obrigatória '{0}' [ {1} ] está sendo instalada agora.</target>
       </trans-unit>
     </body>
   </file>
@@ -596,45 +500,45 @@
     <body>
       <trans-unit id="getClusterContexts.errorFetchingClusters">
         <source xml:lang="en">An error ocurred while loading or parsing the config file:{0}, error is:{1}</source>
-        <target state="new">An error ocurred while loading or parsing the config file:{0}, error is:{1}</target>
+        <target state="translated">Ocorreu um erro ao carregar ou analisar o arquivo de configuração: {0}. O erro é: {1}</target>
       </trans-unit>
       <trans-unit id="fileChecker.NotFile">
         <source xml:lang="en">Path: {0} is not a file, please select a valid kube config file.</source>
-        <target state="new">Path: {0} is not a file, please select a valid kube config file.</target>
+        <target state="translated">Caminho: {0} não é um arquivo, selecione um arquivo de configuração de kube válido.</target>
       </trans-unit>
       <trans-unit id="fileChecker.FileNotFound">
         <source xml:lang="en">File: {0} not found. Please select a kube config file.</source>
-        <target state="new">File: {0} not found. Please select a kube config file.</target>
+        <target state="translated">Arquivo: {0} não encontrado. Selecione um arquivo de configuração de kube.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedAccountsError">
         <source xml:lang="en">Unexpected error fetching accounts: {0}</source>
-        <target state="new">Unexpected error fetching accounts: {0}</target>
+        <target state="translated">Erro inesperado ao buscar contas: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.errorFetchingStorageClasses">
         <source xml:lang="en">Unexpected error fetching available kubectl storage classes : {0}</source>
-        <target state="new">Unexpected error fetching available kubectl storage classes : {0}</target>
+        <target state="translated">Erro inesperado ao buscar classes de armazenamento kubectl disponíveis: {0}</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedSubscriptionsError">
         <source xml:lang="en">Unexpected error fetching subscriptions for account {0}: {1}</source>
-        <target state="new">Unexpected error fetching subscriptions for account {0}: {1}</target>
+        <target state="translated">Erro inesperado ao buscar assinaturas para a conta {0}: {1}</target>
       </trans-unit>
       <trans-unit id="azure.accounts.accountNotFoundError">
         <source xml:lang="en">The selected account '{0}' is no longer available. Click sign in to add it again or select a different account.</source>
-        <target state="new">The selected account '{0}' is no longer available. Click sign in to add it again or select a different account.</target>
+        <target state="translated">A conta selecionada '{0}' não está mais disponível. Clique em entrar para adicioná-la novamente ou selecione uma conta diferente.</target>
       </trans-unit>
       <trans-unit id="azure.accessError">
         <source xml:lang="en">
  Error Details: {0}.</source>
-        <target state="new">
- Error Details: {0}.</target>
+        <target state="translated">
+ Detalhes do Erro: {0}.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.accountStaleError">
         <source xml:lang="en">The access token for selected account '{0}' is no longer valid. Please click the sign in button and refresh the account or select a different account.</source>
-        <target state="new">The access token for selected account '{0}' is no longer valid. Please click the sign in button and refresh the account or select a different account.</target>
+        <target state="translated">O token de acesso para a conta selecionada '{0}' não é mais válido. Clique no botão Entrar e atualize a conta ou selecione uma conta diferente.</target>
       </trans-unit>
       <trans-unit id="azure.accounts.unexpectedResourceGroupsError">
         <source xml:lang="en">Unexpected error fetching resource groups for subscription {0}: {1}</source>
-        <target state="new">Unexpected error fetching resource groups for subscription {0}: {1}</target>
+        <target state="translated">Erro inesperado ao buscar grupos de recursos para a assinatura {0}: {1}</target>
       </trans-unit>
       <trans-unit id="invalidSQLPassword">
         <source xml:lang="en">{0} doesn't meet the password complexity requirement. For more information: https://docs.microsoft.com/sql/relational-databases/security/password-policy</source>
@@ -650,139 +554,139 @@
     <body>
       <trans-unit id="deployAzureSQLVM.NewSQLVMTitle">
         <source xml:lang="en">Deploy Azure SQL VM</source>
-        <target state="new">Deploy Azure SQL VM</target>
+        <target state="translated">Implantar a VM do SQL do Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Script para o Notebook</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">Preencha os campos obrigatórios marcados com asteriscos vermelhos.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureSettingsPageTitle">
         <source xml:lang="en">Azure settings</source>
-        <target state="new">Azure settings</target>
+        <target state="translated">Configurações do Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureAccountDropdownLabel">
         <source xml:lang="en">Azure Account</source>
-        <target state="new">Azure Account</target>
+        <target state="translated">Conta do Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureSubscriptionDropdownLabel">
         <source xml:lang="en">Subscription</source>
-        <target state="new">Subscription</target>
+        <target state="translated">Assinatura</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.ResourceGroup">
         <source xml:lang="en">Resource Group</source>
-        <target state="new">Resource Group</target>
+        <target state="translated">Grupo de Recursos</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.AzureRegionDropdownLabel">
         <source xml:lang="en">Region</source>
-        <target state="new">Region</target>
+        <target state="translated">Região</target>
       </trans-unit>
       <trans-unit id="deployeAzureSQLVM.VmSettingsPageTitle">
         <source xml:lang="en">Virtual machine settings</source>
-        <target state="new">Virtual machine settings</target>
+        <target state="translated">Configurações de máquina virtual</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmNameTextBoxLabel">
         <source xml:lang="en">Virtual machine name</source>
-        <target state="new">Virtual machine name</target>
+        <target state="translated">Nome da máquina virtual</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminUsernameTextBoxLabel">
         <source xml:lang="en">Administrator account username</source>
-        <target state="new">Administrator account username</target>
+        <target state="translated">Nome de usuário da conta de administrador</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminPasswordTextBoxLabel">
         <source xml:lang="en">Administrator account password</source>
-        <target state="new">Administrator account password</target>
+        <target state="translated">Senha da conta de administrador</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmAdminConfirmPasswordTextBoxLabel">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">Confirmar a senha</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmImageDropdownLabel">
         <source xml:lang="en">Image</source>
-        <target state="new">Image</target>
+        <target state="translated">Imagem</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmSkuDropdownLabel">
         <source xml:lang="en">Image SKU</source>
-        <target state="new">Image SKU</target>
+        <target state="translated">SKU da Imagem</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmImageVersionDropdownLabel">
         <source xml:lang="en">Image Version</source>
-        <target state="new">Image Version</target>
+        <target state="translated">Versão da Imagem</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmSizeDropdownLabel">
         <source xml:lang="en">Size</source>
-        <target state="new">Size</target>
+        <target state="translated">Tamanho</target>
       </trans-unit>
       <trans-unit id="deployeAzureSQLVM.VmSizeLearnMoreLabel">
         <source xml:lang="en">Click here to learn more about pricing and supported VM sizes</source>
-        <target state="new">Click here to learn more about pricing and supported VM sizes</target>
+        <target state="translated">Clique aqui para saber mais sobre o preço e os tamanhos de VM com suporte</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsPageTitle">
         <source xml:lang="en">Networking</source>
-        <target state="new">Networking</target>
+        <target state="translated">Rede</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsPageDescription">
         <source xml:lang="en">Configure network settings</source>
-        <target state="new">Configure network settings</target>
+        <target state="translated">Definir configurações de rede</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsNewVirtualNetwork">
         <source xml:lang="en">New virtual network</source>
-        <target state="new">New virtual network</target>
+        <target state="translated">Nova rede virtual</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VirtualNetworkDropdownLabel">
         <source xml:lang="en">Virtual Network</source>
-        <target state="new">Virtual Network</target>
+        <target state="translated">Rede Virtual</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsNewSubnet">
         <source xml:lang="en">New subnet</source>
-        <target state="new">New subnet</target>
+        <target state="translated">Nova sub-rede</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SubnetDropdownLabel">
         <source xml:lang="en">Subnet</source>
-        <target state="new">Subnet</target>
+        <target state="translated">Sub-rede</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PublicIPDropdownLabel">
         <source xml:lang="en">Public IP</source>
-        <target state="new">Public IP</target>
+        <target state="translated">IP</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NetworkSettingsUseExistingPublicIp">
         <source xml:lang="en">New public ip</source>
-        <target state="new">New public ip</target>
+        <target state="translated">Novo IP</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VmRDPAllowCheckboxLabel">
         <source xml:lang="en">Enable Remote Desktop (RDP) inbound port (3389)</source>
-        <target state="new">Enable Remote Desktop (RDP) inbound port (3389)</target>
+        <target state="translated">Habilitar a porta de entrada da RDP (Área de Trabalho Remota) (3389)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlServerSettingsPageTitle">
         <source xml:lang="en">SQL Servers settings</source>
-        <target state="new">SQL Servers settings</target>
+        <target state="translated">Configurações de SQL Servers</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlConnectivityTypeDropdownLabel">
         <source xml:lang="en">SQL connectivity</source>
-        <target state="new">SQL connectivity</target>
+        <target state="translated">Conectividade do SQL</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlPortLabel">
         <source xml:lang="en">Port</source>
-        <target state="new">Port</target>
+        <target state="translated">Porta</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlEnableSQLAuthenticationLabel">
         <source xml:lang="en">Enable SQL authentication</source>
-        <target state="new">Enable SQL authentication</target>
+        <target state="translated">Habilitar autenticação do SQL</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationUsernameLabel">
         <source xml:lang="en">Username</source>
-        <target state="new">Username</target>
+        <target state="translated">Nome de usuário</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationPasswordLabel">
         <source xml:lang="en">Password</source>
-        <target state="new">Password</target>
+        <target state="translated">Senha</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlAuthenticationConfirmPasswordLabel">
         <source xml:lang="en">Confirm password</source>
-        <target state="new">Confirm password</target>
+        <target state="translated">Confirmar a senha</target>
       </trans-unit>
     </body>
   </file>
@@ -790,39 +694,39 @@
     <body>
       <trans-unit id="deployCluster.SaveConfigFiles">
         <source xml:lang="en">Save config files</source>
-        <target state="new">Save config files</target>
+        <target state="translated">Salvar arquivos de configuração</target>
       </trans-unit>
       <trans-unit id="deployCluster.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Script para o Notebook</target>
       </trans-unit>
       <trans-unit id="deployCluster.SelectConfigFileFolder">
         <source xml:lang="en">Save config files</source>
-        <target state="new">Save config files</target>
+        <target state="translated">Salvar arquivos de configuração</target>
       </trans-unit>
       <trans-unit id="deployCluster.SaveConfigFileSucceeded">
         <source xml:lang="en">Config files saved to {0}</source>
-        <target state="new">Config files saved to {0}</target>
+        <target state="translated">Arquivos de configuração salvos em {0}</target>
       </trans-unit>
       <trans-unit id="deployCluster.NewAKSWizardTitle">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on a new AKS cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on a new AKS cluster</target>
+        <target state="translated">Implantar o Cluster de Big Data do SQL Server 2019 em um novo cluster do AKS</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingAKSWizardTitle">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing AKS cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing AKS cluster</target>
+        <target state="translated">Implantar o Cluster de Big Data do SQL Server 2019 em um cluster do AKS existente</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingKubeAdm">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing kubeadm cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing kubeadm cluster</target>
+        <target state="translated">Implantar o Cluster de Big Data do SQL Server 2019 em um cluster de kubeadm existente</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingARO">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing Azure Red Hat OpenShift cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing Azure Red Hat OpenShift cluster</target>
+        <target state="translated">Implante o Cluster de Big Data do SQL Server 2019 em um cluster do Red Hat OpenShift no Azure existente</target>
       </trans-unit>
       <trans-unit id="deployCluster.ExistingOpenShift">
         <source xml:lang="en">Deploy SQL Server 2019 Big Data Cluster on an existing OpenShift cluster</source>
-        <target state="new">Deploy SQL Server 2019 Big Data Cluster on an existing OpenShift cluster</target>
+        <target state="translated">Implante o Cluster de Big Data do SQL Server 2019 em um cluster do OpenShift existente</target>
       </trans-unit>
     </body>
   </file>
@@ -830,79 +734,79 @@
     <body>
       <trans-unit id="deploymentDialog.ToolStatus.NotInstalled">
         <source xml:lang="en">Not Installed</source>
-        <target state="new">Not Installed</target>
+        <target state="translated">Não Instalado</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Installed">
         <source xml:lang="en">Installed</source>
-        <target state="new">Installed</target>
+        <target state="translated">Instalado</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Installing">
         <source xml:lang="en">Installing…</source>
-        <target state="new">Installing…</target>
+        <target state="translated">Instalando…</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Error">
         <source xml:lang="en">Error</source>
-        <target state="new">Error</target>
+        <target state="translated">Erro</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolStatus.Failed">
         <source xml:lang="en">Failed</source>
-        <target state="new">Failed</target>
+        <target state="translated">Com falha</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformationalMessage.Brew">
         <source xml:lang="en">•	brew is needed for deployment of the tools and needs to be pre-installed before necessary tools can be deployed</source>
-        <target state="new">•	brew is needed for deployment of the tools and needs to be pre-installed before necessary tools can be deployed</target>
+        <target state="translated">•	O brew é necessário na implantação das ferramentas e precisa ser pré-instalado antes que as ferramentas necessárias possam ser implantadas</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformationalMessage.Curl">
         <source xml:lang="en">•	curl is needed for installation and needs to be pre-installed before necessary tools can be deployed</source>
-        <target state="new">•	curl is needed for installation and needs to be pre-installed before necessary tools can be deployed</target>
+        <target state="translated">•	O curl é necessário na instalação e precisa ser pré-instalado antes que as ferramentas necessárias possam ser implantadas</target>
       </trans-unit>
       <trans-unit id="toolBase.getPip3InstallationLocation.LocationNotFound">
         <source xml:lang="en">   Could not find 'Location' in the output:</source>
-        <target state="new">   Could not find 'Location' in the output:</target>
+        <target state="translated">   Não foi possível encontrar 'Localização' na saída:</target>
       </trans-unit>
       <trans-unit id="toolBase.getPip3InstallationLocation.Output">
         <source xml:lang="en">   output:</source>
-        <target state="new">   output:</target>
+        <target state="translated">   saída:</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallError">
         <source xml:lang="en">Error installing tool '{0}' [ {1} ].{2}Error: {3}{2}See output channel '{4}' for more details</source>
-        <target state="new">Error installing tool '{0}' [ {1} ].{2}Error: {3}{2}See output channel '{4}' for more details</target>
+        <target state="translated">Erro ao instalar a ferramenta '{0}' [ {1} ].{2}Erro: {3}{2}Confira o canal de saída '{4}' para obter mais detalhes</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallErrorInformation">
         <source xml:lang="en">Error installing tool. See output channel '{0}' for more details</source>
-        <target state="new">Error installing tool. See output channel '{0}' for more details</target>
+        <target state="translated">Erro ao instalar a ferramenta. Confira o canal de saída '{0}' para obter mais detalhes</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallFailed">
         <source xml:lang="en">Installation commands completed but version of tool '{0}' could not be detected so our installation attempt has failed. Detection Error: {1}{2}Cleaning up previous installations would help.</source>
-        <target state="new">Installation commands completed but version of tool '{0}' could not be detected so our installation attempt has failed. Detection Error: {1}{2}Cleaning up previous installations would help.</target>
+        <target state="translated">Os comandos de instalação foram concluídos, mas a versão da ferramenta '{0}' não pôde ser detectada, portanto, houve uma falha na tentativa de instalação. Erro de detecção: {1}{2}Limpar instalações anteriores pode ajudar.</target>
       </trans-unit>
       <trans-unit id="toolBase.InstallFailInformation">
         <source xml:lang="en">Failed to detect version post installation. See output channel '{0}' for more details</source>
-        <target state="new">Failed to detect version post installation. See output channel '{0}' for more details</target>
+        <target state="translated">Falha ao detectar a versão após a instalação. Confira o canal de saída '{0}' para obter mais detalhes</target>
       </trans-unit>
       <trans-unit id="toolBase.ManualUninstallCommand">
         <source xml:lang="en"> A possibly way to uninstall is using this command:{0}   &gt;{1}</source>
-        <target state="new"> A possibly way to uninstall is using this command:{0}   &gt;{1}</target>
+        <target state="translated"> Um modo possível de desinstalar é usando este comando:{0}   &gt;{1}</target>
       </trans-unit>
       <trans-unit id="toolBase.SeeOutputChannel">
         <source xml:lang="en">{0}See output channel '{1}' for more details</source>
-        <target state="new">{0}See output channel '{1}' for more details</target>
+        <target state="translated">{0}Confira o canal de saída '{1}' para obter mais detalhes</target>
       </trans-unit>
       <trans-unit id="toolBase.installCore.CannotInstallTool">
         <source xml:lang="en">Cannot install tool:{0}::{1} as installation commands are unknown for your OS distribution, Please install {0} manually before proceeding</source>
-        <target state="new">Cannot install tool:{0}::{1} as installation commands are unknown for your OS distribution, Please install {0} manually before proceeding</target>
+        <target state="translated">Não é possível instalar a ferramenta {0}::{1}, pois os comandos de instalação são desconhecidos pela sua distribuição de SO. Instale o {0} manualmente antes de continuar</target>
       </trans-unit>
       <trans-unit id="toolBase.addInstallationSearchPathsToSystemPath.SearchPaths">
         <source xml:lang="en">Search Paths for tool '{0}': {1}</source>
-        <target state="new">Search Paths for tool '{0}': {1}</target>
+        <target state="translated">Caminhos de pesquisa para a ferramenta '{0}': {1}</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
-        <target state="new">Error retrieving version information. See output channel '{0}' for more details</target>
+        <target state="translated">Erro ao recuperar as informações da versão. Confira o canal de saída '{0}' para obter mais detalhes</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
-        <target state="new">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </target>
+        <target state="translated">Erro ao recuperar informações de versão.{0}Saída inválida recebida, obtenha a saída do comando da versão: '{1}' </target>
       </trans-unit>
     </body>
   </file>
@@ -910,87 +814,87 @@
     <body>
       <trans-unit id="deployAzureSQLDB.NewSQLDBTitle">
         <source xml:lang="en">Deploy Azure SQL DB</source>
-        <target state="new">Deploy Azure SQL DB</target>
+        <target state="translated">Implantar o BD SQL do Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.ScriptToNotebook">
         <source xml:lang="en">Script to Notebook</source>
-        <target state="new">Script to Notebook</target>
+        <target state="translated">Script para o Notebook</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">Preencha os campos obrigatórios marcados com asteriscos vermelhos.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSettingsPageTitle">
         <source xml:lang="en">Azure SQL Database - Azure account settings</source>
-        <target state="new">Azure SQL Database - Azure account settings</target>
+        <target state="translated">Banco de Dados SQL do Azure – Configurações da conta do Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSettingsSummaryPageTitle">
         <source xml:lang="en">Azure account settings</source>
-        <target state="new">Azure account settings</target>
+        <target state="translated">Configurações de conta do Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureAccountDropdownLabel">
         <source xml:lang="en">Azure account</source>
-        <target state="new">Azure account</target>
+        <target state="translated">Conta do Azure</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureSubscriptionDropdownLabel">
         <source xml:lang="en">Subscription</source>
-        <target state="new">Subscription</target>
+        <target state="translated">Assinatura</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.AzureDatabaseServersDropdownLabel">
         <source xml:lang="en">Server</source>
-        <target state="new">Server</target>
+        <target state="translated">Servidor</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.ResourceGroup">
         <source xml:lang="en">Resource group</source>
-        <target state="new">Resource group</target>
+        <target state="translated">Grupo de recursos</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DatabaseSettingsPageTitle">
         <source xml:lang="en">Database settings</source>
-        <target state="new">Database settings</target>
+        <target state="translated">Configurações do banco de dados</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallRuleNameLabel">
         <source xml:lang="en">Firewall rule name</source>
-        <target state="new">Firewall rule name</target>
+        <target state="translated">Nome da regra de firewall</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DatabaseNameLabel">
         <source xml:lang="en">SQL database name</source>
-        <target state="new">SQL database name</target>
+        <target state="translated">Nome do banco de dados SQL</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.CollationNameLabel">
         <source xml:lang="en">Database collation</source>
-        <target state="new">Database collation</target>
+        <target state="translated">Ordenação de banco de dados</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.CollationNameSummaryLabel">
         <source xml:lang="en">Collation for database</source>
-        <target state="new">Collation for database</target>
+        <target state="translated">Ordenação para banco de dados</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.IpAddressInfoLabel">
         <source xml:lang="en">Enter IP addresses in IPv4 format.</source>
-        <target state="new">Enter IP addresses in IPv4 format.</target>
+        <target state="translated">Insira os endereços IP no formato IPv4.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.StartIpAddressLabel">
         <source xml:lang="en">Min IP address in firewall IP range</source>
-        <target state="new">Min IP address in firewall IP range</target>
+        <target state="translated">Endereço IP mínimo no intervalo de IP do firewall</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.EndIpAddressLabel">
         <source xml:lang="en">Max IP address in firewall IP range</source>
-        <target state="new">Max IP address in firewall IP range</target>
+        <target state="translated">Endereço IP máximo no intervalo de IP do firewall</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.StartIpAddressShortLabel">
         <source xml:lang="en">Min IP address</source>
-        <target state="new">Min IP address</target>
+        <target state="translated">Endereço IP mínimo</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.EndIpAddressShortLabel">
         <source xml:lang="en">Max IP address</source>
-        <target state="new">Max IP address</target>
+        <target state="translated">Endereço IP máximo</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallRuleDescription">
         <source xml:lang="en">Create a firewall rule for your local client IP in order to connect to your database through Azure Data Studio after creation is completed.</source>
-        <target state="new">Create a firewall rule for your local client IP in order to connect to your database through Azure Data Studio after creation is completed.</target>
+        <target state="translated">Crie uma regra de firewall para o IP do cliente local para se conectar ao seu banco de dados por meio do Azure Data Studio após a conclusão da criação.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.FirewallToggleLabel">
         <source xml:lang="en">Create a firewall rule</source>
-        <target state="new">Create a firewall rule</target>
+        <target state="translated">Criar uma regra de firewall</target>
       </trans-unit>
     </body>
   </file>
@@ -998,7 +902,7 @@
     <body>
       <trans-unit id="resourceDeployment.KubeCtlDescription">
         <source xml:lang="en">Runs commands against Kubernetes clusters</source>
-        <target state="new">Runs commands against Kubernetes clusters</target>
+        <target state="translated">Executa comandos em clusters do Kubernetes</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.KubeCtlDisplayName">
         <source xml:lang="en">kubectl</source>
@@ -1006,67 +910,67 @@
       </trans-unit>
       <trans-unit id="resourceDeployment.invalidKubectlVersionOutput">
         <source xml:lang="en">Unable to parse the kubectl version command output: "{0}"</source>
-        <target state="new">Unable to parse the kubectl version command output: "{0}"</target>
+        <target state="translated">Não é possível analisar a saída do comando da versão do kubectl: "{0}"</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.UpdatingBrewRepository">
         <source xml:lang="en">updating your brew repository for kubectl installation …</source>
-        <target state="new">updating your brew repository for kubectl installation …</target>
+        <target state="translated">atualizando o seu repositório brew para a instalação do kubectl…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.InstallingKubeCtl">
         <source xml:lang="en">installing kubectl …</source>
-        <target state="new">installing kubectl …</target>
+        <target state="translated">instalando o kubectl…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AptGetUpdate">
         <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
+        <target state="translated">atualizando informações do repositório…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AptGetPackages">
         <source xml:lang="en">getting packages needed for kubectl installation …</source>
-        <target state="new">getting packages needed for kubectl installation …</target>
+        <target state="translated">obtendo pacotes necessários para a instalação do kubectl…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for kubectl …</source>
-        <target state="new">downloading and installing the signing key for kubectl …</target>
+        <target state="translated">baixando e instalando a chave de assinatura para kubectl…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.AddingKubectlRepositoryInformation">
         <source xml:lang="en">adding the kubectl repository information …</source>
-        <target state="new">adding the kubectl repository information …</target>
+        <target state="translated">adicionando informações do repositório kubectl…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.InstallingKubectl">
         <source xml:lang="en">installing kubectl …</source>
-        <target state="new">installing kubectl …</target>
+        <target state="translated">instalando o kubectl…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DeletePreviousDownloadedKubectl.exe">
         <source xml:lang="en">deleting previously downloaded kubectl.exe if one exists …</source>
-        <target state="new">deleting previously downloaded kubectl.exe if one exists …</target>
+        <target state="translated">excluindo o kubectl.exe baixado anteriormente, se houver…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadingAndInstallingKubectl">
         <source xml:lang="en">downloading and installing the latest kubectl.exe …</source>
-        <target state="new">downloading and installing the latest kubectl.exe …</target>
+        <target state="translated">baixando e instalando o kubectl.exe mais recente…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DeletePreviousDownloadedKubectl">
         <source xml:lang="en">deleting previously downloaded kubectl if one exists …</source>
-        <target state="new">deleting previously downloaded kubectl if one exists …</target>
+        <target state="translated">excluindo o kubectl baixado anteriormente, se houver…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.DownloadingKubectl">
         <source xml:lang="en">downloading the latest kubectl release …</source>
-        <target state="new">downloading the latest kubectl release …</target>
+        <target state="translated">baixando a versão mais recente do kubectl…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.MakingExecutable">
         <source xml:lang="en">making kubectl executable …</source>
-        <target state="new">making kubectl executable …</target>
+        <target state="translated">tornando o kubectl executável…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.CleaningUpOldBackups">
         <source xml:lang="en">cleaning up any previously backed up version in the install location if they exist …</source>
-        <target state="new">cleaning up any previously backed up version in the install location if they exist …</target>
+        <target state="translated">limpando todas as versões das quais foi feito backup anteriormente na localização de instalação, se houver…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.BackupCurrentBinary">
         <source xml:lang="en">backing up any existing kubectl in the install location …</source>
-        <target state="new">backing up any existing kubectl in the install location …</target>
+        <target state="translated">fazendo backup de qualquer kubectl existente na localização de instalação…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Kubectl.MoveToSystemPath">
         <source xml:lang="en">moving kubectl into the install location in the PATH …</source>
-        <target state="new">moving kubectl into the install location in the PATH …</target>
+        <target state="translated">movendo o kubectl para a localização de instalação em PATH…</target>
       </trans-unit>
     </body>
   </file>
@@ -1074,7 +978,7 @@
     <body>
       <trans-unit id="wizardPage.ValidationError">
         <source xml:lang="en">There are some errors on this page, click 'Show Details' to view the errors.</source>
-        <target state="new">There are some errors on this page, click 'Show Details' to view the errors.</target>
+        <target state="translated">Há alguns erros nesta página. Clique em 'Mostrar Detalhes' para exibir os erros.</target>
       </trans-unit>
     </body>
   </file>
@@ -1082,24 +986,20 @@
     <body>
       <trans-unit id="deploymentDialog.OpenNotebook">
         <source xml:lang="en">Open Notebook</source>
-        <target state="new">Open Notebook</target>
+        <target state="translated">Abrir Notebook</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.OkButtonText">
         <source xml:lang="en">OK</source>
-        <target state="new">OK</target>
+        <target state="translated">OK</target>
       </trans-unit>
       <trans-unit id="notebookType">
         <source xml:lang="en">Notebook type</source>
-        <target state="new">Notebook type</target>
+        <target state="translated">Tipo de notebook</target>
       </trans-unit>
     </body>
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">Falha ao carregar a extensão: {0}, Erro detectado na definição de tipo de recurso no package.json. Verifique o console de depuração para obter detalhes.</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">O tipo de recurso: {0} não está definido</target>
@@ -1118,31 +1018,31 @@
     <body>
       <trans-unit id="resourceDeployment.outputChannel">
         <source xml:lang="en">Deployments</source>
-        <target state="new">Deployments</target>
+        <target state="translated">Implantações</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.ErroredOut">
         <source xml:lang="en">	&gt;&gt;&gt; {0}   … errored out: {1}</source>
-        <target state="new">	&gt;&gt;&gt; {0}   … errored out: {1}</target>
+        <target state="translated">	&gt;&gt;&gt; {0}   … com o erro: {1}</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.IgnoringError">
         <source xml:lang="en">	&gt;&gt;&gt; Ignoring error in execution and continuing tool deployment</source>
-        <target state="new">	&gt;&gt;&gt; Ignoring error in execution and continuing tool deployment</target>
+        <target state="translated">	&gt;&gt;&gt; Ignorando erro na execução e continuando a implantação da ferramenta</target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.stdout">
         <source xml:lang="en">    stdout: </source>
-        <target state="new">    stdout: </target>
+        <target state="translated">    stdout: </target>
       </trans-unit>
       <trans-unit id="platformService.RunCommand.stderr">
         <source xml:lang="en">    stderr: </source>
-        <target state="new">    stderr: </target>
+        <target state="translated">    stderr: </target>
       </trans-unit>
       <trans-unit id="platformService.RunStreamedCommand.ExitedWithCode">
         <source xml:lang="en">    &gt;&gt;&gt; {0}    … exited with code: {1}</source>
-        <target state="new">    &gt;&gt;&gt; {0}    … exited with code: {1}</target>
+        <target state="translated">    &gt;&gt;&gt; {0}    … foi encerrado com o código: {1}</target>
       </trans-unit>
       <trans-unit id="platformService.RunStreamedCommand.ExitedWithSignal">
         <source xml:lang="en">    &gt;&gt;&gt; {0}   … exited with signal: {1}</source>
-        <target state="new">    &gt;&gt;&gt; {0}   … exited with signal: {1}</target>
+        <target state="translated">    &gt;&gt;&gt; {0}   … foi encerrado com o sinal: {1}</target>
       </trans-unit>
     </body>
   </file>
@@ -1158,31 +1058,31 @@
     <body>
       <trans-unit id="deployCluster.serviceScaleTableTitle">
         <source xml:lang="en">Service scale settings (Instances)</source>
-        <target state="new">Service scale settings (Instances)</target>
+        <target state="translated">Configurações de escala de serviço (Instâncias)</target>
       </trans-unit>
       <trans-unit id="deployCluster.storageTableTitle">
         <source xml:lang="en">Service storage settings (GB per Instance)</source>
-        <target state="new">Service storage settings (GB per Instance)</target>
+        <target state="translated">Configurações de armazenamento de serviço (GB por Instância)</target>
       </trans-unit>
       <trans-unit id="deployCluster.featureTableTitle">
         <source xml:lang="en">Features</source>
-        <target state="new">Features</target>
+        <target state="translated">Recursos</target>
       </trans-unit>
       <trans-unit id="deployCluster.yesText">
         <source xml:lang="en">Yes</source>
-        <target state="new">Yes</target>
+        <target state="translated">Sim</target>
       </trans-unit>
       <trans-unit id="deployCluster.noText">
         <source xml:lang="en">No</source>
-        <target state="new">No</target>
+        <target state="translated">Não</target>
       </trans-unit>
       <trans-unit id="deployCluster.summaryPageTitle">
         <source xml:lang="en">Deployment configuration profile</source>
-        <target state="new">Deployment configuration profile</target>
+        <target state="translated">Perfil de configuração de implantação</target>
       </trans-unit>
       <trans-unit id="deployCluster.summaryPageDescription">
         <source xml:lang="en">Select the target configuration profile</source>
-        <target state="new">Select the target configuration profile</target>
+        <target state="translated">Selecione o perfil de configuração de destino</target>
       </trans-unit>
       <trans-unit id="deployCluster.ProfileHintText">
         <source xml:lang="en">Note: The settings of the deployment profile can be customized in later steps.</source>
@@ -1190,15 +1090,15 @@
       </trans-unit>
       <trans-unit id="deployCluster.loadingProfiles">
         <source xml:lang="en">Loading profiles</source>
-        <target state="new">Loading profiles</target>
+        <target state="translated">Carregando perfis</target>
       </trans-unit>
       <trans-unit id="deployCluster.loadingProfilesCompleted">
         <source xml:lang="en">Loading profiles completed</source>
-        <target state="new">Loading profiles completed</target>
+        <target state="translated">Carregamento de perfis concluído</target>
       </trans-unit>
       <trans-unit id="deployCluster.profileRadioGroupLabel">
         <source xml:lang="en">Deployment configuration profile</source>
-        <target state="new">Deployment configuration profile</target>
+        <target state="translated">Perfil de configuração de implantação</target>
       </trans-unit>
       <trans-unit id="deployCluster.loadProfileFailed">
         <source xml:lang="en">Failed to load the deployment profiles: {0}</source>
@@ -1222,19 +1122,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">Serviço</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataStorageType">
         <source xml:lang="en">Data</source>
-        <target state="new">Data</target>
+        <target state="translated">Dados</target>
       </trans-unit>
       <trans-unit id="deployCluster.logsStorageType">
         <source xml:lang="en">Logs</source>
-        <target state="new">Logs</target>
+        <target state="translated">Logs</target>
       </trans-unit>
       <trans-unit id="deployCluster.StorageType">
         <source xml:lang="en">Storage type</source>
-        <target state="new">Storage type</target>
+        <target state="translated">Tipo de armazenamento</target>
       </trans-unit>
       <trans-unit id="deployCluster.basicAuthentication">
         <source xml:lang="en">Basic authentication</source>
@@ -1250,7 +1150,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.featureText">
         <source xml:lang="en">Feature</source>
-        <target state="new">Feature</target>
+        <target state="translated">Recurso</target>
       </trans-unit>
       <trans-unit id="deployCluster.ProfileNotSelectedError">
         <source xml:lang="en">Please select a deployment profile.</source>
@@ -1262,7 +1162,7 @@
     <body>
       <trans-unit id="deployCluster.MissingRequiredInfoError">
         <source xml:lang="en">Please fill out the required fields marked with red asterisks.</source>
-        <target state="new">Please fill out the required fields marked with red asterisks.</target>
+        <target state="translated">Preencha os campos obrigatórios marcados com asteriscos vermelhos.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AzureSettingsPageTitle">
         <source xml:lang="en">Azure settings</source>
@@ -1322,7 +1222,7 @@
     <body>
       <trans-unit id="deployCluster.ClusterNameDescription">
         <source xml:lang="en">The cluster name must consist only of alphanumeric lowercase characters or '-' and must start and end with an alphanumeric character.</source>
-        <target state="new">The cluster name must consist only of alphanumeric lowercase characters or '-' and must start and end with an alphanumeric character.</target>
+        <target state="translated">O nome do cluster precisa conter apenas caracteres alfanuméricos em minúsculas ou '-', e começar e terminar com um caractere alfanumérico.</target>
       </trans-unit>
       <trans-unit id="deployCluster.ClusterSettingsPageTitle">
         <source xml:lang="en">Cluster settings</source>
@@ -1434,7 +1334,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.RealmDescription">
         <source xml:lang="en">If not provided, the domain DNS name will be used as the default value.</source>
-        <target state="new">If not provided, the domain DNS name will be used as the default value.</target>
+        <target state="translated">Se não for fornecido, o nome DNS do domínio será usado como o valor padrão.</target>
       </trans-unit>
       <trans-unit id="deployCluster.ClusterAdmins">
         <source xml:lang="en">Cluster admin group</source>
@@ -1470,7 +1370,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.AppOwners">
         <source xml:lang="en">App owners</source>
-        <target state="new">App owners</target>
+        <target state="translated">Proprietários de aplicativos</target>
       </trans-unit>
       <trans-unit id="deployCluster.AppOwnersPlaceHolder">
         <source xml:lang="en">Use comma to separate the values.</source>
@@ -1494,19 +1394,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.Subdomain">
         <source xml:lang="en">Subdomain</source>
-        <target state="new">Subdomain</target>
+        <target state="translated">Subdomínio</target>
       </trans-unit>
       <trans-unit id="deployCluster.SubdomainDescription">
         <source xml:lang="en">A unique DNS subdomain to use for this SQL Server Big Data Cluster. If not provided, the cluster name will be used as the default value.</source>
-        <target state="new">A unique DNS subdomain to use for this SQL Server Big Data Cluster. If not provided, the cluster name will be used as the default value.</target>
+        <target state="translated">Um subdomínio DNS exclusivo a ser usado neste Cluster de Big Data do SQL Server. Se não for fornecido, o nome do cluster será usado como o valor padrão.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefix">
         <source xml:lang="en">Account prefix</source>
-        <target state="new">Account prefix</target>
+        <target state="translated">Prefixo da conta</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefixDescription">
         <source xml:lang="en">A unique prefix for AD accounts SQL Server Big Data Cluster will generate. If not provided, the subdomain name will be used as the default value. If a subdomain is not provided, the cluster name will be used as the default value.</source>
-        <target state="new">A unique prefix for AD accounts SQL Server Big Data Cluster will generate. If not provided, the subdomain name will be used as the default value. If a subdomain is not provided, the cluster name will be used as the default value.</target>
+        <target state="translated">Um prefixo exclusivo para contas do AD que o Cluster de Big Data do SQL Server vai gerar. Se não for fornecido, o nome de subdomínio será usado como o valor padrão. Se um subdomínio não for fornecido, o nome do cluster será usado como o valor padrão.</target>
       </trans-unit>
       <trans-unit id="deployCluster.AdminPasswordField">
         <source xml:lang="en">Password</source>
@@ -1646,19 +1546,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.controllerDataStorageClass">
         <source xml:lang="en">Controller's data storage class</source>
-        <target state="new">Controller's data storage class</target>
+        <target state="translated">Classe de armazenamento de dados do controlador</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerDataStorageClaimSize">
         <source xml:lang="en">Controller's data storage claim size</source>
-        <target state="new">Controller's data storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de dados do controlador</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerLogsStorageClass">
         <source xml:lang="en">Controller's logs storage class</source>
-        <target state="new">Controller's logs storage class</target>
+        <target state="translated">Classe de armazenamento de logs do controlador</target>
       </trans-unit>
       <trans-unit id="deployCluster.controllerLogsStorageClaimSize">
         <source xml:lang="en">Controller's logs storage claim size</source>
-        <target state="new">Controller's logs storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de logs do controlador</target>
       </trans-unit>
       <trans-unit id="deployCluster.StoragePool">
         <source xml:lang="en">Storage pool (HDFS)</source>
@@ -1666,19 +1566,19 @@
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolDataStorageClass">
         <source xml:lang="en">Storage pool's data storage class</source>
-        <target state="new">Storage pool's data storage class</target>
+        <target state="translated">Classe de armazenamento de dados do pool de armazenamento</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolDataStorageClaimSize">
         <source xml:lang="en">Storage pool's data storage claim size</source>
-        <target state="new">Storage pool's data storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de dados do pool de armazenamento</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolLogsStorageClass">
         <source xml:lang="en">Storage pool's logs storage class</source>
-        <target state="new">Storage pool's logs storage class</target>
+        <target state="translated">Classe de armazenamento de logs do pool de armazenamento</target>
       </trans-unit>
       <trans-unit id="deployCluster.storagePoolLogsStorageClaimSize">
         <source xml:lang="en">Storage pool's logs storage claim size</source>
-        <target state="new">Storage pool's logs storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de logs do pool de armazenamento</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataPool">
         <source xml:lang="en">Data pool</source>
@@ -1686,39 +1586,39 @@
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolDataStorageClass">
         <source xml:lang="en">Data pool's data storage class</source>
-        <target state="new">Data pool's data storage class</target>
+        <target state="translated">Classe de armazenamento de dados do pool de dados</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolDataStorageClaimSize">
         <source xml:lang="en">Data pool's data storage claim size</source>
-        <target state="new">Data pool's data storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de dados do pool de dados</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolLogsStorageClass">
         <source xml:lang="en">Data pool's logs storage class</source>
-        <target state="new">Data pool's logs storage class</target>
+        <target state="translated">Classe de armazenamento de logs do pool de dados</target>
       </trans-unit>
       <trans-unit id="deployCluster.dataPoolLogsStorageClaimSize">
         <source xml:lang="en">Data pool's logs storage claim size</source>
-        <target state="new">Data pool's logs storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de logs do pool de dados</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterDataStorageClass">
         <source xml:lang="en">SQL Server master's data storage class</source>
-        <target state="new">SQL Server master's data storage class</target>
+        <target state="translated">Classe de armazenamento de dados do SQL Server mestre</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterDataStorageClaimSize">
         <source xml:lang="en">SQL Server master's data storage claim size</source>
-        <target state="new">SQL Server master's data storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de dados do SQL Server mestre</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterLogsStorageClass">
         <source xml:lang="en">SQL Server master's logs storage class</source>
-        <target state="new">SQL Server master's logs storage class</target>
+        <target state="translated">Classe de armazenamento de logs do SQL Server mestre</target>
       </trans-unit>
       <trans-unit id="deployCluster.sqlServerMasterLogsStorageClaimSize">
         <source xml:lang="en">SQL Server master's logs storage claim size</source>
-        <target state="new">SQL Server master's logs storage claim size</target>
+        <target state="translated">Tamanho da declaração de armazenamento de logs do SQL Server mestre</target>
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service name</source>
-        <target state="new">Service name</target>
+        <target state="translated">Nome do serviço</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataStorageClassName">
         <source xml:lang="en">Storage class for data</source>
@@ -1738,7 +1638,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.StorageSettings">
         <source xml:lang="en">Storage settings</source>
-        <target state="new">Storage settings</target>
+        <target state="translated">Configurações de armazenamento</target>
       </trans-unit>
       <trans-unit id="deployCluster.StorageSectionTitle">
         <source xml:lang="en">Storage settings</source>
@@ -1822,7 +1722,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.AppOwners">
         <source xml:lang="en">App owners</source>
-        <target state="new">App owners</target>
+        <target state="translated">Proprietários de aplicativos</target>
       </trans-unit>
       <trans-unit id="deployCluster.AppReaders">
         <source xml:lang="en">App readers</source>
@@ -1830,11 +1730,11 @@
       </trans-unit>
       <trans-unit id="deployCluster.Subdomain">
         <source xml:lang="en">Subdomain</source>
-        <target state="new">Subdomain</target>
+        <target state="translated">Subdomínio</target>
       </trans-unit>
       <trans-unit id="deployCluster.AccountPrefix">
         <source xml:lang="en">Account prefix</source>
-        <target state="new">Account prefix</target>
+        <target state="translated">Prefixo da conta</target>
       </trans-unit>
       <trans-unit id="deployCluster.DomainServiceAccountUserName">
         <source xml:lang="en">Service account username</source>
@@ -1902,7 +1802,7 @@
       </trans-unit>
       <trans-unit id="deployCluster.ServiceName">
         <source xml:lang="en">Service</source>
-        <target state="new">Service</target>
+        <target state="translated">Serviço</target>
       </trans-unit>
       <trans-unit id="deployCluster.DataStorageClassName">
         <source xml:lang="en">Storage class for data</source>
@@ -2010,11 +1910,11 @@
     <body>
       <trans-unit id="sqlVMDeploymentWizard.PasswordLengthError">
         <source xml:lang="en">Password must be between 12 and 123 characters long.</source>
-        <target state="new">Password must be between 12 and 123 characters long.</target>
+        <target state="translated">A senha precisa ter entre 12 e 123 caracteres.</target>
       </trans-unit>
       <trans-unit id="sqlVMDeploymentWizard.PasswordSpecialCharRequirementError">
         <source xml:lang="en">Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character.</source>
-        <target state="new">Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character.</target>
+        <target state="translated">A senha deve ter 3 dos seguintes itens: 1 caractere minúsculo, 1 caractere maiúsculo, 1 número e 1 caractere especial.</target>
       </trans-unit>
     </body>
   </file>
@@ -2022,47 +1922,47 @@
     <body>
       <trans-unit id="deployAzureSQLVM.VnameLengthError">
         <source xml:lang="en">Virtual machine name must be between 1 and 15 characters long.</source>
-        <target state="new">Virtual machine name must be between 1 and 15 characters long.</target>
+        <target state="translated">O nome da máquina virtual precisa ter entre 1 e 15 caracteres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameOnlyNumericNameError">
         <source xml:lang="en">Virtual machine name cannot contain only numbers.</source>
-        <target state="new">Virtual machine name cannot contain only numbers.</target>
+        <target state="translated">O nome da máquina virtual não pode conter somente números.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNamePrefixSuffixError">
         <source xml:lang="en">Virtual machine name Can't start with underscore. Can't end with period or hyphen</source>
-        <target state="new">Virtual machine name Can't start with underscore. Can't end with period or hyphen</target>
+        <target state="translated">O nome da máquina virtual não pode começar com sublinhado e não pode terminar com ponto ou hífen</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameSpecialCharError">
         <source xml:lang="en">Virtual machine name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Virtual machine name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">O nome da máquina virtual não pode conter os caracteres especiais \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VNameExistsError">
         <source xml:lang="en">Virtual machine name must be unique in the current resource group.</source>
-        <target state="new">Virtual machine name must be unique in the current resource group.</target>
+        <target state="translated">O nome da máquina virtual deve ser exclusivo no grupo de recursos atual.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameLengthError">
         <source xml:lang="en">Username must be between 1 and 20 characters long.</source>
-        <target state="new">Username must be between 1 and 20 characters long.</target>
+        <target state="translated">O nome de usuário precisa ter entre 1 e 20 caracteres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameSuffixError">
         <source xml:lang="en">Username cannot end with period</source>
-        <target state="new">Username cannot end with period</target>
+        <target state="translated">O nome de usuário não pode terminar com um ponto</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameSpecialCharError">
         <source xml:lang="en">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp; .</source>
-        <target state="new">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp; .</target>
+        <target state="translated">O nome de usuário não pode conter caracteres especiais \/""[]:|&lt;&gt;+=;,?*@&amp; .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMUsernameReservedWordsError">
         <source xml:lang="en">Username must not include reserved words.</source>
-        <target state="new">Username must not include reserved words.</target>
+        <target state="translated">O nome de usuário não pode incluir palavras reservadas.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VMConfirmPasswordError">
         <source xml:lang="en">Password and confirm password must match.</source>
-        <target state="new">Password and confirm password must match.</target>
+        <target state="translated">A Senha e a Confirmação de senha devem corresponder.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.vmDropdownSizeError">
         <source xml:lang="en">Select a valid virtual machine size.</source>
-        <target state="new">Select a valid virtual machine size.</target>
+        <target state="translated">Selecione um tamanho de máquina virtual válido.</target>
       </trans-unit>
     </body>
   </file>
@@ -2070,39 +1970,39 @@
     <body>
       <trans-unit id="deployAzureSQLVM.NewVnetPlaceholder">
         <source xml:lang="en">Enter name for new virtual network</source>
-        <target state="new">Enter name for new virtual network</target>
+        <target state="translated">Inserir o nome da nova rede virtual</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewSubnetPlaceholder">
         <source xml:lang="en">Enter name for new subnet</source>
-        <target state="new">Enter name for new subnet</target>
+        <target state="translated">Inserir o nome da nova sub-rede</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewPipPlaceholder">
         <source xml:lang="en">Enter name for new public IP</source>
-        <target state="new">Enter name for new public IP</target>
+        <target state="translated">Inserir o nome do novo IP</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.VnetNameLengthError">
         <source xml:lang="en">Virtual Network name must be between 2 and 64 characters long</source>
-        <target state="new">Virtual Network name must be between 2 and 64 characters long</target>
+        <target state="translated">O nome da Rede Virtual precisa ter entre 2 e 64 caracteres</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewVnetError">
         <source xml:lang="en">Create a new virtual network</source>
-        <target state="new">Create a new virtual network</target>
+        <target state="translated">Criar uma rede virtual</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SubnetNameLengthError">
         <source xml:lang="en">Subnet name must be between 1 and 80 characters long</source>
-        <target state="new">Subnet name must be between 1 and 80 characters long</target>
+        <target state="translated">O nome da sub-rede precisa ter entre 1 e 80 caracteres</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewSubnetError">
         <source xml:lang="en">Create a new sub network</source>
-        <target state="new">Create a new sub network</target>
+        <target state="translated">Criar uma sub-rede</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PipNameError">
         <source xml:lang="en">Public IP name must be between 1 and 80 characters long</source>
-        <target state="new">Public IP name must be between 1 and 80 characters long</target>
+        <target state="translated">O nome do IP precisa ter entre 1 e 80 caracteres</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.NewPipError">
         <source xml:lang="en">Create a new new public Ip</source>
-        <target state="new">Create a new new public Ip</target>
+        <target state="translated">Criar um IP</target>
       </trans-unit>
     </body>
   </file>
@@ -2110,27 +2010,27 @@
     <body>
       <trans-unit id="deployAzureSQLVM.PrivateConnectivityDropdownOptionDefault">
         <source xml:lang="en">Private (within Virtual Network)</source>
-        <target state="new">Private (within Virtual Network)</target>
+        <target state="translated">Privado (dentro da Rede Virtual)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.LocalConnectivityDropdownOption">
         <source xml:lang="en">Local (inside VM only)</source>
-        <target state="new">Local (inside VM only)</target>
+        <target state="translated">Local (somente dentro da VM)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.PublicConnectivityDropdownOption">
         <source xml:lang="en">Public (Internet)</source>
-        <target state="new">Public (Internet)</target>
+        <target state="translated">Público (Internet)</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlUsernameLengthError">
         <source xml:lang="en">Username must be between 2 and 128 characters long.</source>
-        <target state="new">Username must be between 2 and 128 characters long.</target>
+        <target state="translated">O nome de usuário precisa ter entre 2 e 128 caracteres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlUsernameSpecialCharError">
         <source xml:lang="en">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?* .</source>
-        <target state="new">Username cannot contain special characters \/""[]:|&lt;&gt;+=;,?* .</target>
+        <target state="translated">O nome de usuário não pode conter caracteres especiais \/""[]:|&lt;&gt;+=;,?* .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLVM.SqlConfirmPasswordError">
         <source xml:lang="en">Password and confirm password must match.</source>
-        <target state="new">Password and confirm password must match.</target>
+        <target state="translated">A Senha e a Confirmação de senha devem corresponder.</target>
       </trans-unit>
     </body>
   </file>
@@ -2138,7 +2038,7 @@
     <body>
       <trans-unit id="notebookWizard.autoSummaryPageTitle">
         <source xml:lang="en">Review your configuration</source>
-        <target state="new">Review your configuration</target>
+        <target state="translated">Examine a sua configuração</target>
       </trans-unit>
     </body>
   </file>
@@ -2146,55 +2046,55 @@
     <body>
       <trans-unit id="deployAzureSQLDB.DBMinIpInvalidError">
         <source xml:lang="en">Min Ip address is invalid</source>
-        <target state="new">Min Ip address is invalid</target>
+        <target state="translated">O endereço IP mínimo é inválido</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBMaxIpInvalidError">
         <source xml:lang="en">Max Ip address is invalid</source>
-        <target state="new">Max Ip address is invalid</target>
+        <target state="translated">O endereço IP máximo é inválido</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallOnlyNumericNameError">
         <source xml:lang="en">Firewall name cannot contain only numbers.</source>
-        <target state="new">Firewall name cannot contain only numbers.</target>
+        <target state="translated">O nome do firewall não pode conter somente números.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallLengthError">
         <source xml:lang="en">Firewall name must be between 1 and 100 characters long.</source>
-        <target state="new">Firewall name must be between 1 and 100 characters long.</target>
+        <target state="translated">O nome do firewall precisa ter entre 1 e 100 caracteres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallSpecialCharError">
         <source xml:lang="en">Firewall name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Firewall name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">O nome do firewall não pode conter caracteres especiais \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBFirewallUpperCaseError">
         <source xml:lang="en">Upper case letters are not allowed for firewall name</source>
-        <target state="new">Upper case letters are not allowed for firewall name</target>
+        <target state="translated">Letras maiúsculas não são permitidas no nome do firewall</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameOnlyNumericNameError">
         <source xml:lang="en">Database name cannot contain only numbers.</source>
-        <target state="new">Database name cannot contain only numbers.</target>
+        <target state="translated">O nome do banco de dados não pode conter somente números.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameLengthError">
         <source xml:lang="en">Database name must be between 1 and 100 characters long.</source>
-        <target state="new">Database name must be between 1 and 100 characters long.</target>
+        <target state="translated">O nome do banco de dados precisa ter entre 1 e 100 caracteres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameSpecialCharError">
         <source xml:lang="en">Database name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Database name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">O nome do banco de dados não pode conter caracteres especiais \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBNameExistsError">
         <source xml:lang="en">Database name must be unique in the current server.</source>
-        <target state="new">Database name must be unique in the current server.</target>
+        <target state="translated">O nome do banco de dados precisa ser exclusivo no servidor atual.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationOnlyNumericNameError">
         <source xml:lang="en">Collation name cannot contain only numbers.</source>
-        <target state="new">Collation name cannot contain only numbers.</target>
+        <target state="translated">O nome da ordenação não pode conter somente números.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationLengthError">
         <source xml:lang="en">Collation name must be between 1 and 100 characters long.</source>
-        <target state="new">Collation name must be between 1 and 100 characters long.</target>
+        <target state="translated">O nome da ordenação precisa ter entre 1 e 100 caracteres.</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.DBCollationSpecialCharError">
         <source xml:lang="en">Collation name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</source>
-        <target state="new">Collation name cannot contain special characters \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
+        <target state="translated">O nome da ordenação não pode conter caracteres especiais \/""[]:|&lt;&gt;+=;,?*@&amp;, .</target>
       </trans-unit>
     </body>
   </file>
@@ -2202,17 +2102,17 @@
     <body>
       <trans-unit id="deployAzureSQLDB.azureSignInError">
         <source xml:lang="en">Sign in to an Azure account first</source>
-        <target state="new">Sign in to an Azure account first</target>
+        <target state="translated">Entrar em uma conta do Azure primeiro</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.NoServerLabel">
         <source xml:lang="en">No servers found</source>
-        <target state="new">No servers found</target>
+        <target state="translated">Não foram encontrados servidores</target>
       </trans-unit>
       <trans-unit id="deployAzureSQLDB.NoServerError">
         <source xml:lang="en">No servers found in current subscription.
 Select a different subscription containing at least one server</source>
-        <target state="new">No servers found in current subscription.
-Select a different subscription containing at least one server</target>
+        <target state="translated">Nenhum servidor encontrado na assinatura atual.
+Selecione uma assinatura diferente contendo pelo menos um servidor</target>
       </trans-unit>
     </body>
   </file>
@@ -2220,59 +2120,59 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="notebookWizard.toolsAndEulaPageTitle">
         <source xml:lang="en">Deployment pre-requisites</source>
-        <target state="new">Deployment pre-requisites</target>
-      </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="new">To proceed, you must accept the terms of the End User License Agreement(EULA)</target>
+        <target state="translated">Pré-requisitos da implantação</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
-        <target state="new">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</target>
+        <target state="translated">Algumas ferramentas ainda não foram descobertas. Verifique se eles estão instaladas, em execução e são detectáveis</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">Para continuar, você precisa aceitar os Termos de Licença</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
-        <target state="new">Loading required tools information completed</target>
+        <target state="translated">O carregamento das informações das ferramentas necessárias foi concluído</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredTools">
         <source xml:lang="en">Loading required tools information</source>
-        <target state="new">Loading required tools information</target>
+        <target state="translated">Carregando informações de ferramentas necessárias</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AgreementTitle">
         <source xml:lang="en">Accept terms of use</source>
-        <target state="new">Accept terms of use</target>
+        <target state="translated">Aceitar os termos de uso</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolDoesNotMeetVersionRequirement">
         <source xml:lang="en">'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.</source>
-        <target state="new">'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.</target>
+        <target state="translated">O '{0}' [ {1} ] não atende ao requisito mínimo de versão. Desinstale-o e reinicie o Azure Data Studio.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstalledTools">
         <source xml:lang="en">All required tools are installed now.</source>
-        <target state="new">All required tools are installed now.</target>
+        <target state="translated">Todas as ferramentas necessárias estão instaladas agora.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.PendingInstallation">
         <source xml:lang="en">Following tools: {0} were still not discovered. Please make sure that they are installed, running and discoverable</source>
-        <target state="new">Following tools: {0} were still not discovered. Please make sure that they are installed, running and discoverable</target>
+        <target state="translated">As ferramentas {0} ainda não foram descobertas. Verifique se elas estão instaladas, em execução e são detectáveis</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.ToolInformation">
         <source xml:lang="en">'{0}' was not discovered and automated installation is not currently supported. Install '{0}' manually or ensure it is started and discoverable. Once done please restart Azure Data Studio. See [{1}] .</source>
-        <target state="new">'{0}' was not discovered and automated installation is not currently supported. Install '{0}' manually or ensure it is started and discoverable. Once done please restart Azure Data Studio. See [{1}] .</target>
+        <target state="translated">O '{0}' não foi descoberto e a instalação automática não tem suporte atualmente. Instale o '{0}' manualmente ou verifique se ele foi iniciado e é detectável. Depois de fazer isso, reinicie o Azure Data Studio. Confira [{1}].</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.VersionInformationDebugHint">
         <source xml:lang="en">You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'Azure Data CLI' output channels</source>
-        <target state="new">You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'Azure Data CLI' output channels</target>
+        <target state="translated">Você precisará reiniciar o Azure Data Studio se as ferramentas forem instaladas manualmente para escolher a alteração. Você pode encontrar mais detalhes nos canais de saída 'Implantações' e 'CLI de Dados do Azure'</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallToolsHintOne">
         <source xml:lang="en">Tool: {0} is not installed, you can click the "{1}" button to install it.</source>
-        <target state="new">Tool: {0} is not installed, you can click the "{1}" button to install it.</target>
+        <target state="translated">Ferramenta: o {0} não está instalado, você pode clicar no botão "{1}" para instalá-lo.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.InstallToolsHintMany">
         <source xml:lang="en">Tools: {0} are not installed, you can click the "{1}" button to install them.</source>
-        <target state="new">Tools: {0} are not installed, you can click the "{1}" button to install them.</target>
+        <target state="translated">Ferramentas: os {0} não estão instalados, você pode clicar no botão "{1}" para instalá-los.</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.NoRequiredTool">
         <source xml:lang="en">No tools required</source>
-        <target state="new">No tools required</target>
+        <target state="translated">Nenhuma ferramenta é necessária</target>
       </trans-unit>
     </body>
   </file>
@@ -2280,23 +2180,23 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.DownloadAndLaunchTaskName">
         <source xml:lang="en">Download and launch installer, URL: {0}</source>
-        <target state="new">Download and launch installer, URL: {0}</target>
+        <target state="translated">Baixe e inicie o instalador, URL: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DownloadingText">
         <source xml:lang="en">Downloading from: {0}</source>
-        <target state="new">Downloading from: {0}</target>
+        <target state="translated">Baixando de: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DownloadCompleteText">
         <source xml:lang="en">Successfully downloaded: {0}</source>
-        <target state="new">Successfully downloaded: {0}</target>
+        <target state="translated">Baixado com êxito: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.LaunchingProgramText">
         <source xml:lang="en">Launching: {0}</source>
-        <target state="new">Launching: {0}</target>
+        <target state="translated">Iniciando: {0}</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.ProgramLaunchedText">
         <source xml:lang="en">Successfully launched: {0}</source>
-        <target state="new">Successfully launched: {0}</target>
+        <target state="translated">Iniciado com êxito: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -2304,7 +2204,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.DockerDescription">
         <source xml:lang="en">Packages and runs applications in isolated containers</source>
-        <target state="new">Packages and runs applications in isolated containers</target>
+        <target state="translated">Empacota e executa aplicativos em contêineres isolados</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.DockerDisplayName">
         <source xml:lang="en">docker</source>
@@ -2316,7 +2216,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzCLIDescription">
         <source xml:lang="en">Manages Azure resources</source>
-        <target state="new">Manages Azure resources</target>
+        <target state="translated">Gerencia recursos do Azure</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzCLIDisplayName">
         <source xml:lang="en">Azure CLI</source>
@@ -2324,47 +2224,47 @@ Select a different subscription containing at least one server</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DeletingPreviousAzureCli.msi">
         <source xml:lang="en">deleting previously downloaded azurecli.msi if one exists …</source>
-        <target state="new">deleting previously downloaded azurecli.msi if one exists …</target>
+        <target state="translated">excluindo o azurecli.msi baixado anteriormente, se houver…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DownloadingAndInstallingAzureCli">
         <source xml:lang="en">downloading azurecli.msi and installing azure-cli …</source>
-        <target state="new">downloading azurecli.msi and installing azure-cli …</target>
+        <target state="translated">baixando o azurecli.msi e instalando o azure-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DisplayingInstallationLog">
         <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
+        <target state="translated">exibindo o log de instalação…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.UpdatingBrewRepository">
         <source xml:lang="en">updating your brew repository for azure-cli installation …</source>
-        <target state="new">updating your brew repository for azure-cli installation …</target>
+        <target state="translated">atualizando o seu repositório brew para a instalação do azure-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.InstallingAzureCli">
         <source xml:lang="en">installing azure-cli …</source>
-        <target state="new">installing azure-cli …</target>
+        <target state="translated">instalando o azure-cli.…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetUpdate">
         <source xml:lang="en">updating repository information before installing azure-cli …</source>
-        <target state="new">updating repository information before installing azure-cli …</target>
+        <target state="translated">atualizando as informações do repositório antes de instalar o azure-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetPackages">
         <source xml:lang="en">getting packages needed for azure-cli installation …</source>
-        <target state="new">getting packages needed for azure-cli installation …</target>
+        <target state="translated">obtendo pacotes necessários para a instalação do azure-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for azure-cli …</source>
-        <target state="new">downloading and installing the signing key for azure-cli …</target>
+        <target state="translated">baixando e instalando a chave de assinatura do azure-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AddingAzureCliRepositoryInformation">
         <source xml:lang="en">adding the azure-cli repository information …</source>
-        <target state="new">adding the azure-cli repository information …</target>
+        <target state="translated">adicionando informações do repositório do azure-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.AptGetUpdateAgain">
         <source xml:lang="en">updating repository information again for azure-cli …</source>
-        <target state="new">updating repository information again for azure-cli …</target>
+        <target state="translated">atualizando as informações do repositório novamente do azure-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AziCli.ScriptedInstall">
         <source xml:lang="en">download and invoking script to install azure-cli …</source>
-        <target state="new">download and invoking script to install azure-cli …</target>
+        <target state="translated">baixe e invoque o script para instalar o azure-cli…</target>
       </trans-unit>
     </body>
   </file>
@@ -2372,59 +2272,23 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzdataDescription">
         <source xml:lang="en">Azure Data command line interface</source>
-        <target state="new">Azure Data command line interface</target>
+        <target state="translated">Interface de linha de comando dos Dados do Azure</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzdataDisplayName">
         <source xml:lang="en">Azure Data CLI</source>
-        <target state="new">Azure Data CLI</target>
+        <target state="translated">CLI de Dados do Azure</target>
+      </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">A extensão Azure Data CLI deve ser instalada para implantar esse recurso. Instale-o por meio da galeria de extensões e tente novamente.</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
-        <target state="new">Error retrieving version information. See output channel '{0}' for more details</target>
+        <target state="translated">Erro ao recuperar as informações da versão. Confira o canal de saída '{0}' para obter mais detalhes</target>
       </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
-        <target state="new">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="new">deleting previously downloaded Azdata.msi if one exists …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="new">downloading Azdata.msi and installing azdata-cli …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="new">tapping into the brew repository for azdata-cli …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="new">updating the brew repository for azdata-cli installation …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="new">installing azdata …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="new">getting packages needed for azdata installation …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="new">downloading and installing the signing key for azdata …</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="new">adding the azdata repository information …</target>
+        <target state="translated">Erro ao recuperar informações de versão.{0}Saída inválida recebida, obtenha a saída do comando da versão: '{1}' </target>
       </trans-unit>
     </body>
   </file>
@@ -2432,51 +2296,51 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="resourceDeployment.AzdataDescription">
         <source xml:lang="en">Azure Data command line interface</source>
-        <target state="new">Azure Data command line interface</target>
+        <target state="translated">Interface de linha de comando dos Dados do Azure</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.AzdataDisplayName">
         <source xml:lang="en">Azure Data CLI</source>
-        <target state="new">Azure Data CLI</target>
+        <target state="translated">CLI de Dados do Azure</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
         <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="new">deleting previously downloaded Azdata.msi if one exists …</target>
+        <target state="translated">excluindo o Azdata.msi baixado anteriormente, se houver…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
         <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="new">downloading Azdata.msi and installing azdata-cli …</target>
+        <target state="translated">baixando o Azdata.msi e instalando o azdata-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
         <source xml:lang="en">displaying the installation log …</source>
-        <target state="new">displaying the installation log …</target>
+        <target state="translated">exibindo o log de instalação…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
         <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="new">tapping into the brew repository for azdata-cli …</target>
+        <target state="translated">explorando o repositório brew para azdata-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
         <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="new">updating the brew repository for azdata-cli installation …</target>
+        <target state="translated">atualizando o repositório brew para a instalação do azdata-cli…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
         <source xml:lang="en">installing azdata …</source>
-        <target state="new">installing azdata …</target>
+        <target state="translated">instalando o azdata…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
         <source xml:lang="en">updating repository information …</source>
-        <target state="new">updating repository information …</target>
+        <target state="translated">atualizando informações do repositório…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
         <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="new">getting packages needed for azdata installation …</target>
+        <target state="translated">obtendo pacotes necessários para a instalação do azdata…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
         <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="new">downloading and installing the signing key for azdata …</target>
+        <target state="translated">baixando e instalando a chave de assinatura para azdata…</target>
       </trans-unit>
       <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
         <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="new">adding the azdata repository information …</target>
+        <target state="translated">adicionando informações do repositório azdata…</target>
       </trans-unit>
     </body>
   </file>
@@ -2484,7 +2348,7 @@ Select a different subscription containing at least one server</target>
     <body>
       <trans-unit id="deploymentDialog.deploymentOptions">
         <source xml:lang="en">Deployment options</source>
-        <target state="new">Deployment options</target>
+        <target state="translated">Opções de implantação</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/schema-compare.pt-BR.xlf
+++ b/resources/xlf/pt-br/schema-compare.pt-BR.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">Ok</target>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Fonte</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">Destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">Arquivo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">Arquivo do Aplicativo da Camada de Dados (.dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Banco de dados</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">Servidor</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Banco de dados</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">Comparação de Esquemas</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Um esquema de origem diferente foi selecionado. Comparar para ver a comparação?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Um esquema de destino diferente foi selecionado. Comparar para ver a comparação?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">Diferentes esquemas de origem e de destino foram selecionados. Comparar para ver a comparação?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">Arquivo de origem</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">Arquivo de destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Banco de Dados de Origem</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Banco de Dados de Destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Servidor de Origem</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Servidor de Destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">padrão</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">Selecione o arquivo de origem</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">Selecionar a pasta de destino</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">Redefinir</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">Incluir Tipos de Objetos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">Comparar os Detalhes</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">Tem certeza de que deseja atualizar o destino?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">Pressione Comparar para atualizar a comparação.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">Gerar script para implantar alterações no destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">Nenhuma alteração no script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">Aplicar alterações ao destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">Não há nenhuma alteração a ser aplicada</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">Observe que as operações incluir/excluir podem demorar um pouco para calcular as dependências afetadas</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Excluir</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">Alterar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">Adicionar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">Comparação entre Origem e Destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">Inicializando a comparação. Isso pode demorar um pouco.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">Para comparar dois esquemas, primeiro selecione um esquema de origem e um esquema de destino e, em seguida, pressione Comparar.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">Não foi encontrada nenhuma diferença de esquema.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">Nome da Origem</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">Incluir</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Ação</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">Nome do Destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">Gerar script é habilitado quando o destino é um banco de dados</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">Aplicar é habilitado quando o destino é um banco de dados</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">Não é possível excluir {0}. Existem dependentes incluídos, como {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">Não é possível incluir {0}. Existem dependentes excluídos, como {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">Não é possível excluir {0}. Existem dependentes incluídos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">Não é possível incluir {0}. Existem dependentes excluídos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">Comparar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Parar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Gerar script</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Opções</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Aplicar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">Alternar direção</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">Alternar origem e destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">Selecionar Origem</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">Selecionar Destino</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">Abrir arquivo .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">Carregar a origem, o destino e as opções salvas em um arquivo .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">Salvar o arquivo .scmp</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">Salvar a origem e o destino, as opções e os elementos excluídos</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">Salvar</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">Você deseja se conectar a {0}?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">Selecionar a conexão</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,8 +663,8 @@
         <target state="translated">Funções de Banco de Dados</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
-        <target state="translated">DatabaseTriggers</target>
+        <source xml:lang="en">Database Triggers</source>
+        <target state="translated">Gatilhos de Banco de Dados</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
         <source xml:lang="en">Defaults</source>
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">Formatos de Arquivo Externos</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">Fluxos Externos</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">Trabalhos de Streaming Externos</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">Tabelas Externas</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">Grupos de Arquivos</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Arquivos</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">Assinaturas</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">Procedimentos Armazenados</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">Chaves Simétricas</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">Especifica se as diferenças na ordem das colunas da tabela deverão ser ignoradas ou atualizadas quando você publicar em um banco de dados.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">Ok</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Fonte</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">Arquivo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">Arquivo do Aplicativo da Camada de Dados (.dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Banco de dados</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">Servidor</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Banco de dados</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">Nenhuma conexão ativa</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Comparação de Esquemas</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Um esquema de origem diferente foi selecionado. Comparar para ver a comparação?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Um esquema de destino diferente foi selecionado. Comparar para ver a comparação?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">Diferentes esquemas de origem e de destino foram selecionados. Comparar para ver a comparação?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">padrão</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">Comparar os Detalhes</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">Tem certeza de que deseja atualizar o destino?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">Pressione Comparar para atualizar a comparação.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">Gerar script para implantar alterações no destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">Nenhuma alteração no script</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">Aplicar alterações ao destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">Não há nenhuma alteração a ser aplicada</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Excluir</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">Alterar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">Adicionar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Comparação de Esquemas</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Fonte</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">Inicializando a comparação. Isso pode demorar um pouco.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">Para comparar dois esquemas, primeiro selecione um esquema de origem e um esquema de destino e, em seguida, pressione Comparar.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">Não foi encontrada nenhuma diferença de esquema.</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">Falha na Comparação de Esquemas: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">Nome da Origem</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">Incluir</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Ação</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">Nome do Destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">Gerar script é habilitado quando o destino é um banco de dados</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">Aplicar é habilitado quando o destino é um banco de dados</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Comparar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Comparar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Parar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Parar</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">Falha ao salvar scmp: '{0}'</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">Falha no cancelamento da comparação de esquemas: '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Gerar script</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">Falha ao gerar script: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opções</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opções</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Aplicar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">Falha ao Aplicar a Comparação de Esquemas '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">Alternar direção</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">Alternar origem e destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">Selecionar Origem</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">Selecionar Destino</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">Abrir arquivo .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">Carregar a origem, o destino e as opções salvas em um arquivo .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">Falha ao abrir o scmp: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">Salvar o arquivo .scmp</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">Salvar a origem e o destino, as opções e os elementos excluídos</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">Salvar</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">Falha ao salvar scmp: '{0}'</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/pt-br/sql.pt-BR.xlf
+++ b/resources/xlf/pt-br/sql.pt-BR.xlf
@@ -1,2251 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">Não há suporte para copiar imagens</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">Introdução</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">Mostrar Introdução</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">I&amp;&amp;ntrodução</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">QueryHistory</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">Se a captura do Histórico de Consultas estiver habilitada. Se for false, as consultas executadas não serão capturadas.</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Exibir</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Histórico de Consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">Histórico de Consultas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">Conectando: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">Comando em execução: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">Abrindo a nova consulta: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">Não é possível se conectar, pois não foi fornecida nenhuma informação do servidor</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">Não foi possível abrir a URL devido ao erro {0}</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">Isso será conectado ao servidor {0}</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">Tem certeza de que deseja se conectar?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">&amp;&amp;Abrir</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">Conectando o arquivo de consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">1 ou mais tarefas estão em andamento. Tem certeza de que deseja sair?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">Os recursos de versão prévia aprimoram a sua experiência no Azure Data Studio oferecendo a você acesso completo a novos recursos e melhorias. Saiba mais sobre os recursos de versão prévia [aqui]({0}). Deseja habilitar os recursos de versão prévia?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">Sim (recomendado)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">Não, não mostrar novamente</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">Ativar/desativar o Histórico de Consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Excluir</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">Limpar Todo o Histórico</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">Abrir Consulta</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Executar Consulta</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">Ativar/desativar a captura de Histórico de Consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">Pausar a Captura de Histórico de Consultas</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">Iniciar a Captura do Histórico de Consultas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">Não há nenhuma consulta a ser exibida.</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">Histórico de Consultas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Erro</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Aviso</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">Informações</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">Ignorar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">O salvamento de resultados em diferentes formatos está desabilitado para este provedor de dados.</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">Não foi possível serializar os dados, pois não foi registrado nenhum provedor</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">Falha na serialização com um erro desconhecido</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">A conexão é necessária para interagir com adminservice</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Nenhum manipulador registrado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">Selecionar um arquivo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">A conexão é necessária para interagir com o Serviço de Avaliação</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Nenhum Manipulador Registrado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">Grade de Resultados e Mensagens</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">Controla a família de fontes.</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">Controla a espessura da fonte.</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">Controla o tamanho da fonte em pixels.</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">Controla o espaçamento de letras em pixels.</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">Controla a altura da linha em pixels</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">Controla o preenchimento em pixels da célula</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">Dimensionar automaticamente a largura de colunas nos resultados iniciais. Pode haver problemas de desempenho com um grande número de colunas ou com células grandes</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">A largura máxima em pixels para colunas dimensionadas automaticamente</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Exibir</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">Conexões de Banco de Dados</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">conexões de fonte de dados</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">grupos de fonte de dados</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">Configuração de Inicialização</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">True para a exibição Servidores a ser mostrada na inicialização do padrão do Azure Data Studio; false se a última visualização aberta deve ser mostrada</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Atualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">Versões prévias dos recursos</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">Habilitar versões prévias dos recursos não liberadas</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">Mostrar caixa de diálogo de conexão na inicialização</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">Notificação de API obsoleta</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">Habilitar/desabilitar a notificação de uso de API obsoleta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">Problemas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} tarefas em andamento</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Exibir</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">Tarefas</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Tarefas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">O número máximo de conexões usadas recentemente para armazenar na lista de conexão.</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">Mecanismo SQL padrão a ser usado. Isso direciona o provedor de idioma padrão em arquivos .sql e o padrão a ser usado ao criar uma conexão.</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">Tentativa de analisar o conteúdo da área de transferência quando a caixa de diálogo conexão é aberta ou a cópia é executada.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">Paleta de cores do grupo de servidores usada no viewlet do Pesquisador de Objetos.</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">Expanda automaticamente grupos de servidores no viewlet do Pesquisador de Objetos.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(Versão Prévia) Use a nova árvore de servidor assíncrono para o modo de exibição Servidores e a caixa de diálogo Conexão com suporte para novos recursos, como filtragem dinâmica de nós.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">Identificador do tipo de conta</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(Opcional) Ícone que é usado para representar o accpunt na interface do usuário. Um caminho de arquivo ou uma configuração tematizáveis</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Caminho do ícone quando um tema leve é usado</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Caminho de ícone quando um tema escuro é usado</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">Contribui ícones para provedor de conta.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">Mostrar painel do SQL Editar Dados na inicialização</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Valor mínimo do eixo y</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Valor máximo do eixo y</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Rótulo para o eixo y</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">Valor mínimo do eixo x</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">Valor máximo do eixo x</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">Rótulo para o eixo x</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visualizador de Recursos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">Indica a propriedade de dados de um conjunto de dados para um gráfico.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">Para cada coluna em um conjunto de resultados, exibe o valor na linha 0 como uma contagem seguida pelo nome da coluna. Dá suporte para '1 Íntegro', '3 Não Íntegro', por exemplo, em que 'Íntegro' é o nome da coluna e 1 é o valor na célula 1 da linha 1</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">Exibe os resultados em uma tabela simples</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">Exibe uma imagem, por exemplo, um retornado por uma consulta R usando o ggplot2</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">Qual é o formato esperado – É um JPEG, PNG ou outro formato?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">É codificado como hexa, base64 ou algum outro formato?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gerenciar</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Painel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">O modo de exibição da Web que será exibido nesta guia.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">O controlhost que será exibido nesta guia.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">A lista de widgets que serão exibidos nesta guia.</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">A lista de widgets é esperada dentro de contêiner de widgets para a extensão.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">A lista de widgets ou de modos de exibição da Web que serão exibidos nesta guia.</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">widgets ou modos de exibição da Web são esperados dentro de contêiner de widgets para a extensão.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">Identificador exclusivo para este contêiner.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">O contêiner que será exibido na guia.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">Contribui com um único ou vários contêineres de painéis para os usuários adicionarem ao painel.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">Nenhuma ID no contêiner de painéis especificada para a extensão.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">Nenhum contêiner no contêiner de painéis especificado para a extensão.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Exatamente 1 contêiner de painéis deve ser definido por espaço.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">O tipo de contêiner desconhecido é definido no contêiner de painéis para extensão.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificador exclusivo para esta seção de navegação. Será passado para a extensão para quaisquer solicitações.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Opcional) Ícone usado para representar essa seção de navegação na interface do usuário. Um caminho de arquivo ou uma configuração com tema</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Caminho do ícone quando um tema leve é usado</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Caminho de ícone quando um tema escuro é usado</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">Título da seção de navegação para mostrar ao usuário.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">O contêiner que será exibido nesta seção de navegação.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">A lista de contêineres de painéis que será exibida nesta seção de navegação.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">Não foi especificado nenhum título na seção de navegação para a extensão.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">Não foi especificado nenhum contêiner na seção de navegação para a extensão.</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Exatamente 1 contêiner de painéis deve ser definido por espaço.</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION dentro de NAV_SECTION é um contêiner inválido para a extensão.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">A visualização com suporte do modelo que será exibida nesta guia.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Backup</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">Abrir no Portal do Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">desconectado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">Não é possível expandir, pois o provedor de conexão necessário '{0}' não foi encontrado</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">Usuário cancelado</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">Caixa de diálogo do Firewall cancelada</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">A conexão é necessária para interagir com JobManagementService</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Nenhum Manipulador Registrado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">Ocorreu um erro ao carregar o navegador de arquivos.</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">Erro do navegador de arquivo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">ID comum do provedor</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">Nome de Exibição do provedor</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">Alias do Kernel do Notebook para o provedor</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">Caminho do ícone do tipo de servidor</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">Opções de conexão</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificador exclusivo para esta guia. Será passado para a extensão para quaisquer solicitações.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">Título da guia para mostrar ao usuário.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">Descrição desta guia que será mostrada ao usuário.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">A condição deve ser true para mostrar este item</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">Define os tipos de conexão com os quais essa guia é compatível. O padrão será 'MSSQL' se essa opção não for definida</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">O contêiner que será exibido nesta guia.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">Se esta guia deve ou não ser sempre exibida ou apenas quando o usuário a adiciona.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">Se esta guia deve ou não ser usada como guia da Página Inicial para um tipo de conexão.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">O identificador exclusivo do grupo ao qual esta guia pertence. Valor do grupo doméstico: página inicial.</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Opcional) Ícone usado para representar esta guia na interface do usuário. Um caminho de arquivo ou uma configuração com tema</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Caminho do ícone quando um tema leve é usado</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Caminho de ícone quando um tema escuro é usado</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">Contribui com uma única ou várias guias para que os usuários adicionem ao painel.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">Nenhum título especificado para a extensão.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">Nenhuma descrição especificada para mostrar.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">Nenhum contêiner especificado para a extensão.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">Exatamente 1 contêiner de painéis deve ser definido por espaço</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">Identificador exclusivo deste grupo de guias.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">Título do grupo de guias.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">Contribui com um ou vários grupos de guias para os usuários adicionarem ao painel.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">Nenhuma ID foi especificada para o grupo de guias.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">Nenhum título foi especificado para o grupo de guias.</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">Administração</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">Monitoramento</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">Desempenho</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">Segurança</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">Solução de Problemas</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Configurações</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">guia de bancos de dados</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">Bancos de Dados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">com êxito</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">falhou</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">Erro de conexão</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">A conexão falhou devido a um erro do Kerberos.</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">Ajuda para configurar o Kerberos está disponível em {0}</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">Se você já se conectou anteriormente, pode ser necessário executar novamente o kinit.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fechar</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">Adicionando conta...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">A conta de atualização foi cancelada pelo usuário</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">Resultados da Consulta</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor da Consulta</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nova Consulta</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor de Consultas</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">Quando true, os cabeçalhos de coluna são incluídos ao salvar os resultados como CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">O delimitador personalizado a ser usado entre valores ao salvar como CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">Os caracteres usados para separar linhas ao salvar os resultados como CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">O caractere usado para delimitar os campos de texto ao salvar os resultados como CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">Arquivo de codificação usado ao salvar os resultados como CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">Quando true, a saída XML será formatada ao salvar resultados como XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">Codificação de arquivo usada ao salvar os resultados como XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">Habilitar streaming de resultados; contém alguns problemas visuais menores</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">Opções de configuração para copiar os resultados na Visualização dos Resultados</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">Opções de configuração para copiar os resultados de várias linhas da Visualização dos Resultados</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(Experimental) Use uma tabela otimizada nos resultados. Algumas funcionalidades podem estar ausentes e em funcionamento.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">O tempo de execução deve ser mostrado para lotes individuais?</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">Mensagens de quebra automática de linha</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">O tipo de gráfico padrão a ser usado ao abrir o Visualizador de Gráficos nos Resultados da Consulta</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">A coloração da guia será desabilitada</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">A borda superior de cada guia do editor será colorida para combinar com o grupo de servidores relevante</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">A cor de fundo de cada editor da guia corresponderá ao grupo de servidores relevante</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">Controla como colorir as guias com base no grupo de servidores de sua conexão ativa</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">Controla se deseja mostrar a informação de conexão para uma guia no título.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">Pedir para salvar arquivos SQL gerados</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">Defina keybinding workbench.action.query.shortcut{0} para executar o texto do atalho como uma chamada de procedimento. Qualquer texto selecionado no editor de consultas será passado como um parâmetro</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">Especifica os modelos de exibição</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">Especifica os modelos de sessão</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Filtros do Profiler</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script como Criar</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script como Soltar</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Selecione Top 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script como Executar</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script como Alterar</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Editar Dados</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Selecione Top 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Levar 10</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script como Criar</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script como Executar</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script como Alterar</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script como Soltar</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Atualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">A linha de commit falhou: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">Iniciada a execução de consulta em </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">Começou a executar consulta "{0}"</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">Linha {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">O cancelamento da consulta falhou: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">Falha na célula de atualização: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">Nenhum URI foi passado ao criar um gerenciador de notebooks</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">O provedor de notebooks não existe</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Editor do Notebook</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Novo Notebook</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Novo Notebook</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">Definir Workspace e Abrir</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">Kernel do SQL: parar a execução do Notebook quando ocorrer um erro em uma célula.</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(Versão Prévia) Mostrar todos os kernels para o provedor do notebook atual.</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">Permitir que notebooks executem comandos do Azure Data Studio.</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">Habilitar clique duplo para editar células de texto nos notebooks</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">Definir modo de Exibição de Rich Text por padrão para células de texto</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(Versão Prévia) Salve o nome da conexão nos metadados do notebook.</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">Controla a altura da linha usada na versão prévia de markdown do notebook. Este número é relativo ao tamanho da fonte.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Exibir</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">Pesquisar Notebooks</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">Configurar padrões glob para excluir arquivos e pastas em pesquisas de texto completo e abrir rapidamente. Herda todos os padrões glob da configuração `#files.exclude#`. Leia mais sobre padrões glob [aqui] (https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">O padrão glob ao qual corresponder os caminhos do arquivo. Defina como true ou false para habilitar ou desabilitar o padrão.</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">Verificação adicional nos irmãos de um arquivo correspondente. Use $(basename) como variável para o nome do arquivo correspondente.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">Essa configuração foi preterida e agora retorna ao "search.usePCRE2".</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">Preterido. Considere "search.usePCRE2" para obter suporte do recurso regex avançado.</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">Quando habilitado, o processo de searchService será mantido ativo em vez de ser desligado após uma hora de inatividade. Isso manterá o cache de pesquisa de arquivo na memória.</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Controla se os arquivos `.gitignore` e `.ignore` devem ser usados ao pesquisar arquivos.</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Controla se os arquivos globais `.gitignore` e `.ignore` devem ser usados durante a pesquisa de arquivos.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">Se deseja incluir os resultados de uma pesquisa de símbolo global nos resultados do arquivo para Abertura Rápida.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">Se deseja incluir os resultados de arquivos abertos recentemente nos resultados do arquivo para Abertura Rápida.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">As entradas do histórico são classificadas por relevância com base no valor do filtro usado. As entradas mais relevantes aparecem primeiro.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">As entradas do histórico são classificadas por recência. As entradas abertas mais recentemente aparecem primeiro.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">Controla a ordem de classificação do histórico do editor ao abrir rapidamente ao filtrar.</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">Controla se os ciclos de links devem ser seguidos durante a pesquisa.</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">Pesquisar sem diferenciar maiúsculas de minúsculas se o padrão for todo em minúsculas, caso contrário, pesquisar diferenciando maiúsculas de minúsculas.</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">Controla se o modo de exibição de pesquisa deve ler ou modificar a área de transferência de localização compartilhada no macOS.</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">Controla se a pesquisa será mostrada como um modo de exibição na barra lateral ou como um painel na área do painel para obter mais espaço horizontal.</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">Esta configuração é preterida. Em vez disso, use o menu de contexto da exibição de pesquisa.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">Arquivos com menos de 10 resultados são expandidos. Outros são recolhidos.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">Controla se os resultados da pesquisa serão recolhidos ou expandidos.</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">Controla se é necessário abrir a Visualização de Substituição ao selecionar ou substituir uma correspondência.</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">Controla se os números de linha devem ser mostrados para os resultados da pesquisa.</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">Se o mecanismo de regex do PCRE2 deve ser usado na pesquisa de texto. Isso permite o uso de alguns recursos de regex avançados, como referências inversas e de lookahead. No entanto, nem todos os recursos PCRE2 são compatíveis, somente recursos compatíveis com o JavaScript.</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">Preterido. O PCRE2 será usado automaticamente ao usar os recursos regex que só têm suporte do PCRE2.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">Posicione o actionBar à direita quando o modo de exibição de pesquisa for estreito e imediatamente após o conteúdo quando o modo de exibição de pesquisa for largo.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">Sempre posicione o actionbar à direita.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">Controla o posicionamento do actionbar nas linhas do modo de exibição de pesquisa.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">Pesquisar todos os arquivos enquanto você digita.</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">Habilitar a pesquisa de propagação da palavra mais próxima ao cursor quando o editor ativo não tiver nenhuma seleção.</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">Atualizar a consulta de pesquisa do workspace para o texto selecionado do editor ao focar no modo de exibição de pesquisa. Isso acontece ao clicar ou ao disparar o comando `workbench.views.search.focus`.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">Quando `#search.searchOnType#` está habilitado, controla o tempo limite em milissegundos entre um caractere que está sendo digitado e o início da pesquisa. Não tem efeito quando `search.searchOnType` está desabilitado.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">Clicar duas vezes seleciona a palavra sob o cursor.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">Clicar duas vezes abre o resultado no grupo de editor ativo.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">Clicar duas vezes abrirá o resultado no grupo editor ao lado, criando um se ele ainda não existir.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">Configurar efeito de clicar duas vezes em um resultado em um editor de pesquisas.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">Os resultados são classificados por nomes de pastas e arquivos, em ordem alfabética.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">Os resultados são classificados por nomes de arquivo ignorando a ordem da pasta, em ordem alfabética.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">Os resultados são classificados por extensões de arquivo, em ordem alfabética.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">Os resultados são classificados pela data da última modificação do arquivo, em ordem descendente.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">Os resultados são classificados por contagem por arquivo, em ordem descendente.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">Os resultados são classificados por contagem por arquivo, em ordem ascendente.</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">Controla a ordem de classificação dos resultados da pesquisa.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Nova Consulta</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Executar</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">Explicar</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">Real</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Alterar Conexão</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Conectar</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">Habilitar SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">Desabilitar SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">Selecionar Banco de Dados</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Falha ao alterar o banco de dados</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">Falha ao alterar o banco de dados {0}</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">Exportar o Notebook</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fechar</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Ação</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">Copiar detalhes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">Adicionar grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">Editar grupo de servidores</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">Extensão</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">Falha ao criar a sessão do Pesquisador de Objetos</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">Múltiplos erros:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Erro ao adicionar a conta</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">Erro de regra de firewall</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">Algumas das extensões carregadas estão usando APIs obsoletas. Encontre as informações detalhadas na guia Console da janela Ferramentas para Desenvolvedores</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Não Mostrar Novamente</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">Identificador da exibição. Use isso para registrar um provedor de dados por meio da API 'vscode.window.registerTreeDataProviderForView'. Também para ativar sua extensão registrando o evento 'onView: ${id}' para 'activationEvents'.</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">O nome legível para humanos da exibição. Será mostrado</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">A condição que deve ser true para mostrar esta exibição</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">Contribui com exibições para o editor</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">Contribui com exibições para o contêiner do Data Explorer na barra de Atividade</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">Contribui com exibições para o contêiner de exibições contribuídas</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">Não é possível registrar vários modos de exibição com a mesma id '{0}' no contêiner de exibição '{1}'</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">Uma exibição com a id '{0}' já está registrada no contêiner de exibição '{1}'</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">as exibições devem ser uma matriz</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">a propriedade `{0}` é obrigatória e deve ser do tipo `string`</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">a propriedade `{0}` pode ser omitida ou deve ser do tipo `string`</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">{0} foi substituído por {1} nas suas configurações de usuário.</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">{0} foi substituído por {1} nas suas configurações de workspace.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gerenciar</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Mostrar Detalhes</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">Saiba Mais</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">Limpar todas as contas salvas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">Alternar Tarefas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">Status da Conexão</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">Nome visível do usuário para o provedor de árvore</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">A ID do provedor precisa ser a mesma usada para registrar o provedor de dados de árvore e precisa começar com `connectionDialog/`</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">Exibe os resultados de uma consulta como um gráfico no painel</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">Mapeia 'nome de coluna' -&gt; cor. Por exemplo, adicione 'column1': red para garantir que essa coluna use uma cor vermelha </target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">Indica a posição preferida e a visibilidade da legenda do gráfico. Esses são os nomes das colunas da sua consulta e mapeados para o rótulo de cada entrada do gráfico</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">Se dataDirection for horizontal, definir como true usará o valor das primeiras colunas para a legenda.</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">Se dataDirection for vertical, definir como true usará os nomes das colunas para a legenda.</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">Define se os dados são lidos de uma coluna (vertical) ou uma linha (horizontal). Para séries temporais, isso é ignorado, pois a direção deve ser vertical.</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">Se showTopNData for definido, mostre somente os dados top N no gráfico.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usado nos painéis</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostrar Ações</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Visualizador de Recursos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">Identificador do recurso.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">O nome legível para humanos da exibição. Será mostrado</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">Caminho para o ícone de recurso.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">Contribui o recurso para o modo de exibição de recursos</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">a propriedade `{0}` é obrigatória e deve ser do tipo `string`</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">a propriedade `{0}` pode ser omitida ou deve ser do tipo `string`</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">Árvore do Visualizador de Recursos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usado nos painéis</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usado nos painéis</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Widget usado nos painéis</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">A condição deve ser true para mostrar este item</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">Opção de ocultar o cabeçalho do widget. O valor padrão é false</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">O título do contêiner</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">A linha do componente na grade</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">O rowspan do componente na grade. O valor padrão é 1. Use '*' para definir o número de linhas na grade.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">A coluna do componente na grade</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">O colspan do component na grade. O valor padrão é 1. Use '*' para definir o número de colunas na grade.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Identificador exclusivo para esta guia. Será passado para a extensão para quaisquer solicitações.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">A guia Extensão é desconhecida ou não está instalada.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Habilitar ou desabilitar o widget de propriedades</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valores de propriedade para mostrar</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nome de exibição da propriedade</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">Valor no objeto de informações do banco de dados</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">Especificar valores específicos para ignorar</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">Modo de Recuperação</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">Último Backup de Banco de Dados</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">Último Backup de Log</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">Nível de Compatibilidade</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Proprietário</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">Personaliza a página do painel de banco de dados</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Pesquisar</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">Personaliza as guias do painel de banco de dados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Habilitar ou desabilitar o widget de propriedades</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Valores de propriedade para mostrar</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Nome de exibição da propriedade</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">Valor no objeto de informações do servidor</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Versão</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">Edição</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">Nome do Computador</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">Versão do Sistema Operacional</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Pesquisar</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">Personaliza a página de painel do servidor</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">Personaliza as guias de painel do servidor</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Gerenciar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">propriedade `ícone` pode ser omitida ou deve ser uma cadeia de caracteres ou um literal como `{escuro, claro}`</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">Adiciona um widget que pode consultar um servidor ou banco de dados e exibir os resultados de várias maneiras – como um gráfico, uma contagem resumida e muito mais</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">Identificador Exclusivo usado para armazenar em cache os resultados do insight.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">Consulta SQL para executar. Isso deve retornar exatamente 1 resultset.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[Opcional] caminho para um arquivo que contém uma consulta. Use se a 'query' não for definida</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[Opcional] Intervalo de atualização automática em minutos, se não estiver definido, não haverá atualização automática</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">Quais ações usar</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Banco de dados de destino da ação. É possível usar o formato '${ columnName }' para usar um nome de coluna controlado por dados.</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">O servidor de destino da ação. É possível usar o formato '${ columnName }' para usar um nome de coluna controlado por dados.</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">O usuário de destino para a ação. É possível usar o formato '${ columnName }' para usar um nome de coluna controlado por dados.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">Identificador do insight</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">Contribui com insights para a paleta do painel.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Backup</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">Você precisa habilitar as versões prévias dos recursos para poder utilizar o backup</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">O comando Backup não é compatível com bancos de dados SQL do Azure.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">O comando Backup não é compatível no contexto do servidor. Selecione um banco de dados e tente novamente.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">Você precisa habilitar as versões prévias dos recursos para poder utilizar a restauração</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">O comando Restore não é compatível com bancos de dados SQL do Azure.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Mostrar Recomendações</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">Instalar Extensões</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">Criar uma Extensão...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">Falha ao conectar sessão de dados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">Abrir extensões do painel</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">Não há extensões de painel para serem instaladas neste momento. Vá para o Gerenciador de Extensões para explorar extensões recomendadas.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">Caminho selecionado</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">Arquivos do tipo</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Descartar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">Nenhum Perfil de Conexão foi passado para o submenu de insights</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">Erro de insights</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">Houve um erro ao ler o arquivo de consulta: </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">Ocorreu um erro ao analisar a configuração do insight. Não foi possível encontrar a matriz/cadeia de caracteres de consulta ou o arquivo de consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Conta do Azure</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Locatário do Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">Mostrar Conexões</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Servidores</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Conexões</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">Nenhum histórico de tarefas a ser exibido.</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">Histórico de tarefa</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">Erro de tarefa</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">Limpar Lista</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">Lista de conexões recentes limpa</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">Tem certeza de que deseja excluir todas as conexões da lista?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Excluir</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">Obter a Cadeia de Conexão Atual</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">A cadeia de conexão não está disponível</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">Nenhuma conexão ativa disponível</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Atualizar</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">Editar Conexão</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">Nova Conexão</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">Novo Grupo de Servidores</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">Editar Grupo de Servidores</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">Mostrar Conexões Ativas</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">Mostrar Todas as Conexões</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexões Recentes</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">Excluir Conexão</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">Excluir Grupo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Executar</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">Editar descarte falhou com o erro: </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Parar</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">Mostrar Painel do SQL</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">Fechar Painel do SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">Não conectado</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">A sessão do XEvent Profiler parou inesperadamente no servidor {0}.</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">Erro ao iniciar nova sessão</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">A sessão do XEvent Profiler para {0} perdeu eventos.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2257,743 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">Grupos de Servidores</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">Ocultar rótulos de texto</target>
       </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">Nome do grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">O nome do grupo é obrigatório.</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">Descrição do grupo</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">Cor do grupo</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">Mostrar rótulos de texto</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Erro ao adicionar a conta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">Item</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">Detalhes do Insight</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">Propriedade</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">Insights</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">Itens</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">Detalhes do Item</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">Não é possível iniciar o OAuth automático. Um OAuth automático já está em andamento.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">Classificar por evento</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">Classificar por coluna</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">Limpar tudo</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Aplicar</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">Filtros</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">Remover esta cláusula</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">Salvar Filtro</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">Carregar Filtro</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">Adicionar uma cláusula</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">Campo</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">Operador</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">É Nulo</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">Não É Nulo</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">Contém</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">Não Contém</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">Começa Com</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">Não Começa Com</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Salvar Como CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Salvar Como JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Salvar Como Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Salvar Como XML</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copiar com Cabeçalhos</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Selecionar Tudo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">Define uma propriedade para mostrar no painel</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">Qual o valor a ser usado como um rótulo para a propriedade</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">Qual o valor do objeto para acessar o valor</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">Especifique os valores a serem ignorados</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">Valor padrão para mostrar se ignorado ou sem valor</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">Uma variante para definir as propriedades do painel</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">Id da variante</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">Condição para usar essa variante</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">Campo para comparar a</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">Qual operador usar para comparação</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">Valor para comparar o campo com</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">Propriedades a serem exibidas na página de banco de dados</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">Propriedades a serem exibidas na página do servidor</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">Define que este provedor oferece suporte para o painel</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">Id do provedor (ex. MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">Valores de propriedade a serem exibidos no painel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">Valor inválido</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Carregando</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Carregamento concluído</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">branco</target>
-      </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">marcar todas as caixas de seleção na coluna: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">Não há exibição de árvore com a id '{0}' registrada.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">Falha ao inicializar a sessão de edição de dados: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">Identificador do provedor de notebook.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">Quais extensões de arquivo devem ser registradas para este provedor de notebook?</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">Quais kernels devem ser padrão com este provedor de notebook?</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">Contribui com provedores de notebooks.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">Nome do magic da célula, como '%%sql'.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">A linguagem de célula a ser usada se esta magic da célula estiver incluída na célula</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">Destino de execução opcional que essa mágic indica, por exemplo, Spark versus SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">Conjunto opcional de kernels que é válido para, por exemplo, python3, pyspark, SQL</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">Contribui com a linguagem do notebook.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">A tecla de atalho F5 requer que uma célula de código seja selecionada. Selecione uma célula de código para executar.</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">Limpar o resultado requer que uma célula de código seja selecionada. Selecione uma célula de código para executar.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">Máximo de Linhas:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">Selecionar Exibição</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">Selecionar Sessão</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">Selecionar Sessão:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">Selecionar Exibição:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Texto</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">Rótulo</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Valor</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Detalhes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">Tempo Decorrido</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">Contagem de Linhas</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} linhas</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">Executando consulta...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">Status de Execução</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">Resumo da Seleção</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">Média: {0}  Contagem: {1}  Soma: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">Escolha a linguagem SQL</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">Alterar provedor de linguagem SQL</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">Variante de linguagem SQL</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">Alterar Provedor de Mecanismo SQL</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">Existe uma conexão usando o mecanismo {0}. Para alterar, desconecte ou altere a conexão</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">Nenhum editor de texto ativo neste momento</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">Selecionar o Provedor de Linguagem</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">Erro ao exibir o gráfico Plotly: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Nenhum renderizador {0} foi encontrado para saída. Ele tem os seguintes tipos MIME: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(seguro) </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Selecione Top 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Levar 10</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Script como Executar</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Script como Alterar</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Editar Dados</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Script como Criar</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Script como Soltar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">Um NotebookProvider com providerId válido precisa ser passado para este método</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">Um NotebookProvider com providerId válido precisa ser passado para este método</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">nenhum provedor de notebook encontrado</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">Nenhum Gerenciador encontrado</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">O Notebook Manager para o notebook {0} não tem um gerenciador de servidores. Não é possível executar operações nele</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">O Notebook Manager do notebook {0} não tem um gerenciador de conteúdo. Não é possível executar operações nele</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">O Notebook Manager do notebook {0} não tem um gerenciador de sessão. Não é possível executar operações nele</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">Falha ao obter o token de conta do Azure para a conexão</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">Conexão não aceita</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">Tem certeza de que deseja cancelar esta conexão?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">Fechar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">Carregando kernels...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">Alterando kernel...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">Anexar a </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">Kernel </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">Carregando contextos...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Alterar Conexão</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">Selecionar Conexão</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">Nenhum Kernel</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">Limpar Resultados</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">Confiável</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">Não Confiável</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">Recolher Células</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">Expandir Células</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">Nenhum</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Novo Notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Encontrar Próxima Cadeia de Caracteres</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Encontrar Cadeia de Caracteres Anterior</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">Plano de Consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Atualizar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">Etapa {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">Deve ser uma opção da lista</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">Selecionar Caixa</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,133 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Conexão</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">Conectando</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">Tipo de conexão</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexões Recentes</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexões Salvas</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">Detalhes da Conexão</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Conectar</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexões Recentes</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">Nenhuma conexão recente</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexões Salvas</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">Nenhuma conexão salva</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">não há dados disponíveis</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">Árvore de navegador de arquivo</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">Selecionar/Desmarcar Tudo</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">De</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">Mostrar Filtro</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">Para</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Selecionar tudo</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">Criar regra de firewall</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Pesquisar</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} resultados</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">{0} selecionado(s)</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">Classificação Crescente</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">Classificação Decrescente</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">Limpar</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">Seu endereço IP de cliente não tem acesso ao servidor. Entre com uma conta Azure e crie uma regra de firewall para permitir o acesso.</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">Saiba mais sobre as configurações do firewall</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">Regra de firewall</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">Adicionar o meu IP de cliente </target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">Adicionar meu intervalo de IP de sub-rede</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">Opções de filtro</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">Todos os arquivos</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Carregando</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">Não foi possível encontrar o arquivo de consulta em nenhum dos seguintes caminhos: {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">Erro ao carregar...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">Você precisa atualizar as credenciais para esta conta.</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">Alternar Mais</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">Habilitar verificações de atualização automática. O Azure Data Studio verificará se há atualizações automaticamente e periodicamente.</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">Habilitar o download e a instalação de novas versões do Azure Data Studio no segundo plano no Windows</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">Mostrar notas de versão após uma atualização. As notas de versão são abertas em uma nova janela do navegador da Web.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">O menu de ação da barra de ferramentas do painel</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">O menu de título da célula do bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">O menu de título do bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">O menu da barra de ferramentas do bloco de anotações.</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">O menu de ação do título do contêiner de exibição dataexplorer</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">O menu de contexto do item dataexplorer</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">O menu de contexto do item do explorador de objetos</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">O menu de contexto da árvore de navegação da caixa de diálogo de conexão</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">O menu de contexto do item da grade de dados</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">Define a política de segurança para baixar extensões.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">A política de extensão não permite a instalação de extensões. Altere sua política de extensão e tente novamente.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">A instalação da extensão {0} foi concluída do VSIX. Recarregue o Azure Data Studio para habilitá-la.</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">Recarregue o Azure Data Studio para concluir a desinstalação dessa extensão.</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">Recarregue o Azure Data Studio para habilitar a extensão atualizada.</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">Recarregue o Azure Data Studio para habilitar essa extensão localmente.</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">Recarregue o Azure Data Studio para habilitar essa extensão.</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">Recarregue o Azure Data Studio para desabilitar essa extensão.</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">Recarregue o Azure Data Studio para concluir a desinstalação da extensão {0}.</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">Recarregue o Azure Data Studio para habilitar essa extensão em {0}.</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">A instalação da extensão {0} foi concluída. Recarregue o Azure Data Studio para habilitá-la.</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">Recarregue o Azure Data Studio para concluir a reinstalação da extensão {0}.</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Marketplace</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">O tipo de cenário para as recomendações de extensão precisa ser fornecido.</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">Não é possível instalar a extensão '{0}' porque ela não é compatível com o Azure Data Studio '{1}'.</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nova consulta</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Nova &amp;&amp;consulta</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Novo Bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">Controla a memória disponível para o Azure Data Studio após a reinicialização ao tentar abrir arquivos grandes. O mesmo efeito que especificar `--max-memory=NEWSIZE` na linha de comando.</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">Deseja alterar o idioma da interface do usuário do Azure Data Studio para {0} e reiniciar?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">Para usar o Azure Data Studio em {0}, o Azure Data Studio precisa ser reiniciado.</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">Novo arquivo SQL</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Novo bloco de anotações</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Instalar extensão do pacote VSIX</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">Deve ser uma opção da lista</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">Selecionar Caixa</target>
       </trans-unit>
     </body>
   </file>
@@ -3183,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">Mostrar Notebooks</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">Resultados da Pesquisa</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">Caminho de pesquisa não encontrado: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">Não há suporte para copiar imagens</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">Foco na Consulta Atual</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Executar Consulta</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">Executar Consulta Atual</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">Copiar Consulta com Resultados</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">Consulta e resultados copiados com êxito.</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">Executar Consulta Atual com Plano Real</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">Cancelar Consulta</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">Atualizar Cache do IntelliSense</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">Alternar Resultados da Consulta</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">Alternar Foco entre a Consulta e os Resultados</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">O editor de parâmetro é necessário para um atalho ser executado</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">Analisar Consulta</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">Comandos concluídos com êxito</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">Falha no comando: </target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">Conecte-se a um servidor</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">Um grupo de servidores com o mesmo nome já existe.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">com êxito</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">falhou</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">em andamento</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">não iniciado</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">cancelado</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">cancelando</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usado nos painéis</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">O gráfico não pode ser exibido com os dados fornecidos</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usado nos painéis</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usado nos painéis</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Widget usado nos painéis</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">Erro ao abrir o link: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">Erro ao executar o comando '{0}' : {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Falha na cópia com o erro {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">Mostrar gráfico</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">Mostrar tabela</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Clique duas vezes para editar&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Adicionar conteúdo aqui... &lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">Ocorreu um erro ao atualizar o nó '{0}': {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Concluído</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Gerar script</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Próximo</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">Anterior</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">As guias não estão inicializadas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated"> é necessário.</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">Entrada inválida. Valor numérico esperado.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">Caminho do arquivo de backup</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">Banco de dados de destino</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Restaurar banco de dados</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Banco de dados</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">Arquivo de backup</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Restaurar banco de dados</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Fonte</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">Restaurar de</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">O caminho do arquivo de backup é obrigatório.</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">Insira um ou mais caminhos de arquivo separados por vírgulas</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Banco de dados</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">Destino</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">Restaurar para</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">Restaurar plano</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">Conjuntos de backup para restaurar</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">Restaurar arquivos de banco de dados como</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">Restaurar os detalhes do arquivo de banco de dados</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">Nome do Arquivo lógico</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">Tipo de arquivo</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">Nome do Arquivo Original</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">Restaurar como</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">Opções de restauração</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">Backup da parte final do log</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">Conexões de servidor</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">Geral</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">Arquivos</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Opções</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">Copiar Célula</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Concluído</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">Copiar e Abrir</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">Código do usuário</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">Site</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">O índice {0} é inválido.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">Descrição do Servidor (opcional)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">Propriedades Avançadas</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Descartar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">nbformat v{0}.{1} não reconhecido</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">Este arquivo não tem um formato de notebook válido</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">Tipo de célula {0} desconhecido</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Tipo de saída {0} não reconhecido</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">Espera-se que os dados de {0} sejam uma cadeia de caracteres ou uma matriz de cadeia de caracteres</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Tipo de saída {0} não reconhecido</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Bem-vindo(a)</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Admin Pack do SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Admin Pack do SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">O Admin Pack do SQL Server é uma coleção de extensões populares de administração de banco de dados que ajudam você a gerenciar o SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Grave e execute scripts do PowerShell usando o editor de consultas avançado do Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">Virtualização de Dados</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">Virtualize os dados com o SQL Server 2019 e crie tabelas externas usando assistentes interativos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">Conecte-se, consulte e gerencie bancos de dados Postgres com o Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">O suporte para {0} já está instalado.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">A janela será recarregada após a instalação do suporte adicional para {0}.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">Instalando suporte adicional para {0}...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">Não foi possível encontrar suporte para {0} com a id {1}.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nova conexão</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nova consulta</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Novo notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Implantar um servidor</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Bem-vindo(a)</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">Novo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">Abrir…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">Abrir arquivo…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">Abrir a pasta…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">Iniciar Tour</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">Fechar barra do tour rápido</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">Deseja fazer um tour rápido pelo Azure Data Studio?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">Bem-vindo(a)!</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">Abrir pasta {0} com caminho {1}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">Instalar</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">Instalar o mapa de teclas {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">Instalar suporte adicional para {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Instalado</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">O mapa de teclas {0} já está instalado</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">O suporte de {0} já está instalado</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Detalhes</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">Cor da tela de fundo da página inicial.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">Editor do Profiler para o texto do evento .ReadOnly</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">Falha ao salvar os resultados. </target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">Escolher o Arquivo de Resultados</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (separado por vírgula)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Pasta de Trabalho do Excel</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">Texto Sem Formatação</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">Salvando arquivo...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">Os resultados foram salvos com êxito em {0}</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Abrir arquivo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">Ocultar rótulos de texto</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">Mostrar rótulos de texto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">Editor de código modelview para modelo de exibição.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">Informações</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Aviso</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Erro</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Mostrar Detalhes</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fechar</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">Voltar</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">Ocultar Detalhes</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">Contas</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">Contas vinculadas</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fechar</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">Não há nenhuma conta vinculada. Adicione uma conta.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">Adicionar uma conta</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">Você não tem nuvens habilitadas. Acesse Configurações-&gt; Pesquisar Configuração de Conta do Azure-&gt; Habilitar pelo menos uma nuvem</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">Você não selecionou nenhum provedor de autenticação. Tente novamente.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">A execução falhou devido a um erro inesperado: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">Tempo total de execução: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">Execução da consulta iniciada na linha {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">Execução do lote {0} iniciada</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">Tempo de execução em lote: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Falha na cópia com o erro {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Início</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Nova conexão</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Nova consulta</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Novo notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Abrir arquivo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Abrir arquivo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">Implantar</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">Nova Implantação…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">Recente</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">Mais...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">Não há pastas recentes</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Ajuda</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">Introdução</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentação</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">Relatar problema ou solicitação de recurso</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">Repositório GitHub</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">Notas sobre a versão</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Mostrar a página inicial na inicialização</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">Personalizar</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensões</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">Baixe as extensões necessárias, incluindo o pacote de Administrador do SQL Server e muito mais</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">Atalhos de Teclado</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">Encontre seus comandos favoritos e personalize-os</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">Tema de cores</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">Faça com que o editor e seu código tenham a aparência que você mais gosta</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">Learn</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">Encontrar e executar todos os comandos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">Acesse e pesquise rapidamente comandos na Paleta de Comandos ({0})</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">Descubra o que há de novo na versão mais recente</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">Novas postagens mensais do blog apresentando nossos novos recursos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Siga-nos no Twitter</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">Mantenha-se atualizado com a forma como a Comunidade está usando o Azure Data Studio e converse diretamente com os engenheiros.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Conectar</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Desconectar</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Início</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">Nova Sessão</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">Pausar</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">Continuar</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Parar</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">Limpar Dados</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">Tem certeza de que deseja limpar os dados?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">Rolagem Automática: Ativada</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">Rolagem Automática: Desativada</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">Alternar Painel Recolhido</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">Editar Colunas</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Encontrar Próxima Cadeia de Caracteres</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Encontrar Cadeia de Caracteres Anterior</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Iniciar Profiler</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">Filtro...</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">Limpar Filtro</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">Tem certeza de que deseja limpar os filtros?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">Eventos (Filtrados): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">Eventos: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">Contagem de Eventos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">não há dados disponíveis</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">Resultados</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">Mensagens</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">Nenhum script foi retornado ao chamar o script select no objeto </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">Selecionar</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">Criar</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">Inserir</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">Atualizar</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Excluir</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">Nenhum script foi retornado durante o script como {0} no objeto {1}</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">O script falhou</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">Nenhum script foi retornado ao criar scripts como {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">Cor da tela de fundo do cabeçalho de tabela</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">Cor de primeiro plano do cabeçalho de tabela</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">Cor da tela de fundo da lista/tabela para o item selecionado e foco quando a lista/tabela estiver ativa</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">Cor do contorno de uma célula.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">Fundo da caixa de entrada desabilitado.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">Primeiro plano da caixa de entrada desabilitado.</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">Cor do contorno do botão quando focada.</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">Primeiro plano da caixa de seleção desabilitado.</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">Cor da tela de fundo da tabela do SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">Cor da tela de fundo da célula de tabela do SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">Cor da tela de fundo para tabela do SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">Cor da tela de fundo do título do SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">Cor da borda da célula na tabela do SQL Agent.</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">Cor de erro das mensagens de resultados.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">Nome do backup</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">Modelo de recuperação</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">Tipo de backup</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">Arquivos de backup</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">Algoritmo</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">Chave de Certificado ou Assimétrica</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">Mídia</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">Backup para o conjunto de mídias existente</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">Backup para um novo conjunto de mídias</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">Acrescentar ao conjunto de backup existente</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">Substituir todos os conjuntos de backup existentes</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">Novo nome do conjunto de mídias</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">Nova descrição do conjunto de mídias</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">Executar soma de verificação antes de gravar na mídia</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">Verificar backup quando terminar</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">Continuar em caso de erro</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">Expiração</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">Defina os dias de retenção de backup</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">Backup somente cópia</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">Configuração Avançada</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">Compactação</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">Definir a compactação de backup</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">Criptografia</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">Log de transações</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">Truncar o log de transações</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">Backup do final do log</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">Confiabilidade</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">O nome da mídia é obrigatório</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">Nenhum certificado ou chave assimétrica está disponível</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">Adicionar um arquivo</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">Remover arquivos</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">Entrada inválida. O valor deve ser maior ou igual a 0.</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Backup</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">Apenas backup para arquivo é compatível</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">O caminho do arquivo de backup é obrigatório</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">O salvamento de resultados em diferentes formatos está desabilitado para este provedor de dados.</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">Não foi possível serializar os dados, pois não foi registrado nenhum provedor</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">Falha na serialização com um erro desconhecido</target>
       </trans-unit>
     </body>
   </file>
@@ -4631,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">Não há nenhum provedor de dados registrado que possa fornecer dados de exibição.</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">Cor da tela de fundo do cabeçalho de tabela</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Atualizar</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">Cor de primeiro plano do cabeçalho de tabela</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Recolher Tudo</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">Cor da tela de fundo da lista/tabela para o item selecionado e foco quando a lista/tabela estiver ativa</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">Erro ao executar o comando {1}: {0}. Isso provavelmente é causado pela extensão que contribui com {1}.</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">Cor do contorno de uma célula.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">Fundo da caixa de entrada desabilitado.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">Primeiro plano da caixa de entrada desabilitado.</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">Cor do contorno do botão quando focada.</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">Primeiro plano da caixa de seleção desabilitado.</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">Cor da tela de fundo da tabela do SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">Cor da tela de fundo da célula de tabela do SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">Cor da tela de fundo para tabela do SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">Cor da tela de fundo do título do SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">Cor da borda da célula na tabela do SQL Agent.</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">Cor de erro das mensagens de resultados.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">Selecione a célula ativa e tente novamente</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">Algumas das extensões carregadas estão usando APIs obsoletas. Encontre as informações detalhadas na guia Console da janela Ferramentas para Desenvolvedores</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">Executar célula</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">Cancelar execução</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">Erro na última execução. Clique para executar novamente</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Não Mostrar Novamente</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">Falha ao cancelar a tarefa.</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Script</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">Alternar Mais</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Carregando</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">Página Inicial</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">A seção "{0}" tem conteúdo inválido. Entre em contato com o proprietário da extensão.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">Trabalhos</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Alertas</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">Proxies</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">Operadores</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">Propriedades do Servidor</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">Propriedades do Banco de Dados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">Selecionar/Desmarcar Tudo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">Mostrar Filtro</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">Limpar</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Conexões Recentes</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Servidores</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Servidores</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">Arquivos de Backup</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">Todos os Arquivos</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">Pesquisar: digite o termo de pesquisa e pressione Enter para pesquisar ou Escape para cancelar</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Pesquisar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Falha ao alterar o banco de dados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">Última Ocorrência</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">Atraso Entre as Respostas (em segundos)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">Nome da Categoria</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">Endereço de Email</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">Nome da Conta</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">Nome da Credencial</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrição</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">carregando objetos</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">carregando bancos de dados</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">carregamento de objetos concluído.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">carregamento dos bancos de dados concluído.</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">Pesquisar pelo nome do tipo (t:, v:, f: ou sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">Pesquisar bancos de dados</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">Não é possível carregar objetos</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">Não é possível carregar bancos de dados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">Carregando as propriedades</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">Carregamento de propriedades concluído</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">Não é possível carregar as propriedades do painel</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">Carregando {0}</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">Carregamento de {0} concluído</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">Atualização Automática: DESATIVADA</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">Ultima Atualização: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">Nenhum resultado para mostrar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Etapas</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Salvar Como CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Salvar Como JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Salvar Como Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Salvar Como XML</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">A codificação de resultados não será salva ao exportar para JSON. Lembre-se de salvar com a codificação desejada após a criação do arquivo.</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">Salvar em arquivo não é uma ação compatível com a fonte de dados de backup</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Copiar Com Cabeçalhos</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Selecionar Tudo</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">Maximizar</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Restaurar</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Gráfico</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">Visualizador</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">A tecla de atalho F5 requer que uma célula de código seja selecionada. Selecione uma célula de código para executar.</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">Limpar o resultado requer que uma célula de código seja selecionada. Selecione uma célula de código para executar.</target>
       </trans-unit>
     </body>
   </file>
@@ -5051,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">ID da Etapa</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Concluído</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">Nome da Etapa</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">Mensagem</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Gerar script</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Próximo</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">Anterior</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">As guias não estão inicializadas</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Encontrar</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">Não há exibição de árvore com a id '{0}' registrada.</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Encontrar</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">Um NotebookProvider com providerId válido precisa ser passado para este método</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Correspondência anterior</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">nenhum provedor de notebook encontrado</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Próxima correspondência</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">Nenhum Gerenciador encontrado</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">O Notebook Manager para o notebook {0} não tem um gerenciador de servidores. Não é possível executar operações nele</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">O Notebook Manager do notebook {0} não tem um gerenciador de conteúdo. Não é possível executar operações nele</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">O Notebook Manager do notebook {0} não tem um gerenciador de sessão. Não é possível executar operações nele</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">Um NotebookProvider com providerId válido precisa ser passado para este método</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gerenciar</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Mostrar Detalhes</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">Saiba Mais</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">Limpar todas as contas salvas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">Versões prévias dos recursos</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">Habilitar versões prévias dos recursos não liberadas</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">Mostrar caixa de diálogo de conexão na inicialização</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">Notificação de API obsoleta</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">Habilitar/desabilitar a notificação de uso de API obsoleta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">Falha ao conectar sessão de dados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">Não conectado</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">A sessão do XEvent Profiler parou inesperadamente no servidor {0}.</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">Erro ao iniciar nova sessão</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">A sessão do XEvent Profiler para {0} perdeu eventos.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar Ações</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visualizador de Recursos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">Informações</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Aviso</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Erro</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Mostrar Detalhes</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">Fechar</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">Sua pesquisa retornou um grande número de resultados. Apenas as primeiras 999 correspondências serão destacadas.</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">Voltar</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} de {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Nenhum Resultado</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">Ocultar Detalhes</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">Barra Horizontal</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">Barra</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">Linha</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">Pizza</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">Dispersão</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">Série Temporal</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Imagem</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">Contagem</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">Tabela</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">Rosca</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">Falha ao obter as linhas do conjunto de dados para o gráfico.</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">Não há suporte para o tipo de gráfico '{0}'.</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">Parâmetros</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated"> é necessário.</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">Entrada inválida. Valor numérico esperado.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">Conectado a</target>
-      </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
-        <target state="translated">Desconectado</target>
-      </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">Conexões Não Salvas</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">O índice {0} é inválido.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">Procurar (Versão Prévia)</target>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">branco</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">Digite aqui para filtrar a lista</target>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">marcar todas as caixas de seleção na coluna: {0}</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">Filtrar conexões</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">Aplicando filtro</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">Removendo filtro</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">Filtro aplicado</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">Filtro removido</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexões Salvas</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Conexões Salvas</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">Árvore do Navegador de Conexão</target>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar ações</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Esta extensão é recomendada pelo Azure Data Studio.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Carregando</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Carregamento concluído</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Não Mostrar Novamente</target>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">Valor inválido</target>
       </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">O Azure Data Studio tem recomendações de extensão.</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">O Azure Data Studio tem recomendações de extensão para a visualização de dados.
-Quando ele estiver, você poderá selecionar o ícone Visualizador para visualizar os resultados da consulta.</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">Instalar Tudo</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Mostrar Recomendações</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">O tipo de cenário para as recomendações de extensão precisa ser fornecido.</target>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}. {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">Esta página de recurso está em versão prévia. Os recursos de versão prévia apresentam novas funcionalidades que estão no caminho para se tornar parte permanente do produto. Eles são estáveis, mas precisam de melhorias de acessibilidade adicionais. Nós agradecemos os seus comentários iniciais enquanto os recursos estão em desenvolvimento.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Carregando</target>
       </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">Versão prévia</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">Criar uma conexão</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">Conectar a uma instância do banco de dados por meio da caixa de diálogo de conexão.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">Executar uma consulta</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">Interagir com os dados por meio de um editor de consultas.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">Criar um notebook</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">Crie um notebook usando um editor de notebook nativo.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Implantar um servidor</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">Crie uma instância de um serviço de dados relacionais na plataforma de sua escolha.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">Recursos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">Histórico</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">Localização</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">Mostrar mais</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Mostrar a página inicial na inicialização</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">Links Úteis</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">Introdução</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Descubra as funcionalidades oferecidas pelo Azure Data Studio e saiba como aproveitá-las ao máximo.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Documentação</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">Visite o centro de documentos para obter guias de início rápido, guias de instruções e referências para o PowerShell, as APIs e outros.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Visão geral do Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Introdução aos Notebooks do Azure Data Studio | Dados Expostos</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensões</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">Mostrar Tudo</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">Saiba mais </target>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Carregamento concluído</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">Data de Criação: </target>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">Editor de código modelview para modelo de exibição.</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Erro do Notebook: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">Não foi possível localizar o componente para o tipo {0}</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">Erro de Trabalho: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">Não há suporte para alterar os tipos de editor em arquivos não salvos</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">Fixo</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Selecione Top 1000</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">Execuções Recentes</target>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Levar 10</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">Execuções Anteriores</target>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script como Executar</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script como Alterar</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Editar Dados</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script como Criar</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script como Soltar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">Nenhum script foi retornado ao chamar o script select no objeto </target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">Selecionar</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">Criar</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">Inserir</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Excluir</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">Nenhum script foi retornado durante o script como {0} no objeto {1}</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">O script falhou</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">Nenhum script foi retornado ao criar scripts como {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
+        <target state="translated">desconectado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
+        <target state="translated">Extensão</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">Cor da tela de fundo da guia ativa para guias verticais</target>
+      </trans-unit>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">Cor das bordas no painel</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">Cor do título do widget do painel</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">Cor do subtexto do widget de painel</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">Cor dos valores de propriedade exibidos no componente contêiner de propriedades</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">Cor dos nomes de propriedade exibidos no componente contêiner de propriedades</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">Cor da sombra do estouro de barra de ferramentas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">Identificador do tipo de conta</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(Opcional) Ícone que é usado para representar o accpunt na interface do usuário. Um caminho de arquivo ou uma configuração tematizáveis</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Caminho do ícone quando um tema leve é usado</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Caminho de ícone quando um tema escuro é usado</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">Contribui ícones para provedor de conta.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">Exibir regras aplicáveis</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">Exibir regras aplicáveis para {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">Invocar Avaliação</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">Invocar Avaliação para {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">Exportar como Script</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">Veja todas as regras e saiba mais no GitHub</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">Criar Relatório HTML</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">O relatório foi salvo. Deseja abri-lo?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Abrir</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
       </trans-unit>
     </body>
   </file>
@@ -5422,390 +1206,6 @@ Quando ele estiver, você poderá selecionar o ícone Visualizador para visualiz
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">O banco de dados {0} está em total conformidade com as práticas recomendadas. Bom trabalho!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Gráfico</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">Operação</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">Objeto</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">Custo Est.</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">Custo Est. da Subárvore</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">Linhas Atuais</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">Linhas Est.</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">Execuções Reais</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">Custo Est. de CPU</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">Custo Est. de E/S</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">Paralelo</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">Reassociações Reais</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">Reassociações Est.</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">Rebobinações Reais</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">Rebobinações Est.</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">Particionado</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">Operações Principais</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">Nenhuma conexão encontrada.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">Adicionar Conexão</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">Adicionar uma conta...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Padrão&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Carregando...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">Grupo de servidores</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;Padrão&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">Adicionar novo grupo...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;Não salvar&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} é obrigatório.</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0} será removido.</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">Lembrar senha</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">Conta</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">Atualizar as credenciais de conta</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Locatário do Azure AD</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">Nome (opcional)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">Avançado...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">Você precisa selecionar uma conta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">Banco de dados</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">Arquivos e grupos de arquivos</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">Completo</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">Diferencial</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">Log de Transações</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">Disco</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">Usar a configuração padrão do servidor</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">Compactar backup</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">Não compactar backup</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">Certificado do Servidor</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">Chave Assimétrica</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">Você não abriu nenhuma pasta que contenha notebooks/livros. </target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">Abrir os Notebooks</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">O conjunto de resultados contém apenas um subconjunto de todas as correspondências. Faça uma pesquisa mais específica para restringir os resultados.</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">Pesquisa em andamento... – </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">Nenhum resultado encontrado em '{0}', exceto '{1}' – </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">Nenhum resultado encontrado em '{0}' – </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">Nenhum resultado encontrado, exceto '{0}' – </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">Nenhum resultado encontrado. Examine suas configurações para obter exclusões configuradas e verifique os arquivos do gitignore – </target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">Pesquisar novamente</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Cancelar Pesquisa</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">Pesquisar novamente em todos os arquivos</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">Abrir as Configurações</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">A pesquisa retornou {0} resultados em {1} arquivos</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">Ativar/Desativar Recolhimento e Expansão</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Cancelar Pesquisa</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">Expandir Tudo</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Recolher Tudo</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">Limpar os Resultados da Pesquisa</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Conexões</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">Conecte-se, consulte e gerencie as suas conexões no SQL Server, no Azure e muito mais.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Próximo</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">Comece a criar o seu notebook ou uma coleção de notebooks em um único lugar.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Extensões</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Estenda a funcionalidade do Azure Data Studio instalando extensões desenvolvidas por nós/Microsoft e também pela comunidade de terceiros (você!).</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Configurações</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">Personalize o Azure Data Studio com base nas suas preferências. Você pode definir configurações como o salvamento automático e o tamanho da tabulação, personalizar os seus Atalhos de Teclado e mudar para um Tema de Cores de sua preferência.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">Página Inicial</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">Descubra os principais recursos, arquivos abertos recentemente e extensões recomendadas na Página inicial. Para obter mais informações sobre como começar a usar o Azure Data Studio, confira nossos vídeos e documentação.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">Concluir</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">Tour de Boas-Vindas do Usuário</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">Ocultar Tour de Boas-Vindas</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">Leia mais</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Ajuda</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">Excluir Linha</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">Desfazer Linha Atual</target>
       </trans-unit>
     </body>
   </file>
@@ -5893,575 +1293,283 @@ Quando ele estiver, você poderá selecionar o ícone Visualizador para visualiz
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">Painel de Mensagens</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Copiar</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">Copiar Tudo</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">Abrir no Portal do Azure</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Carregando</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">Nome do backup</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Carregamento concluído</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">Modelo de recuperação</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">Tipo de backup</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">Arquivos de backup</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">Algoritmo</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">Chave de Certificado ou Assimétrica</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">Mídia</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">Backup para o conjunto de mídias existente</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">Backup para um novo conjunto de mídias</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">Acrescentar ao conjunto de backup existente</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">Substituir todos os conjuntos de backup existentes</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">Novo nome do conjunto de mídias</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">Nova descrição do conjunto de mídias</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">Executar soma de verificação antes de gravar na mídia</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">Verificar backup quando terminar</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">Continuar em caso de erro</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">Expiração</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">Defina os dias de retenção de backup</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">Backup somente cópia</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">Configuração Avançada</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">Compactação</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">Definir a compactação de backup</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">Criptografia</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">Log de transações</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">Truncar o log de transações</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">Backup do final do log</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">Confiabilidade</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">O nome da mídia é obrigatório</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">Nenhum certificado ou chave assimétrica está disponível</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">Adicionar um arquivo</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">Remover arquivos</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">Entrada inválida. O valor deve ser maior ou igual a 0.</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Backup</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">Apenas backup para arquivo é compatível</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">O caminho do arquivo de backup é obrigatório</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">Clique em</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ Código</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">ou</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ Texto</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">para adicionar uma célula de texto ou código</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Backup</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">Stdin:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">Você precisa habilitar as versões prévias dos recursos para poder utilizar o backup</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">O comando Backup não é suportado fora de um contexto de banco de dados. Selecione um banco de dados e tente novamente.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">O comando Backup não é compatível com bancos de dados SQL do Azure.</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Backup</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">Expandir conteúdo da célula do código</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Banco de dados</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">Recolher conteúdo da célula do código</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">Arquivos e grupos de arquivos</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">Completo</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">Diferencial</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">Log de Transações</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">Disco</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">Usar a configuração padrão do servidor</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">Compactar backup</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">Não compactar backup</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">Certificado do Servidor</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">Chave Assimétrica</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">Plano de execução XML</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">Grade de resultados</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Adicionar célula</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Célula de código</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Célula de texto</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">Mover a célula para baixo</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">Mover a célula para cima</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Excluir</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Adicionar célula</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Célula de código</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Célula de texto</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">Erro no kernel do SQL</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">Uma conexão precisa ser escolhida para executar as células do notebook</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">Exibindo as Primeiras {0} linhas.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Última Execução</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Próxima Execução</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Habilitado</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Status</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Categoria</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">Executável</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">Agendamento</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Resultado da Última Execução</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Execuções Anteriores</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Nenhuma etapa disponível para este trabalho.</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Erro: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">Não foi possível localizar o componente para o tipo {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Encontrar</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Encontrar</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Correspondência anterior</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Próxima correspondência</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fechar</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">Sua pesquisa retornou um grande número de resultados. Apenas as primeiras 999 correspondências serão destacadas.</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} de {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Nenhum Resultado</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">Esquema</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Tipo</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Executar Consulta</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Não foi possível encontrar nenhum {0}renderizador para saída. Ele tem os seguintes tipos MIME: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">seguro </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">Não foi possível encontrar nenhum componente para o seletor {0}</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">Erro ao renderizar o componente: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Carregando...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Carregando...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Editar</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">Sair</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Atualizar</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostrar Ações</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">Excluir Widget</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">Clique para desafixar</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">Clique para fixar</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">Abrir recursos instalados</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">Recolher Widget</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">Expandir Widget</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} é um contêiner desconhecido.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Nome</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Banco de Dados de Destino</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Última Execução</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Próxima Execução</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Status</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Resultado da Última Execução</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Execuções Anteriores</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Nenhuma etapa disponível para este trabalho.</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Erro: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Erro do Notebook: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">Erro ao carregar...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Mostrar Ações</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">Não foi encontrado nenhum item correspondente</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">Lista de pesquisa filtrada para um item</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">Lista de pesquisa filtrada para {0} itens</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">Com falha</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">Com Êxito</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">Tentar Novamente</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">Cancelado</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">Em Andamento</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">Status Desconhecido</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">Executando</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">Esperando pela Thread</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">Entre Tentativas</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">Ocioso</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">Suspenso</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[Obsoleto]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Sim</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Não</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">Não Agendado</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">Nunca Executar</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">Negrito</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">Itálico</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">Sublinhado</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">Realçar</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Código</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">Vínculo</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">Lista</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">Lista ordenada</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Imagem</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Alternância de versão prévia do Markdown – Desativado</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">Título</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">Título 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">Título 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">Título 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">Parágrafo</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">Inserir link</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">Inserir imagem</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">Exibição de Rich Text</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">Modo Divisão</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Exibição do Markdown</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">Criar Insight</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">Não é possível criar insight, pois o editor ativo não é um Editor SQL</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">Meu Widget</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">Configurar Gráfico</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">Copiar como imagem</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">Não foi possível encontrar o gráfico para salvar</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">Salvar como imagem</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">Gráfico salvo no caminho: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6549,19 +1657,411 @@ Quando ele estiver, você poderá selecionar o ícone Visualizador para visualiz
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Gráfico</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">Barra Horizontal</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">Barra</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">Linha</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">Pizza</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">Dispersão</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">Série Temporal</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Imagem</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">Contagem</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">Tabela</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">Rosca</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">Falha ao obter as linhas do conjunto de dados para o gráfico.</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">Não há suporte para o tipo de gráfico '{0}'.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Gráficos Integrados</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">O número máximo de linhas para os gráficos exibirem. Aviso: aumentar isso pode afetar o desempenho.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">Fechar</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">Um grupo de servidores com o mesmo nome já existe.</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">Série {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">A tabela não contém uma imagem válida</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">A contagem máxima de linhas para gráficos integrados foi excedida, somente as primeiras {0} linhas são usadas. Para definir o valor, você pode abrir as configurações do usuário e procurar: 'builtinCharts.maxRowCount'.</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Não Mostrar Novamente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">Conectando: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">Comando em execução: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">Abrindo a nova consulta: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">Não é possível se conectar, pois não foi fornecida nenhuma informação do servidor</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">Não foi possível abrir a URL devido ao erro {0}</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">Isso será conectado ao servidor {0}</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">Tem certeza de que deseja se conectar?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">&amp;&amp;Abrir</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">Conectando o arquivo de consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">{0} foi substituído por {1} nas suas configurações de usuário.</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">{0} foi substituído por {1} nas suas configurações de workspace.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">O número máximo de conexões usadas recentemente para armazenar na lista de conexão.</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">Mecanismo SQL padrão a ser usado. Isso direciona o provedor de idioma padrão em arquivos .sql e o padrão a ser usado ao criar uma conexão.</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">Tentativa de analisar o conteúdo da área de transferência quando a caixa de diálogo conexão é aberta ou a cópia é executada.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">Status da Conexão</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">ID comum do provedor</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">Nome de Exibição do provedor</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">Alias do Kernel do Notebook para o provedor</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">Caminho do ícone do tipo de servidor</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">Opções de conexão</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">Nome visível do usuário para o provedor de árvore</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">A ID do provedor precisa ser a mesma usada para registrar o provedor de dados de árvore e precisa começar com `connectionDialog/`</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">Identificador exclusivo para este contêiner.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">O contêiner que será exibido na guia.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">Contribui com um único ou vários contêineres de painéis para os usuários adicionarem ao painel.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">Nenhuma ID no contêiner de painéis especificada para a extensão.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">Nenhum contêiner no contêiner de painéis especificado para a extensão.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Exatamente 1 contêiner de painéis deve ser definido por espaço.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">O tipo de contêiner desconhecido é definido no contêiner de painéis para extensão.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">O controlhost que será exibido nesta guia.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">A seção "{0}" tem conteúdo inválido. Entre em contato com o proprietário da extensão.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">A lista de widgets ou de modos de exibição da Web que serão exibidos nesta guia.</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">widgets ou modos de exibição da Web são esperados dentro de contêiner de widgets para a extensão.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">A visualização com suporte do modelo que será exibida nesta guia.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificador exclusivo para esta seção de navegação. Será passado para a extensão para quaisquer solicitações.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Opcional) Ícone usado para representar essa seção de navegação na interface do usuário. Um caminho de arquivo ou uma configuração com tema</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Caminho do ícone quando um tema leve é usado</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Caminho de ícone quando um tema escuro é usado</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">Título da seção de navegação para mostrar ao usuário.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">O contêiner que será exibido nesta seção de navegação.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">A lista de contêineres de painéis que será exibida nesta seção de navegação.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">Não foi especificado nenhum título na seção de navegação para a extensão.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">Não foi especificado nenhum contêiner na seção de navegação para a extensão.</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Exatamente 1 contêiner de painéis deve ser definido por espaço.</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION dentro de NAV_SECTION é um contêiner inválido para a extensão.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">O modo de exibição da Web que será exibido nesta guia.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">A lista de widgets que serão exibidos nesta guia.</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">A lista de widgets é esperada dentro de contêiner de widgets para a extensão.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Editar</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">Sair</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar Ações</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">Excluir Widget</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">Clique para desafixar</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">Clique para fixar</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">Abrir recursos instalados</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">Recolher Widget</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">Expandir Widget</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} é um contêiner desconhecido.</target>
       </trans-unit>
     </body>
   </file>
@@ -6581,111 +2081,1025 @@ Quando ele estiver, você poderá selecionar o ícone Visualizador para visualiz
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">Criar Insight</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificador exclusivo para esta guia. Será passado para a extensão para quaisquer solicitações.</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">Não é possível criar insight, pois o editor ativo não é um Editor SQL</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">Título da guia para mostrar ao usuário.</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">Meu Widget</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">Descrição desta guia que será mostrada ao usuário.</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">Configurar Gráfico</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">A condição deve ser true para mostrar este item</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">Copiar como imagem</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">Define os tipos de conexão com os quais essa guia é compatível. O padrão será 'MSSQL' se essa opção não for definida</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">Não foi possível encontrar o gráfico para salvar</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">O contêiner que será exibido nesta guia.</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">Salvar como imagem</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">Se esta guia deve ou não ser sempre exibida ou apenas quando o usuário a adiciona.</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">Se esta guia deve ou não ser usada como guia da Página Inicial para um tipo de conexão.</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">Gráfico salvo no caminho: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">O identificador exclusivo do grupo ao qual esta guia pertence. Valor do grupo doméstico: página inicial.</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Opcional) Ícone usado para representar esta guia na interface do usuário. Um caminho de arquivo ou uma configuração com tema</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Caminho do ícone quando um tema leve é usado</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Caminho de ícone quando um tema escuro é usado</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">Contribui com uma única ou várias guias para que os usuários adicionem ao painel.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">Nenhum título especificado para a extensão.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">Nenhuma descrição especificada para mostrar.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">Nenhum contêiner especificado para a extensão.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">Exatamente 1 contêiner de painéis deve ser definido por espaço</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">Identificador exclusivo deste grupo de guias.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">Título do grupo de guias.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">Contribui com um ou vários grupos de guias para os usuários adicionarem ao painel.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">Nenhuma ID foi especificada para o grupo de guias.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">Nenhum título foi especificado para o grupo de guias.</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">Administração</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">Monitoramento</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">Desempenho</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">Segurança</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">Solução de Problemas</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Configurações</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">guia de bancos de dados</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">Bancos de Dados</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">Adicionar código</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gerenciar</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">Adicionar texto</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Painel</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">Criar Arquivo</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Gerenciar</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">Não foi possível exibir o conteúdo: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">propriedade `ícone` pode ser omitida ou deve ser uma cadeia de caracteres ou um literal como `{escuro, claro}`</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Adicionar célula</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">Define uma propriedade para mostrar no painel</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Célula de código</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">Qual o valor a ser usado como um rótulo para a propriedade</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Célula de texto</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">Qual o valor do objeto para acessar o valor</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">Executar tudo</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">Especifique os valores a serem ignorados</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">Célula</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">Valor padrão para mostrar se ignorado ou sem valor</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Código</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">Uma variante para definir as propriedades do painel</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Texto</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">Id da variante</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">Executar Células</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">Condição para usar essa variante</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; Anterior</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">Campo para comparar a</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">Próximo &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">Qual operador usar para comparação</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">a célula com o URI {0} não foi encontrada neste modelo</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">Valor para comparar o campo com</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">Falha ao executar células – Confira o erro na saída da célula selecionada no momento para obter mais informações.</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">Propriedades a serem exibidas na página de banco de dados</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">Propriedades a serem exibidas na página do servidor</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">Define que este provedor oferece suporte para o painel</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">Id do provedor (ex. MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">Valores de propriedade a serem exibidos no painel</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">A condição deve ser true para mostrar este item</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">Opção de ocultar o cabeçalho do widget. O valor padrão é false</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">O título do contêiner</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">A linha do componente na grade</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">O rowspan do componente na grade. O valor padrão é 1. Use '*' para definir o número de linhas na grade.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">A coluna do componente na grade</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">O colspan do component na grade. O valor padrão é 1. Use '*' para definir o número de colunas na grade.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Identificador exclusivo para esta guia. Será passado para a extensão para quaisquer solicitações.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">A guia Extensão é desconhecida ou não está instalada.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">Propriedades do Banco de Dados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Habilitar ou desabilitar o widget de propriedades</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valores de propriedade para mostrar</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nome de exibição da propriedade</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">Valor no objeto de informações do banco de dados</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">Especificar valores específicos para ignorar</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">Modo de Recuperação</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">Último Backup de Banco de Dados</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">Último Backup de Log</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">Nível de Compatibilidade</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Proprietário</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">Personaliza a página do painel de banco de dados</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Pesquisar</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">Personaliza as guias do painel de banco de dados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">Propriedades do Servidor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Habilitar ou desabilitar o widget de propriedades</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Valores de propriedade para mostrar</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Nome de exibição da propriedade</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">Valor no objeto de informações do servidor</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Versão</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">Edição</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">Nome do Computador</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">Versão do Sistema Operacional</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Pesquisar</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">Personaliza a página de painel do servidor</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">Personaliza as guias de painel do servidor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">Página Inicial</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Falha ao alterar o banco de dados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Mostrar Ações</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">Não foi encontrado nenhum item correspondente</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">Lista de pesquisa filtrada para um item</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">Lista de pesquisa filtrada para {0} itens</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">Esquema</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Tipo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">carregando objetos</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">carregando bancos de dados</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">carregamento de objetos concluído.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">carregamento dos bancos de dados concluído.</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">Pesquisar pelo nome do tipo (t:, v:, f: ou sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">Pesquisar bancos de dados</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">Não é possível carregar objetos</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">Não é possível carregar bancos de dados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Executar Consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">Carregando {0}</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">Carregamento de {0} concluído</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">Atualização Automática: DESATIVADA</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">Ultima Atualização: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">Nenhum resultado para mostrar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">Adiciona um widget que pode consultar um servidor ou banco de dados e exibir os resultados de várias maneiras – como um gráfico, uma contagem resumida e muito mais</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">Identificador Exclusivo usado para armazenar em cache os resultados do insight.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">Consulta SQL para executar. Isso deve retornar exatamente 1 resultset.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[Opcional] caminho para um arquivo que contém uma consulta. Use se a 'query' não for definida</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[Opcional] Intervalo de atualização automática em minutos, se não estiver definido, não haverá atualização automática</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">Quais ações usar</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Banco de dados de destino da ação. É possível usar o formato '${ columnName }' para usar um nome de coluna controlado por dados.</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">O servidor de destino da ação. É possível usar o formato '${ columnName }' para usar um nome de coluna controlado por dados.</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">O usuário de destino para a ação. É possível usar o formato '${ columnName }' para usar um nome de coluna controlado por dados.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">Identificador do insight</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">Contribui com insights para a paleta do painel.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">O gráfico não pode ser exibido com os dados fornecidos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">Exibe os resultados de uma consulta como um gráfico no painel</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">Mapeia 'nome de coluna' -&gt; cor. Por exemplo, adicione 'column1': red para garantir que essa coluna use uma cor vermelha </target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">Indica a posição preferida e a visibilidade da legenda do gráfico. Esses são os nomes das colunas da sua consulta e mapeados para o rótulo de cada entrada do gráfico</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">Se dataDirection for horizontal, definir como true usará o valor das primeiras colunas para a legenda.</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">Se dataDirection for vertical, definir como true usará os nomes das colunas para a legenda.</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">Define se os dados são lidos de uma coluna (vertical) ou uma linha (horizontal). Para séries temporais, isso é ignorado, pois a direção deve ser vertical.</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">Se showTopNData for definido, mostre somente os dados top N no gráfico.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Valor mínimo do eixo y</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Valor máximo do eixo y</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Rótulo para o eixo y</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">Valor mínimo do eixo x</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">Valor máximo do eixo x</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">Rótulo para o eixo x</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">Indica a propriedade de dados de um conjunto de dados para um gráfico.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">Para cada coluna em um conjunto de resultados, exibe o valor na linha 0 como uma contagem seguida pelo nome da coluna. Dá suporte para '1 Íntegro', '3 Não Íntegro', por exemplo, em que 'Íntegro' é o nome da coluna e 1 é o valor na célula 1 da linha 1</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">Exibe uma imagem, por exemplo, um retornado por uma consulta R usando o ggplot2</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">Qual é o formato esperado – É um JPEG, PNG ou outro formato?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">É codificado como hexa, base64 ou algum outro formato?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">Exibe os resultados em uma tabela simples</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">Carregando as propriedades</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">Carregamento de propriedades concluído</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">Não é possível carregar as propriedades do painel</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">Conexões de Banco de Dados</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">conexões de fonte de dados</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">grupos de fonte de dados</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">As conexões salvas são classificadas pelas datas em que foram adicionadas.</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">As conexões salvas são classificadas por seus nomes de exibição alfabeticamente.</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">Controla a ordem de classificação das conexões e dos grupos de conexão salvos.</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">Configuração de Inicialização</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">True para a exibição Servidores a ser mostrada na inicialização do padrão do Azure Data Studio; false se a última visualização aberta deve ser mostrada</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">Identificador da exibição. Use isso para registrar um provedor de dados por meio da API 'vscode.window.registerTreeDataProviderForView'. Também para ativar sua extensão registrando o evento 'onView: ${id}' para 'activationEvents'.</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">O nome legível para humanos da exibição. Será mostrado</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">A condição que deve ser true para mostrar esta exibição</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">Contribui com exibições para o editor</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">Contribui com exibições para o contêiner do Data Explorer na barra de Atividade</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">Contribui com exibições para o contêiner de exibições contribuídas</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">Não é possível registrar vários modos de exibição com a mesma id '{0}' no contêiner de exibição '{1}'</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">Uma exibição com a id '{0}' já está registrada no contêiner de exibição '{1}'</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">as exibições devem ser uma matriz</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">a propriedade `{0}` é obrigatória e deve ser do tipo `string`</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">a propriedade `{0}` pode ser omitida ou deve ser do tipo `string`</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Servidores</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Conexões</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">Mostrar Conexões</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">Mostrar painel do SQL Editar Dados na inicialização</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Executar</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">Editar descarte falhou com o erro: </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Parar</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">Mostrar Painel do SQL</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">Fechar Painel do SQL</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">Máximo de Linhas:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">Excluir Linha</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">Desfazer Linha Atual</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Salvar Como CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Salvar Como JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Salvar Como Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Salvar Como XML</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copiar com Cabeçalhos</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Selecionar Tudo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">Guias do Painel ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Título</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrição</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">Painel de Insights ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">Quando</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">Obtém informações de extensão na galeria</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">ID de Extensão</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">Extensão '{0}' não encontrada.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Mostrar Recomendações</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">Instalar Extensões</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">Criar uma Extensão...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Não Mostrar Novamente</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">O Azure Data Studio tem recomendações de extensão.</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">O Azure Data Studio tem recomendações de extensão para a visualização de dados.
+Quando ele estiver, você poderá selecionar o ícone Visualizador para visualizar os resultados da consulta.</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">Instalar Tudo</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Mostrar Recomendações</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">O tipo de cenário para as recomendações de extensão precisa ser fornecido.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Esta extensão é recomendada pelo Azure Data Studio.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">Trabalhos</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Alertas</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">Proxies</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">Operadores</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">Última Ocorrência</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">Atraso Entre as Respostas (em segundos)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">Nome da Categoria</target>
       </trans-unit>
     </body>
   </file>
@@ -6905,257 +3319,187 @@ Erro: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">Exibir regras aplicáveis</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">ID da Etapa</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">Exibir regras aplicáveis para {0}</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">Nome da Etapa</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">Invocar Avaliação</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">Invocar Avaliação para {0}</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">Exportar como Script</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">Veja todas as regras e saiba mais no GitHub</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">Criar Relatório HTML</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">O relatório foi salvo. Deseja abri-lo?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Abrir</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Cancelar</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">Mensagem</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">Dados</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Conexão</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Editor de Consultas</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Painel</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Profiler</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Etapas</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">Guias do Painel ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">Título</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Descrição</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">Painel de Insights ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">Quando</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Última Execução</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Próxima Execução</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Status</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Categoria</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">Executável</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">Agendamento</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Resultado da Última Execução</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Execuções Anteriores</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Nenhuma etapa disponível para este trabalho.</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Erro: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">A tabela não contém uma imagem válida</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">Data de Criação: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Erro do Notebook: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">Erro de Trabalho: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">Fixo</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">Execuções Recentes</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">Execuções Anteriores</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">Mais</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Editar</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Banco de Dados de Destino</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fechar</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Última Execução</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">Converter Célula</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Próxima Execução</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">Executar as Células Acima</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Status</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">Executar as Células Abaixo</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Resultado da Última Execução</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">Inserir Código Acima</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Execuções Anteriores</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">Inserir Código Abaixo</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Nenhuma etapa disponível para este trabalho.</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">Inserir Texto Acima</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Erro: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">Inserir Texto Abaixo</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">Recolher Célula</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">Expandir Célula</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">Criar célula de parâmetro</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">Remover célula de parâmetro</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">Limpar Resultado</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Erro do Notebook: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">Ocorreu um erro ao iniciar a sessão do notebook</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">O servidor não foi iniciado por uma razão desconhecida</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">Endereço de Email</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">O kernel {0} não foi encontrado. O kernel padrão será usado em seu lugar.</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">Série {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">Nome da Conta</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Fechar</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">Nome da Credencial</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="pt-BR">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated"># Injected-Parameters
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Descrição</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">Selecione uma conexão para executar células para este kernel</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">Falha ao excluir a célula.</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">Falha ao alterar o kernel. O kernel {0} será usado. O erro foi: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">Falha ao alterar o kernel devido ao erro: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">Falha ao alterar o contexto: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">Não foi possível iniciar a sessão: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">Ocorreu um erro de sessão de cliente ao fechar o notebook: {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">Não é possível encontrar o gerenciador de notebook do provedor {0}</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Habilitado</target>
       </trans-unit>
     </body>
   </file>
@@ -7227,6 +3571,3316 @@ Erro: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">Mais</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Editar</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fechar</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">Converter Célula</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">Executar as Células Acima</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">Executar as Células Abaixo</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">Inserir Código Acima</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">Inserir Código Abaixo</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">Inserir Texto Acima</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">Inserir Texto Abaixo</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">Recolher Célula</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">Expandir Célula</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">Criar célula de parâmetro</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">Remover célula de parâmetro</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">Limpar Resultado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Adicionar célula</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Célula de código</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Célula de texto</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">Mover a célula para baixo</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">Mover a célula para cima</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Excluir</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Adicionar célula</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Célula de código</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Célula de texto</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">Parâmetros</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">Selecione a célula ativa e tente novamente</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">Executar célula</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">Cancelar execução</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">Erro na última execução. Clique para executar novamente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">Expandir conteúdo da célula do código</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">Recolher conteúdo da célula do código</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">Negrito</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">Itálico</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">Sublinhado</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">Realçar</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Código</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">Vínculo</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">Lista</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">Lista ordenada</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Imagem</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Alternância de versão prévia do Markdown – Desativado</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">Título</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">Título 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">Título 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">Título 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">Parágrafo</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">Inserir link</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">Inserir imagem</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">Exibição de Rich Text</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Modo Divisão</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Exibição do Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Não foi possível encontrar nenhum {0}renderizador para saída. Ele tem os seguintes tipos MIME: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">seguro </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">Não foi possível encontrar nenhum componente para o seletor {0}</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">Erro ao renderizar o componente: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">Clique em</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ Código</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">ou</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ Texto</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">para adicionar uma célula de texto ou código</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">Adicionar uma célula de código</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">Adicionar uma célula de texto</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">Stdin:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Clique duas vezes para editar&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Adicionar conteúdo aqui... &lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Encontrar</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Encontrar</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Correspondência anterior</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Próxima correspondência</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fechar</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">Sua pesquisa retornou um grande número de resultados. Apenas as primeiras 999 correspondências serão destacadas.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} de {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Nenhum Resultado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">Adicionar código</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">Adicionar texto</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">Criar Arquivo</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">Não foi possível exibir o conteúdo: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Adicionar célula</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Célula de código</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Célula de texto</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">Executar tudo</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">Célula</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Código</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Texto</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">Executar Células</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; Anterior</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">Próximo &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">a célula com o URI {0} não foi encontrada neste modelo</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Falha ao executar células – Confira o erro na saída da célula selecionada no momento para obter mais informações.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Novo Notebook</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Novo Notebook</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">Definir Workspace e Abrir</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">Kernel do SQL: parar a execução do Notebook quando ocorrer um erro em uma célula.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(Versão Prévia) Mostrar todos os kernels para o provedor do notebook atual.</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">Permitir que notebooks executem comandos do Azure Data Studio.</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">Habilitar clique duplo para editar células de texto nos notebooks</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">O texto é exibido como Rich Text (também conhecido como WYSIWYG).</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">O Markdown é exibido à esquerda, com uma visualização do texto renderizado à direita.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">O texto é exibido como Markdown.</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">O modo de edição padrão usado para células de texto</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(Versão Prévia) Salve o nome da conexão nos metadados do notebook.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">Controla a altura da linha usada na versão prévia de markdown do notebook. Este número é relativo ao tamanho da fonte.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(Visualização) Mostrar bloco de anotações renderizado no editor de dif.</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">O número máximo de alterações armazenadas no histórico de desfazer do editor de Rich Text do bloco de anotações.</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">Pesquisar Notebooks</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">Configurar padrões glob para excluir arquivos e pastas em pesquisas de texto completo e abrir rapidamente. Herda todos os padrões glob da configuração `#files.exclude#`. Leia mais sobre padrões glob [aqui] (https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">O padrão glob ao qual corresponder os caminhos do arquivo. Defina como true ou false para habilitar ou desabilitar o padrão.</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">Verificação adicional nos irmãos de um arquivo correspondente. Use $(basename) como variável para o nome do arquivo correspondente.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">Essa configuração foi preterida e agora retorna ao "search.usePCRE2".</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">Preterido. Considere "search.usePCRE2" para obter suporte do recurso regex avançado.</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">Quando habilitado, o processo de searchService será mantido ativo em vez de ser desligado após uma hora de inatividade. Isso manterá o cache de pesquisa de arquivo na memória.</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Controla se os arquivos `.gitignore` e `.ignore` devem ser usados ao pesquisar arquivos.</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Controla se os arquivos globais `.gitignore` e `.ignore` devem ser usados durante a pesquisa de arquivos.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">Se deseja incluir os resultados de uma pesquisa de símbolo global nos resultados do arquivo para Abertura Rápida.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">Se deseja incluir os resultados de arquivos abertos recentemente nos resultados do arquivo para Abertura Rápida.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">As entradas do histórico são classificadas por relevância com base no valor do filtro usado. As entradas mais relevantes aparecem primeiro.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">As entradas do histórico são classificadas por recência. As entradas abertas mais recentemente aparecem primeiro.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">Controla a ordem de classificação do histórico do editor ao abrir rapidamente ao filtrar.</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">Controla se os ciclos de links devem ser seguidos durante a pesquisa.</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">Pesquisar sem diferenciar maiúsculas de minúsculas se o padrão for todo em minúsculas, caso contrário, pesquisar diferenciando maiúsculas de minúsculas.</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">Controla se o modo de exibição de pesquisa deve ler ou modificar a área de transferência de localização compartilhada no macOS.</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">Controla se a pesquisa será mostrada como um modo de exibição na barra lateral ou como um painel na área do painel para obter mais espaço horizontal.</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">Esta configuração é preterida. Em vez disso, use o menu de contexto da exibição de pesquisa.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">Arquivos com menos de 10 resultados são expandidos. Outros são recolhidos.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">Controla se os resultados da pesquisa serão recolhidos ou expandidos.</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">Controla se é necessário abrir a Visualização de Substituição ao selecionar ou substituir uma correspondência.</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">Controla se os números de linha devem ser mostrados para os resultados da pesquisa.</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">Se o mecanismo de regex do PCRE2 deve ser usado na pesquisa de texto. Isso permite o uso de alguns recursos de regex avançados, como referências inversas e de lookahead. No entanto, nem todos os recursos PCRE2 são compatíveis, somente recursos compatíveis com o JavaScript.</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">Preterido. O PCRE2 será usado automaticamente ao usar os recursos regex que só têm suporte do PCRE2.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">Posicione o actionBar à direita quando o modo de exibição de pesquisa for estreito e imediatamente após o conteúdo quando o modo de exibição de pesquisa for largo.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">Sempre posicione o actionbar à direita.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">Controla o posicionamento do actionbar nas linhas do modo de exibição de pesquisa.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">Pesquisar todos os arquivos enquanto você digita.</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">Habilitar a pesquisa de propagação da palavra mais próxima ao cursor quando o editor ativo não tiver nenhuma seleção.</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">Atualizar a consulta de pesquisa do workspace para o texto selecionado do editor ao focar no modo de exibição de pesquisa. Isso acontece ao clicar ou ao disparar o comando `workbench.views.search.focus`.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">Quando `#search.searchOnType#` está habilitado, controla o tempo limite em milissegundos entre um caractere que está sendo digitado e o início da pesquisa. Não tem efeito quando `search.searchOnType` está desabilitado.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">Clicar duas vezes seleciona a palavra sob o cursor.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">Clicar duas vezes abre o resultado no grupo de editor ativo.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">Clicar duas vezes abrirá o resultado no grupo editor ao lado, criando um se ele ainda não existir.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">Configurar efeito de clicar duas vezes em um resultado em um editor de pesquisas.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">Os resultados são classificados por nomes de pastas e arquivos, em ordem alfabética.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">Os resultados são classificados por nomes de arquivo ignorando a ordem da pasta, em ordem alfabética.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">Os resultados são classificados por extensões de arquivo, em ordem alfabética.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">Os resultados são classificados pela data da última modificação do arquivo, em ordem descendente.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">Os resultados são classificados por contagem por arquivo, em ordem descendente.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">Os resultados são classificados por contagem por arquivo, em ordem ascendente.</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">Controla a ordem de classificação dos resultados da pesquisa.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">Carregando kernels...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">Alterando kernel...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">Anexar a </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">Kernel </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">Carregando contextos...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Alterar Conexão</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">Selecionar Conexão</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">Nenhum Kernel</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Esse bloco de anotações não pode ser executado com parâmetros porque não há suporte para o kernel. Use os kernels e o formato com suporte. [Learn more] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Este bloco de anotações não pode ser executado com parâmetros até que uma célula de parâmetro seja adicionada. [Saiba mais] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Este bloco de anotações não pode ser executado com parâmetros até que haja parâmetros adicionados à célula de parâmetro. [Saiba mais] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">Limpar Resultados</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">Confiável</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">Não Confiável</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">Recolher Células</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">Expandir Células</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">Executar com Parâmetros</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">Nenhum</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Novo Notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Encontrar Próxima Cadeia de Caracteres</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Encontrar Cadeia de Caracteres Anterior</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">Resultados da Pesquisa</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">Caminho de pesquisa não encontrado: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">Você não abriu nenhuma pasta que contenha notebooks/livros. </target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">Abrir os Notebooks</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">O conjunto de resultados contém apenas um subconjunto de todas as correspondências. Faça uma pesquisa mais específica para restringir os resultados.</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">Pesquisa em andamento... – </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">Nenhum resultado encontrado em '{0}', exceto '{1}' – </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">Nenhum resultado encontrado em '{0}' – </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">Nenhum resultado encontrado, exceto '{0}' – </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">Nenhum resultado encontrado. Examine suas configurações para obter exclusões configuradas e verifique os arquivos do gitignore – </target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">Pesquisar novamente</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">Pesquisar novamente em todos os arquivos</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">Abrir as Configurações</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">A pesquisa retornou {0} resultados em {1} arquivos</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">Ativar/Desativar Recolhimento e Expansão</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">Cancelar Pesquisa</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">Expandir Tudo</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Recolher Tudo</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">Limpar os Resultados da Pesquisa</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">Pesquisar: digite o termo de pesquisa e pressione Enter para pesquisar ou Escape para cancelar</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Pesquisar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">a célula com o URI {0} não foi encontrada neste modelo</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Falha ao executar células – Confira o erro na saída da célula selecionada no momento para obter mais informações.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">Execute essa célula para exibir as saídas.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">Essa exibição está vazia. Adicione uma célula a essa exibição clicando no botão Inserir células.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Falha na cópia com o erro {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">Mostrar gráfico</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">Mostrar tabela</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Nenhum renderizador {0} foi encontrado para saída. Ele tem os seguintes tipos MIME: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(seguro) </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">Erro ao exibir o gráfico Plotly: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">Nenhuma conexão encontrada.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">Adicionar Conexão</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">Paleta de cores do grupo de servidores usada no viewlet do Pesquisador de Objetos.</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">Expanda automaticamente grupos de servidores no viewlet do Pesquisador de Objetos.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(Versão Prévia) Use a nova árvore de servidor assíncrono para o modo de exibição Servidores e a caixa de diálogo Conexão com suporte para novos recursos, como filtragem dinâmica de nós.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">Dados</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Conexão</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Editor de Consultas</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Painel</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Gráficos Integrados</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">Especifica os modelos de exibição</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">Especifica os modelos de sessão</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Filtros do Profiler</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Conectar</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Início</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">Nova Sessão</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">Pausar</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">Continuar</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Parar</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">Limpar Dados</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">Tem certeza de que deseja limpar os dados?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">Rolagem Automática: Ativada</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">Rolagem Automática: Desativada</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">Alternar Painel Recolhido</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">Editar Colunas</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Encontrar Próxima Cadeia de Caracteres</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Encontrar Cadeia de Caracteres Anterior</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Iniciar Profiler</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">Filtro...</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">Limpar Filtro</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">Tem certeza de que deseja limpar os filtros?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">Selecionar Exibição</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">Selecionar Sessão</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">Selecionar Sessão:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">Selecionar Exibição:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Texto</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">Rótulo</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Detalhes</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Encontrar</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Encontrar</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Correspondência anterior</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Próxima correspondência</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fechar</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">Sua pesquisa retornou um grande número de resultados. Apenas as primeiras 999 correspondências serão destacadas.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} de {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Nenhum Resultado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">Editor do Profiler para o texto do evento .ReadOnly</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">Eventos (Filtrados): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">Eventos: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">Contagem de Eventos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Salvar Como CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Salvar Como JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Salvar Como Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Salvar Como XML</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">A codificação de resultados não será salva ao exportar para JSON. Lembre-se de salvar com a codificação desejada após a criação do arquivo.</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">Salvar em arquivo não é uma ação compatível com a fonte de dados de backup</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Copiar Com Cabeçalhos</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Selecionar Tudo</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">Maximizar</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Gráfico</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">Visualizador</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">Escolha a linguagem SQL</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">Alterar provedor de linguagem SQL</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">Variante de linguagem SQL</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">Alterar Provedor de Mecanismo SQL</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">Existe uma conexão usando o mecanismo {0}. Para alterar, desconecte ou altere a conexão</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">Nenhum editor de texto ativo neste momento</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">Selecionar o Provedor de Linguagem</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">Plano de execução XML</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">Grade de resultados</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">A contagem máxima de linhas para filtragem/classificação foi excedida. Para atualizá-la, você pode ir para as configurações do usuário e alterar a configuração: 'queryEditor. Results. inMemoryDataProcessingThreshold'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">Foco na Consulta Atual</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Executar Consulta</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">Executar Consulta Atual</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">Copiar Consulta com Resultados</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">Consulta e resultados copiados com êxito.</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">Executar Consulta Atual com Plano Real</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">Cancelar Consulta</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">Atualizar Cache do IntelliSense</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">Alternar Resultados da Consulta</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">Alternar Foco entre a Consulta e os Resultados</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">O editor de parâmetro é necessário para um atalho ser executado</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">Analisar Consulta</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">Comandos concluídos com êxito</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">Falha no comando: </target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">Conecte-se a um servidor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">Painel de Mensagens</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Copiar</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">Copiar Tudo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">Resultados da Consulta</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nova Consulta</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Editor de Consultas</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">Quando true, os cabeçalhos de coluna são incluídos ao salvar os resultados como CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">O delimitador personalizado a ser usado entre valores ao salvar como CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">Os caracteres usados para separar linhas ao salvar os resultados como CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">O caractere usado para delimitar os campos de texto ao salvar os resultados como CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">Arquivo de codificação usado ao salvar os resultados como CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">Quando true, a saída XML será formatada ao salvar resultados como XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">Codificação de arquivo usada ao salvar os resultados como XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">Habilitar streaming de resultados; contém alguns problemas visuais menores</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">Opções de configuração para copiar os resultados na Visualização dos Resultados</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">Opções de configuração para copiar os resultados de várias linhas da Visualização dos Resultados</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(Experimental) Use uma tabela otimizada nos resultados. Algumas funcionalidades podem estar ausentes e em funcionamento.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">Controla o número máximo de linhas permitidas para filtragem e classificação na memória. Se o número for excedido, a classificação e a filtragem serão desabilitadas. Aviso: aumentar isso pode afetar o desempenho.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">Se o arquivo deve ser aberto no Azure Data Studio depois que o resultado é salvo.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">O tempo de execução deve ser mostrado para lotes individuais?</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">Mensagens de quebra automática de linha</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">O tipo de gráfico padrão a ser usado ao abrir o Visualizador de Gráficos nos Resultados da Consulta</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">A coloração da guia será desabilitada</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">A borda superior de cada guia do editor será colorida para combinar com o grupo de servidores relevante</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">A cor de fundo de cada editor da guia corresponderá ao grupo de servidores relevante</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">Controla como colorir as guias com base no grupo de servidores de sua conexão ativa</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">Controla se deseja mostrar a informação de conexão para uma guia no título.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">Pedir para salvar arquivos SQL gerados</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">Defina o atalho workbench.action.query.shortcut{0} para executar o texto de atalho como uma chamada de procedimento ou execução de consulta. Qualquer texto selecionado no editor de consultas será passado como um parâmetro no final da consulta ou você pode fazer referência a ele com {arg}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Nova Consulta</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Executar</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">Explicar</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">Real</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Alterar Conexão</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Conectar</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">Habilitar SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">Desabilitar SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Selecionar Banco de Dados</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Falha ao alterar o banco de dados</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">Falha ao alterar o banco de dados: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">Exportar o Notebook</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">Resultados</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">Mensagens</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">Tempo Decorrido</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">Contagem de Linhas</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} linhas</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">Executando consulta...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">Status de Execução</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">Resumo da Seleção</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">Média: {0}  Contagem: {1}  Soma: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">Grade de Resultados e Mensagens</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">Controla a família de fontes.</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">Controla a espessura da fonte.</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">Controla o tamanho da fonte em pixels.</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">Controla o espaçamento de letras em pixels.</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">Controla a altura da linha em pixels</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">Controla o preenchimento em pixels da célula</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">Dimensionar automaticamente a largura de colunas nos resultados iniciais. Pode haver problemas de desempenho com um grande número de colunas ou com células grandes</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">A largura máxima em pixels para colunas dimensionadas automaticamente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">Ativar/desativar o Histórico de Consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Excluir</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Limpar Todo o Histórico</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">Abrir Consulta</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Executar Consulta</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">Ativar/desativar a captura de Histórico de Consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Pausar a Captura de Histórico de Consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Iniciar a Captura do Histórico de Consultas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">com êxito</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">falhou</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">Não há nenhuma consulta a ser exibida.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">Histórico de Consultas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">QueryHistory</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">Se a captura do Histórico de Consultas estiver habilitada. Se for false, as consultas executadas não serão capturadas.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Limpar todo o histórico</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Pausar a Captura de Histórico de Consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Iniciar a Captura do Histórico de Consultas</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Exibir</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Histórico de Consultas</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">Histórico de Consultas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">Plano de Consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">Operação</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">Objeto</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">Custo Est.</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">Custo Est. da Subárvore</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">Linhas Atuais</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">Linhas Est.</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">Execuções Reais</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">Custo Est. de CPU</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">Custo Est. de E/S</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">Paralelo</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">Reassociações Reais</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">Reassociações Est.</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">Rebobinações Reais</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">Rebobinações Est.</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">Particionado</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">Operações Principais</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Visualizador de Recursos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">Erro ao abrir o link: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">Erro ao executar o comando '{0}' : {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">Árvore do Visualizador de Recursos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">Identificador do recurso.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">O nome legível para humanos da exibição. Será mostrado</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">Caminho para o ícone de recurso.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">Contribui o recurso para o modo de exibição de recursos</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">a propriedade `{0}` é obrigatória e deve ser do tipo `string`</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">a propriedade `{0}` pode ser omitida ou deve ser do tipo `string`</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">Você precisa habilitar as versões prévias dos recursos para poder utilizar a restauração</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">O comando Restaurar não tem suporte fora de um contexto de servidor. Selecione um servidor ou banco de dados e tente novamente.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">O comando Restore não é compatível com bancos de dados SQL do Azure.</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script como Criar</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script como Soltar</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Selecione Top 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script como Executar</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script como Alterar</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Editar Dados</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Selecione Top 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Levar 10</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Script como Criar</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Script como Executar</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Script como Alterar</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Script como Soltar</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">Ocorreu um erro ao atualizar o nó '{0}': {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} tarefas em andamento</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Exibir</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">Tarefas</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Tarefas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">Alternar Tarefas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">com êxito</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">falhou</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">em andamento</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">não iniciado</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">cancelado</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">cancelando</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">Nenhum histórico de tarefas a ser exibido.</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">Histórico de tarefa</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">Erro de tarefa</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">Falha ao cancelar a tarefa.</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">Não há nenhum provedor de dados registrado que possa fornecer dados de exibição.</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Recolher Tudo</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">Erro ao executar o comando {1}: {0}. Isso provavelmente é causado pela extensão que contribui com {1}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fechar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">Os recursos de versão prévia aprimoram a sua experiência no Azure Data Studio oferecendo a você acesso completo a novos recursos e melhorias. Saiba mais sobre os recursos de versão prévia [aqui]({0}). Deseja habilitar os recursos de versão prévia?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">Sim (recomendado)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">Não, não mostrar novamente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">Esta página de recurso está em versão prévia. Os recursos de versão prévia apresentam novas funcionalidades que estão no caminho para se tornar parte permanente do produto. Eles são estáveis, mas precisam de melhorias de acessibilidade adicionais. Nós agradecemos os seus comentários iniciais enquanto os recursos estão em desenvolvimento.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">Versão prévia</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">Criar uma conexão</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">Conectar a uma instância do banco de dados por meio da caixa de diálogo de conexão.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">Executar uma consulta</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">Interagir com os dados por meio de um editor de consultas.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">Criar um notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">Crie um notebook usando um editor de notebook nativo.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Implantar um servidor</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">Crie uma instância de um serviço de dados relacionais na plataforma de sua escolha.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">Recursos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">Histórico</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Nome</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">Localização</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">Mostrar mais</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Mostrar a página inicial na inicialização</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">Links Úteis</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">Introdução</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Descubra as funcionalidades oferecidas pelo Azure Data Studio e saiba como aproveitá-las ao máximo.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentação</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">Visite o centro de documentos para obter guias de início rápido, guias de instruções e referências para o PowerShell, as APIs e outros.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">Vídeos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Visão geral do Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Introdução aos Notebooks do Azure Data Studio | Dados Expostos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensões</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">Mostrar Tudo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">Saiba mais </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Conexões</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">Conecte-se, consulte e gerencie as suas conexões no SQL Server, no Azure e muito mais.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Próximo</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">Comece a criar o seu notebook ou uma coleção de notebooks em um único lugar.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensões</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Estenda a funcionalidade do Azure Data Studio instalando extensões desenvolvidas por nós/Microsoft e também pela comunidade de terceiros (você!).</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Configurações</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">Personalize o Azure Data Studio com base nas suas preferências. Você pode definir configurações como o salvamento automático e o tamanho da tabulação, personalizar os seus Atalhos de Teclado e mudar para um Tema de Cores de sua preferência.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">Página Inicial</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">Descubra os principais recursos, arquivos abertos recentemente e extensões recomendadas na Página inicial. Para obter mais informações sobre como começar a usar o Azure Data Studio, confira nossos vídeos e documentação.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">Concluir</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">Tour de Boas-Vindas do Usuário</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">Ocultar Tour de Boas-Vindas</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">Leia mais</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Ajuda</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Bem-vindo(a)</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Admin Pack do SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Admin Pack do SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">O Admin Pack do SQL Server é uma coleção de extensões populares de administração de banco de dados que ajudam você a gerenciar o SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server Agent</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">Importação do SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server Dacpac</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Grave e execute scripts do PowerShell usando o editor de consultas avançado do Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">Virtualização de Dados</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">Virtualize os dados com o SQL Server 2019 e crie tabelas externas usando assistentes interativos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">Conecte-se, consulte e gerencie bancos de dados Postgres com o Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">O suporte para {0} já está instalado.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">A janela será recarregada após a instalação do suporte adicional para {0}.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">Instalando suporte adicional para {0}...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">Não foi possível encontrar suporte para {0} com a id {1}.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nova conexão</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nova consulta</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Novo notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Implantar um servidor</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Bem-vindo(a)</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">Novo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">Abrir…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">Abrir arquivo…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">Abrir a pasta…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">Iniciar Tour</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">Fechar barra do tour rápido</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">Deseja fazer um tour rápido pelo Azure Data Studio?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">Bem-vindo(a)!</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">Abrir pasta {0} com caminho {1}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Instalar</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">Instalar o mapa de teclas {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">Instalar suporte adicional para {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">Instalado</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">O mapa de teclas {0} já está instalado</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">O suporte de {0} já está instalado</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Detalhes</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">Cor da tela de fundo da página inicial.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Início</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Nova conexão</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Nova consulta</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Novo notebook</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Abrir arquivo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Abrir arquivo</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">Implantar</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">Nova Implantação…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Recente</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">Mais...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">Não há pastas recentes</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Ajuda</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">Introdução</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Documentação</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">Relatar problema ou solicitação de recurso</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">Repositório GitHub</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">Notas sobre a versão</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Mostrar a página inicial na inicialização</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">Personalizar</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Extensões</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">Baixe as extensões necessárias, incluindo o pacote de Administrador do SQL Server e muito mais</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">Atalhos de Teclado</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">Encontre seus comandos favoritos e personalize-os</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">Tema de cores</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">Faça com que o editor e seu código tenham a aparência que você mais gosta</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">Learn</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">Encontrar e executar todos os comandos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">Acesse e pesquise rapidamente comandos na Paleta de Comandos ({0})</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">Descubra o que há de novo na versão mais recente</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">Novas postagens mensais do blog apresentando nossos novos recursos</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Siga-nos no Twitter</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">Mantenha-se atualizado com a forma como a Comunidade está usando o Azure Data Studio e converse diretamente com os engenheiros.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">Contas</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">Contas vinculadas</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fechar</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">Não há nenhuma conta vinculada. Adicione uma conta.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">Adicionar uma conta</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">Você não tem nuvens habilitadas. Acesse Configurações-&gt; Pesquisar Configuração de Conta do Azure-&gt; Habilitar pelo menos uma nuvem</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">Você não selecionou nenhum provedor de autenticação. Tente novamente.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Erro ao adicionar a conta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">Você precisa atualizar as credenciais para esta conta.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fechar</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">Adicionando conta...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">A conta de atualização foi cancelada pelo usuário</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Conta do Azure</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Locatário do Azure</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">Copiar e Abrir</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">Código do usuário</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">Site</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">Não é possível iniciar o OAuth automático. Um OAuth automático já está em andamento.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">A conexão é necessária para interagir com adminservice</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Nenhum manipulador registrado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">A conexão é necessária para interagir com o Serviço de Avaliação</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Nenhum Manipulador Registrado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">Propriedades Avançadas</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Descartar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">Descrição do Servidor (opcional)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">Limpar Lista</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">Lista de conexões recentes limpa</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">Tem certeza de que deseja excluir todas as conexões da lista?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Excluir</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">Obter a Cadeia de Conexão Atual</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">A cadeia de conexão não está disponível</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">Nenhuma conexão ativa disponível</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Procurar</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">Digite aqui para filtrar a lista</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">Filtrar conexões</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">Aplicando filtro</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">Removendo filtro</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">Filtro aplicado</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">Filtro removido</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Conexões Salvas</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Conexões Salvas</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">Árvore do Navegador de Conexão</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">Erro de conexão</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">A conexão falhou devido a um erro do Kerberos.</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">Ajuda para configurar o Kerberos está disponível em {0}</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">Se você já se conectou anteriormente, pode ser necessário executar novamente o kinit.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Conexão</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">Conectando</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">Tipo de conexão</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Recente</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">Detalhes da Conexão</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Conectar</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Conexões Recentes</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">Nenhuma conexão recente</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">Falha ao obter o token de conta do Azure para a conexão</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">Conexão não aceita</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">Tem certeza de que deseja cancelar esta conexão?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">Adicionar uma conta...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Padrão&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Carregando...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">Grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;Padrão&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">Adicionar novo grupo...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;Não salvar&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} é obrigatório.</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0} será removido.</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">Lembrar senha</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">Conta</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">Atualizar as credenciais de conta</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Locatário do Azure AD</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">Nome (opcional)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">Avançado...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">Você precisa selecionar uma conta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">Conectado a</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">Desconectado</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">Conexões Não Salvas</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">Abrir extensões do painel</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">Não há extensões de painel para serem instaladas neste momento. Vá para o Gerenciador de Extensões para explorar extensões recomendadas.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">Etapa {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Concluído</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">Falha ao inicializar a sessão de edição de dados: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Fechar</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Ação</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">Copiar detalhes</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Erro</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Aviso</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">Informações</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">Ignorar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">Caminho selecionado</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">Arquivos do tipo</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Descartar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">Selecionar um arquivo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">Árvore de navegador de arquivo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">Ocorreu um erro ao carregar o navegador de arquivos.</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">Erro do navegador de arquivo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">Todos os arquivos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">Copiar Célula</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">Nenhum Perfil de Conexão foi passado para o submenu de insights</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">Erro de insights</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">Houve um erro ao ler o arquivo de consulta: </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">Ocorreu um erro ao analisar a configuração do insight. Não foi possível encontrar a matriz/cadeia de caracteres de consulta ou o arquivo de consulta</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">Item</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">Detalhes do Insight</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">Propriedade</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">Insights</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">Itens</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">Detalhes do Item</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">Não foi possível encontrar o arquivo de consulta em nenhum dos seguintes caminhos: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">Com falha</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">Com Êxito</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">Tentar Novamente</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">Cancelado</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">Em Andamento</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">Status Desconhecido</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">Executando</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">Esperando pela Thread</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">Entre Tentativas</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">Ocioso</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">Suspenso</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[Obsoleto]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">Não Agendado</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">Nunca Executar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">A conexão é necessária para interagir com JobManagementService</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Nenhum Manipulador Registrado</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7255,6 +6909,22 @@ Erro: {1}</target>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">Ocorreu um erro ao iniciar a sessão do notebook</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">O servidor não foi iniciado por uma razão desconhecida</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">O kernel {0} não foi encontrado. O kernel padrão será usado em seu lugar.</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
       <trans-unit id="selectConnection">
@@ -7267,11 +6937,738 @@ Erro: {1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="pt-BR">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="pt-BR">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">Não há suporte para alterar os tipos de editor em arquivos não salvos</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated"># Injected-Parameters
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">Selecione uma conexão para executar células para este kernel</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">Falha ao excluir a célula.</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">Falha ao alterar o kernel. O kernel {0} será usado. O erro foi: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">Falha ao alterar o kernel devido ao erro: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">Falha ao alterar o contexto: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">Não foi possível iniciar a sessão: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">Ocorreu um erro de sessão de cliente ao fechar o notebook: {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">Não é possível encontrar o gerenciador de notebook do provedor {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">Nenhum URI foi passado ao criar um gerenciador de notebooks</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">O provedor de notebooks não existe</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">Já existe uma exibição com o nome {0} nesse bloco de anotações.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">Erro no kernel do SQL</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">Uma conexão precisa ser escolhida para executar as células do notebook</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">Exibindo as Primeiras {0} linhas.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">Rich Text</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Modo Divisão</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">nbformat v{0}.{1} não reconhecido</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">Este arquivo não tem um formato de notebook válido</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">Tipo de célula {0} desconhecido</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Tipo de saída {0} não reconhecido</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">Espera-se que os dados de {0} sejam uma cadeia de caracteres ou uma matriz de cadeia de caracteres</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Tipo de saída {0} não reconhecido</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">Identificador do provedor de notebook.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">Quais extensões de arquivo devem ser registradas para este provedor de notebook?</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">Quais kernels devem ser padrão com este provedor de notebook?</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">Contribui com provedores de notebooks.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">Nome do magic da célula, como '%%sql'.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">A linguagem de célula a ser usada se esta magic da célula estiver incluída na célula</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">Destino de execução opcional que essa mágic indica, por exemplo, Spark versus SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">Conjunto opcional de kernels que é válido para, por exemplo, python3, pyspark, SQL</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">Contribui com a linguagem do notebook.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Carregando...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Atualizar</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">Editar Conexão</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Desconectar</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">Nova Conexão</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">Novo Grupo de Servidores</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">Editar Grupo de Servidores</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">Mostrar Conexões Ativas</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">Mostrar Todas as Conexões</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">Excluir Conexão</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">Excluir Grupo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">Falha ao criar a sessão do Pesquisador de Objetos</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">Múltiplos erros:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">Não é possível expandir, pois o provedor de conexão necessário '{0}' não foi encontrado</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">Usuário cancelado</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">Caixa de diálogo do Firewall cancelada</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Carregando...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Conexões Recentes</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Servidores</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Servidores</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">Classificar por evento</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">Classificar por coluna</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Profiler</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">Limpar tudo</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Aplicar</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">Filtros</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">Remover esta cláusula</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">Salvar Filtro</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">Carregar Filtro</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">Adicionar uma cláusula</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">Campo</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">Operador</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Valor</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">É Nulo</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">Não É Nulo</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">Contém</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">Não Contém</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">Começa Com</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">Não Começa Com</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">A linha de commit falhou: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">Iniciada a execução de consulta em </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">Começou a executar consulta "{0}"</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">Linha {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">O cancelamento da consulta falhou: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">Falha na célula de atualização: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">A execução falhou devido a um erro inesperado: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">Tempo total de execução: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">Execução da consulta iniciada na linha {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">Execução do lote {0} iniciada</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">Tempo de execução em lote: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Falha na cópia com o erro {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">Falha ao salvar os resultados. </target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">Escolher o Arquivo de Resultados</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (separado por vírgula)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Pasta de Trabalho do Excel</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">Texto Sem Formatação</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">Salvando arquivo...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">Os resultados foram salvos com êxito em {0}</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Abrir arquivo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">De</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">Para</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">Criar regra de firewall</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">Seu endereço IP de cliente não tem acesso ao servidor. Entre com uma conta Azure e crie uma regra de firewall para permitir o acesso.</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">Saiba mais sobre as configurações do firewall</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">Regra de firewall</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">Adicionar o meu IP de cliente </target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">Adicionar meu intervalo de IP de sub-rede</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Erro ao adicionar a conta</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">Erro de regra de firewall</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">Caminho do arquivo de backup</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">Banco de dados de destino</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Restaurar</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Restaurar banco de dados</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Banco de dados</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">Arquivo de backup</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Restaurar banco de dados</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Script</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Fonte</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">Restaurar de</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">O caminho do arquivo de backup é obrigatório.</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">Insira um ou mais caminhos de arquivo separados por vírgulas</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">Banco de dados</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">Destino</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">Restaurar para</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">Restaurar plano</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">Conjuntos de backup para restaurar</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">Restaurar arquivos de banco de dados como</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">Restaurar os detalhes do arquivo de banco de dados</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">Nome do Arquivo lógico</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">Tipo de arquivo</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">Nome do Arquivo Original</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">Restaurar como</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">Opções de restauração</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">Backup da parte final do log</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">Conexões de servidor</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">Geral</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Arquivos</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Opções</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">Arquivos de Backup</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">Todos os Arquivos</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">Grupos de Servidores</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">Nome do grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">O nome do grupo é obrigatório.</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">Descrição do grupo</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">Cor do grupo</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">Adicionar grupo de servidores</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">Editar grupo de servidores</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">1 ou mais tarefas estão em andamento. Tem certeza de que deseja sair?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Sim</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Não</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="pt-BR">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">Introdução</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">Mostrar Introdução</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">I&amp;&amp;ntrodução</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ru/admin-tool-ext-win.ru.xlf
+++ b/resources/xlf/ru/admin-tool-ext-win.ru.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/ru/agent.ru.xlf
+++ b/resources/xlf/ru/agent.ru.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">Создание расписания</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">ОК</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Отмена</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Имя расписания</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Расписания</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">Создание прокси-сервера</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">Изменить прокси-сервер</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Общее</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">Имя прокси-сервера</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">Имя учетных данных</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Описание</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">Подсистема</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">Операционная система (CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">Репликация: моментальный снимок</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">Репликация: средство чтения журнала транзакций</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">Репликация: распространитель</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">Репликация: слияние</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">Репликация: средство просмотра очередей</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">Запрос служб SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">Команда служб SQL Server Analysis Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">Пакет служб SQL Server Integration Services</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">Активно в следующих подсистемах</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">Расписания заданий</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">Доступные расписания:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">Идентификатор</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Описание</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">Оператор создания</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">Оператор редактирования</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">Общее</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Уведомления</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Включено</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">Имя для адреса электронной почты</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">Имя для адреса электронной почты пейджера</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">понедельник</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">вторник</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">среда</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">четверг</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">пятница  </target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">суббота</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">воскресенье</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">Начало рабочего дня</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">Конец рабочего дня</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">Расписание работы для пейджера</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">Список предупреждений</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">Имя предупреждения</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">Электронная почта</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">Пейджер</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">Общее</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">Расписания заданий</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Шаги</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">ОК</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">Расписания</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Предупреждения</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">Доступные расписания:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">Уведомления</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">Имя задания не может быть пустым.</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">Имя</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Владелец</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">Идентификатор</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Категория</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">Описание</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Включено</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">Список шагов задания</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">Шаг</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Тип</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">При успешном завершении</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">При сбое</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">Новый шаг</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">Изменить шаг</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">Удалить шаг</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">Перейти на шаг выше</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">Перейти на шаг вниз</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">Запустить шаг</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">Действия для выполнения после завершения задачи</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">Адрес электронной почты</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">Страница</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">Запись в журнал событий приложений Windows</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">Автоматически удалить задание</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">Список расписаний</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">Выбор расписания</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">Имя расписания</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">Список предупреждений</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">Новое предупреждение</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">Имя предупреждения</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Включено</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Тип</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">Новое задание</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">Изменение задания</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">Дополнительное уведомление для отправки</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">Задержка между ответами</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">Задержка в минутах</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">Оператор создания</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">Оператор редактирования</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Общее</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Уведомления</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Включено</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">Имя для адреса электронной почты</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">Имя для адреса электронной почты пейджера</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">понедельник</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">вторник</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">среда</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">четверг</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">пятница  </target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">суббота</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">воскресенье</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">Начало рабочего дня</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">Конец рабочего дня</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">Расписание работы для пейджера</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">Список предупреждений</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">Имя предупреждения</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">Электронная почта</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">Пейджер</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">Не удалось обновить прокси-сервер "{0}"</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Общее</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">Прокси-сервер "{0}" обновлен</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Шаги</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">Прокси-сервер "{0}" создан</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">Расписания</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Предупреждения</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">Уведомления</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">Имя задания не может быть пустым.</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Владелец</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Категория</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Описание</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Включено</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">Список шагов задания</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">Шаг</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Тип</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">При успешном завершении</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">При сбое</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">Новый шаг</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">Изменить шаг</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">Удалить шаг</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">Перейти на шаг выше</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">Перейти на шаг вниз</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">Запустить шаг</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">Действия для выполнения после завершения задачи</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">Адрес электронной почты</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">Страница</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">Запись в журнал событий приложений Windows</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">Автоматически удалить задание</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Список расписаний</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Выбор расписания</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Удалить расписание</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">Список предупреждений</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">Новое предупреждение</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">Имя предупреждения</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Включено</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Тип</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">Новое задание</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">Изменение задания</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">Не удалось обновить шаг "{0}"</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">Необходимо указать имя задания</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">Необходимо указать имя шага</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">Не удалось обновить шаг "{0}"</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">Необходимо указать имя задания</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">Необходимо указать имя шага</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">Эта функция находится в разработке. Попробуйте последние сборки для участников программы предварительной оценки, если хотите оценить самые свежие изменения!</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">Шаблон успешно обновлен</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">Сбой обновления шаблона</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">Перед тем, как начать планировать, записную книжку необходимо сохранить. Сохраните и повторите попытку планирования снова.</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">Добавить подключение</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">Выберите подключение</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">Выберите допустимое подключение.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">Эта функция находится в разработке. Попробуйте последние сборки для участников программы предварительной оценки, если хотите оценить самые свежие изменения!</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">Создание прокси-сервера</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">Изменить прокси-сервер</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">Общее</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">Имя прокси-сервера</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">Имя учетных данных</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Описание</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">Подсистема</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">Операционная система (CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">Репликация: моментальный снимок</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">Репликация: средство чтения журнала транзакций</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">Репликация: распространитель</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">Репликация: слияние</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">Репликация: средство просмотра очередей</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">Запрос служб SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">Команда служб SQL Server Analysis Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">Пакет служб SQL Server Integration Services</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">Не удалось обновить прокси-сервер "{0}"</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">Прокси-сервер "{0}" обновлен</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">Прокси-сервер "{0}" создан</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">Новое задание записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">Изменить задание записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">Общее</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">Сведения о записной книжке</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">Путь к записной книжке</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">База данных хранилища</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">База данных выполнения</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Выберите базу данных</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">Сведения о задании</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Владелец</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">Список расписаний</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">Выбор расписания</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">Удалить расписание</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Описание</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">Выберите записную книжку для планирования с компьютера</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">Выберите базу данных для хранения всех метаданных и результатов задания записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">Выберите базу данных, в которой будут выполняться запросы записных книжек</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">При заполнении записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">Когда возникает сбой записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">Когда успешно выполняется операция записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">Записные книжки должны быть предоставлены</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">Необходимо указать путь к шаблону</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">Недопустимый путь к записной книжке</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">Выберите базу данных хранения</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">Выберите базу данных исполнения</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">Работа с похожим названием уже существует</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">Не удалось обновить записную книжку "{0}"</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">Не удалось создать записную книжку "{0}"</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">Записная книжка «{0}» успешно обновлена</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">Записная книжка "{0}" успешно создана</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ru/azurecore.ru.xlf
+++ b/resources/xlf/ru/azurecore.ru.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">Ошибка при получении групп ресурсов для учетной записи {0} ({1}) в подписке {2} ({3}) и клиенте {4}: {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">Ошибка при получении местоположений для учетной записи {0} ({1}) в подписке {2} ({3}) и клиенте {4}: {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">Недопустимый запрос</target>
@@ -379,8 +383,8 @@
         <target state="translated">SQL Server — Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
-        <target state="translated">Гипермасштабирование для PostgreSQL с поддержкой Azure Arc</target>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
+        <target state="translated">Гипермасштабирование для PostgreSQL с поддержкой Azure Arc</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
         <source xml:lang="en">Unable to open link, missing required values</source>
@@ -411,7 +415,7 @@
         <target state="translated">Неизвестная ошибка при проверке подлинности Azure</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">Указанный клиент с идентификатором "{0}" не найден.</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,7 +423,7 @@
         <target state="translated">Произошла ошибка при проверке подлинности, или ваши токены были удалены из системы. Попробуйте добавить учетную запись в Azure Data Studio еще раз.</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">Не удалось получить токен из-за ошибки. Откройте Инструменты разработчика, чтобы просмотреть ошибку</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">Не удалось получить учетные данные для учетной записи {0}. Перейдите в диалоговое окно учетных записей и обновите учетную запись.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">Запросы от этой учетной записи были ограничены. Чтобы повторить попытку, выберите меньшее количество подписок.</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">При загрузке ресурсов Azure произошла ошибка: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Кластер Azure Data Explorer</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ru/big-data-cluster.ru.xlf
+++ b/resources/xlf/ru/big-data-cluster.ru.xlf
@@ -60,6 +60,126 @@
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">Если этот параметр имеет значение TRUE, игнорировать ошибки проверки SSL в отношении конечных точек кластера больших данных SQL Server, таких как HDFS, Spark и Controller</target>
       </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">Кластер больших данных SQL Server</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">Кластер больших данных SQL Server позволяет развертывать масштабируемые кластеры контейнеров SQL Server, Spark и HDFS, работающие на базе Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Версия</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">Целевой объект развертывания</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">Новый кластер Службы Azure Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">Существующий кластер Службы Azure Kubernetes</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">Существующий кластер Kubernetes (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">Существующий кластер Azure Red Hat OpenShift</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">Существующий кластер OpenShift</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">Параметры кластера больших данных SQL Server</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">Имя кластера</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">Имя пользователя контроллера</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">Пароль</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">Подтверждение пароля</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Параметры Azure</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">Идентификатор подписки</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">Использовать мою подписку Azure по умолчанию</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">Имя группы ресурсов</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">Регион</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">Имя кластера AKS</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">Размер виртуальной машины</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">Число виртуальных машин</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">Имя класса хранения</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">Емкость данных (ГБ)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">Емкость для журналов (ГБ)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">Я принимаю {0}, {1} и {2}.</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Заявление о конфиденциальности корпорации Майкрософт</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">Условия лицензии azdata</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">Условия лицензии SQL Server</target>
+      </trans-unit>
     </body>
   </file>
   <file original="extensions/big-data-cluster/dist/bigDataCluster/utils" source-language="en" datatype="plaintext" target-language="ru">

--- a/resources/xlf/ru/cms.ru.xlf
+++ b/resources/xlf/ru/cms.ru.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">Идет загрузка…</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">При загрузке сохраненных серверов произошла непредвиденная ошибка {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">Идет загрузка…</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">Группа центральных серверов управления уже содержит зарегистрированный сервер с именем {0}</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Серверы базы данных SQL Azure не могут использоваться в качестве Центральных серверов управления.</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Серверы SQL Azure не могут использоваться в качестве Центральных серверов управления.</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/ru/dacpac.ru.xlf
+++ b/resources/xlf/ru/dacpac.ru.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="ru">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Dacpac</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">Полный путь к папке, в которой по умолчанию сохраняются файлы DACPAC и BACPAC</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Целевой сервер</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Исходный сервер</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">База данных — источник</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Целевая база данных</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">Расположение файла</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">Выберите файл</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">Итоговые настройки</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Версия</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">Параметр</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Значение</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">Имя базы данных</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Открыть</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">Обновление существующей базы данных</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">Новая база данных</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">{0} из указанных действий развертывания может привести к потере данных. Убедитесь в наличии резервной копии или моментального снимка на случай проблем с развертыванием.</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">Продолжать, несмотря на возможную потерю данных</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">Указанные действия развертывания не приведут к потере данных.</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">Сохранить</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">Расположение файла</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">Версия (используйте формат x.x.x.x, где x — это число)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Открыть</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">Развертывание файла DACPAC приложения уровня данных в экземпляре SQL Server [Развертывание DACPAC]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">Экспорт схемы и данных из базы данных в логический формат файла BACPAC [Экспорт BACPAC]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">Имя базы данных</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">Обновление существующей базы данных</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">Новая база данных</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Целевая база данных</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">Целевой сервер</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">Исходный сервер</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">База данных — источник</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Версия</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">Параметр</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Значение</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">по умолчанию</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">Мастер приложений уровня данных</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">Создать сценарий</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">Вы можете просмотреть состояние создания сценариев в представлении задач после закрытия мастера. После завершения созданный сценарий откроется.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">по умолчанию</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">Операции плана развертывания</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">В этом экземпляре SQL Server уже существует база данных с таким именем.</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">Не определено имя</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">Имя не может заканчиваться точкой</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">Имя файла не может быть пробелом</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">Недопустимые символы файла</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">Это имя файла зарезервировано для использования операционной системой. Выберите другое имя и повторите попытку</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">Имя файла уже используется. Выберите другое имя и повторите попытку</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">Имя не может заканчиваться пробелом</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">Длина имени файла превышает 255 символов</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">Сбой при создании плана развертывания "{0}"</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">Сбой при создании сценария развертывания "{0}"</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">Сбой операции {0} "{1}"</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">Вы можете просмотреть состояние создания сценариев в представлении задач после закрытия мастера. После завершения созданный сценарий откроется.</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ru/import.ru.xlf
+++ b/resources/xlf/ru/import.ru.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="ru">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">Конфигурация импорта неструктурированных файлов</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[Необязательно] Выведите выходные данные отладки в консоль (Вид -&gt; Вывод), а затем выберите подходящий выходной канал в раскрывающемся списке</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">Запущено: {0}</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">Запуск {0}</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">Не удалось запустить {0}: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">Установка {0} в {1}</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">Установка службы {0}</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">Установлено: {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Идет загрузка {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} КБ)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">Скачивание {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">Скачивание {0} завершено</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">Извлечено {0} ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">Оставить отзыв</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">Не удалось запустить компонент службы</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">База данных сервера в</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">База данных, в которой будет создана таблица</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">Недопустимое расположение файла. Попробуйте другой входной файл.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Обзор</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Открыть</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">Расположение файла для импорта</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">Имя новой таблицы</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">Схема таблицы</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">Импорт данных</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Далее</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">Имя столбца</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">Тип данных</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">Первичный ключ</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">Разрешить значения NULL</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">Эта операция проанализировала структуру первых 50 строк входного файла для отображения предварительного просмотра ниже.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">Эта операция не была выполнена. Попробуйте использовать другой входной файл.</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">Сведения об импорте</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ Вы успешно вставили данные в таблицу.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">Эта операция проанализировала структуру первых 50 строк входного файла для отображения предварительного просмотра ниже.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">Эта операция не была выполнена. Попробуйте использовать другой входной файл.</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Обновить</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">Импорт данных</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Далее</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">Имя столбца</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">Тип данных</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">Первичный ключ</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">Разрешить значения NULL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">База данных сервера в</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">База данных, в которой будет создана таблица</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">Обзор</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Открыть</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">Расположение файла для импорта</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">Имя новой таблицы</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">Схема таблицы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">Подключитесь к серверу перед использованием этого мастера.</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">Расширение импорта SQL Server не поддерживает этот тип подключения</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">Импортировать новый файл</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">Оставить отзыв</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">Не удалось запустить компонент службы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">Служба запущена</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">Запуск службы</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">Не удалось запустить службу импорта {0}</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">Установка службы {0} в {1}</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">Установка службы</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Установлен</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">Идет загрузка {0}</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} КБ)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">Скачивание службы</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">Готово!</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ru/notebook.ru.xlf
+++ b/resources/xlf/ru/notebook.ru.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Локальный путь к существующей установке Python, используемой Записными книжками.</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">Не показывать предложение обновить Python.</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">Интервал времени (в минутах), по истечении которого производится завершение работы сервера после закрытия всех записных книжек. (Введите 0, чтобы не завершать работу)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">Переопределите параметры редактора по умолчанию в редакторе Notebook. Параметры включают в себя цвет фона, цвет текущей строки и границу</target>
@@ -49,6 +57,10 @@
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
         <target state="translated">Записные книжки, закрепленные пользователем для текущей рабочей области</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,24 +151,24 @@
         <target state="translated">Книги Jupyter</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">Сохранить книгу</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">Сохранить книгу Jupyter</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="translated">Сделать книгу доверенной</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">Доверенные книги Jupyter</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">Поиск книги</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">Искать книгу Jupyter</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
         <target state="translated">Записные книжки</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="translated">Предоставленные книги</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">Указанные книги Jupyter</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
@@ -174,17 +186,29 @@
         <source xml:lang="en">Close Jupyter Book</source>
         <target state="translated">Закрыть книгу Jupyter</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="translated">Закрыть записную книжку Jupyter</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">Закрыть записную книжку</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">Удалить записную книжку</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">Добавить записную книжку</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">Добавить файл Markdown</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
         <target state="translated">Показать в книгах</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="translated">Создание книги (предварительная версия)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">Создать книгу Jupyter</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
@@ -263,8 +287,8 @@
         <target state="translated">Выбрать папку</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="translated">Выбрать книгу</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">Выберите книгу Jupyter</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
@@ -283,40 +307,40 @@
         <target state="translated">Открыть внешнюю ссылку</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="translated">Книга сейчас является доверенной в рабочей области.</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">Книга Jupyter сейчас является доверенной в рабочей области.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="translated">Книга уже является доверенной в этой рабочей области.</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">Книга Jupyter уже является доверенной в этой рабочей области.</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="translated">Книга больше не является доверенной в этой рабочей области.</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">Книга Jupyter больше не является доверенной в этой рабочей области.</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="translated">Книга уже является недоверенной в этой рабочей области.</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">Книга Jupyter уже является недоверенной в этой рабочей области.</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="translated">Книга {0} сейчас закреплена в рабочей области.</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">Книга Jupyter {0} сейчас закреплена в рабочей области.</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="translated">Книга {0} больше не закреплена в этой рабочей области.</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Книга Jupyter {0} больше не закреплена в этой рабочей области</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="translated">Не удалось найти файл содержания в указанной книге.</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">Не удалось найти файл содержания в указанной книге Jupyter.</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="translated">Книги во вьюлете сейчас не выбраны.</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">В данный момент во viewlet не выбраны книги Jupyter.</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="translated">Выбрать раздел книги</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">Выберите раздел книги Jupyter</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
@@ -339,12 +363,12 @@
         <target state="translated">Отсутствует файл конфигурации</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="translated">Не удалось открыть книгу {0}: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Не удалось открыть книгу Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="translated">Не удалось прочитать книгу {0}: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">Не удалось прочитать книгу Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
@@ -363,8 +387,8 @@
         <target state="translated">Не удалось открыть ссылку {0}: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="translated">Не удалось закрыть книгу {0}: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">Не удалось закрыть книгу Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
@@ -373,12 +397,16 @@
 Имя файла было изменено на {2} для предотвращения потери данных.</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="translated">Ошибка при редактировании книги {0}: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">Ошибка при редактировании книги Jupyter {0}: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="translated">Ошибка при выборе книги или раздела для изменения: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">Ошибка при выборе книги Jupyter или раздела для изменения: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">Не найден раздел {0} в {1}.</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
@@ -393,8 +421,8 @@
         <target state="translated">Расположение</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="translated">Добавить удаленную книгу</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">Добавить удаленную книгу Jupyter</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
@@ -409,8 +437,8 @@
         <target state="translated">Выпуски</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="translated">Книга</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Книга Jupyter</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
@@ -421,8 +449,8 @@
         <target state="translated">Язык</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="translated">По указанной ссылке отсутствуют доступные книги</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">По указанной ссылке отсутствуют доступные книги Jupyter</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
@@ -445,44 +473,44 @@
         <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="translated">Выполняется скачивание удаленной книги</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">Сейчас выполняется скачивание удаленной книги Jupyter</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="translated">Скачивание удаленной книги завершено</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">Скачивание удаленной книги Jupyter завершено</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="translated">Ошибка при скачивании удаленной книги</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">Произошла ошибка во время скачивания удаленной книги Jupyter</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="translated">Ошибка при распаковке удаленной книги</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">Ошибка при распаковке удаленной книги Jupyter</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="translated">Ошибка при создании каталога удаленной книги</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">Ошибка при создании каталога удаленной книги Jupyter</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="translated">Выполняется скачивание удаленной книги</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">Выполняется скачивание удаленной книги Jupyter</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
         <target state="translated">Ресурс не найден</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="translated">Книги не найдены</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">Книги Jupyter не найдены</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
         <target state="translated">Выпуски не найдены</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="translated">Выбранная книга является недопустимой</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">Выбранная книга Jupyter является недопустимой</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
@@ -492,21 +520,21 @@
         <source xml:lang="en">Downloading to {0}</source>
         <target state="translated">Выполняется скачивание в {0}</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="translated">Новая группа</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">Новая книга Jupyter (предварительный просмотр)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="translated">Группы используются для организации записных книжек.</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Для упорядочения записных книжек используется Jupyter Books.</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="translated">Обзор расположений…</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">Подробнее.</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="translated">Выбрать папку содержимого</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">Папка содержимого</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
@@ -524,7 +552,7 @@
         <source xml:lang="en">Save location</source>
         <target state="translated">Расположение сохранения</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
         <target state="translated">Папка содержимого (необязательно)</target>
       </trans-unit>
@@ -533,8 +561,44 @@
         <target state="translated">Путь к папке содержимого не существует</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="translated">Путь к расположению сохранения не существует</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">Путь к расположению сохранения не существует.</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">Ошибка при попытке доступа: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">Новая записная книжка (предварительный просмотр)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">Новый файл Markdown (предварительный просмотр)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">Расширение файла</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">Файл уже существует. Перезаписать его?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Название</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">Имя файла</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">Недопустимый путь к расположению сохранения.</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">Файл {0} уже существует в папке назначения</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">Сейчас выполняется другая установка Python. Дождитесь ее завершения.</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">Сеансы активных записных книжек Python будут завершены, чтобы обновить их. Хотите продолжить?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">{0} Python доступна в Azure Data Studio. Текущая версия Python (3.6.6) не поддерживается в декабре 2021. Вы хотите обновить {0} Python сейчас?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">Будет установлен {0} Python, который заменит 3.6.6 Python. Некоторые пакеты могут быть несовместимы с новой версией или требуют переустановки. Будет создана Записная книжка, которая поможет вам переустановить все пакеты PIP. Вы хотите продолжить обновление сейчас?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">Установка зависимостей Notebook завершилась с ошибкой: {0}</target>
@@ -603,6 +679,18 @@
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
         <target state="translated">Обнаружена ошибка при получении пути пользователя Python: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">Больше не спрашивать</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">Действие {0} не поддерживается для этого обработчика</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">Не удается открыть ссылку {0}, так как поддерживаются только ссылки HTTP и HTTPS</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">Не удается открыть ссылку {0}, так как поддерживаются только ссылки HTTP, HTTPS и ссылки на файлы</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/ru/profiler.ru.xlf
+++ b/resources/xlf/ru/profiler.ru.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/ru/resource-deployment.ru.xlf
+++ b/resources/xlf/ru/resource-deployment.ru.xlf
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">Запустить образ контейнера SQL Server с помощью Docker</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">Кластер больших данных SQL Server</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">Кластер больших данных SQL Server позволяет развертывать масштабируемые кластеры контейнеров SQL Server, Spark и HDFS, работающие на базе Kubernetes</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">Версия</target>
@@ -45,34 +37,6 @@
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
         <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">Целевой объект развертывания</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">Новый кластер Службы Azure Kubernetes</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">Существующий кластер Службы Azure Kubernetes</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">Существующий кластер Kubernetes (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="translated">Существующий кластер Azure Red Hat OpenShift</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="translated">Существующий кластер OpenShift</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">Порт</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">Параметры кластера больших данных SQL Server</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">Имя кластера</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">Имя пользователя контроллера</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">Пароль</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">Подтверждение пароля</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Параметры Azure</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">Идентификатор подписки</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">Использовать мою подписку Azure по умолчанию</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">Имя группы ресурсов</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">Регион</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">Имя кластера AKS</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">Размер виртуальной машины</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">Число виртуальных машин</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">Имя класса хранения</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">Емкость данных (ГБ)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">Емкость для журналов (ГБ)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">SQL Server в Windows</target>
@@ -170,21 +70,9 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">Запустите SQL Server в Windows, выберите версию для начала работы.</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">Я принимаю {0}, {1} и {2}.</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
         <target state="translated">Заявление о конфиденциальности Майкрософт</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">Условия лицензии azdata</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">Условия лицензии SQL Server</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
@@ -485,6 +373,22 @@
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
         <target state="translated">Принять лицензионное соглашение и выбрать</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">Для развертывания этого ресурса требуется расширение "{0}". Хотите ли вы установить его?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Установить</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">Установка расширения "{0}"...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">Неизвестное расширение "{0}"</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
@@ -1096,10 +1000,6 @@
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">Сбой при загрузке расширения: {0}, обнаружена ошибка в определении типа ресурса в package.json, дополнительные сведения см. в консоли отладки.</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">Тип ресурса: {0} не определен</target>
@@ -2222,13 +2122,13 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Deployment pre-requisites</source>
         <target state="translated">Предварительные требования к развертыванию</target>
       </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="translated">Чтобы продолжить, необходимо принять условия лицензионного соглашения (EULA)</target>
-      </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
         <target state="translated">Некоторые инструменты еще не обнаружены. Убедитесь, что они установлены, запущены и могут быть обнаружены</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">Чтобы продолжить, необходимо принять условия лицензионного соглашения (EULA)</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
@@ -2378,6 +2278,10 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Azure Data CLI</source>
         <target state="translated">Azure Data CLI</target>
       </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">Для развертывания этого ресурса необходимо установить расширение Azure Data CLI. Установите его из коллекции расширений и повторите попытку.</target>
+      </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
         <target state="translated">Ошибка при получении сведений о версии. Дополнительные сведения см. в канале вывода "{0}"</target>
@@ -2385,46 +2289,6 @@ Select a different subscription containing at least one server</source>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
         <target state="translated">Ошибка при получении сведений о версии.{0}Получены недопустимые выходные данные, выходные данные команды get version: "{1}" </target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="translated">удаление ранее скачанного файла Azdata.msi, если он существует…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="translated">скачивание Azdata.msi и установка azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="translated">отображение журнала установки…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="translated">получение доступа к репозиторию brew для azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="translated">обновление репозитория brew для установки azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="translated">установка azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="translated">обновление сведений в репозитории…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="translated">получение пакетов, необходимых для установки azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="translated">скачивание и установка ключа подписывания для azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="translated">добавление в репозиторий сведений для azdata…</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ru/schema-compare.ru.xlf
+++ b/resources/xlf/ru/schema-compare.ru.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">ОК</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Исходная база данных</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">Целевой объект</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">Файл</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">Файл приложения уровня данных (DACPAC)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">База данных</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Тип</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">Сервер</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">База данных</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">Сравнение схем</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Выбрана другая исходная схема. Выполнить сравнение для просмотра его результатов?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">Выбрана другая целевая схема. Выполнить сравнение для просмотра его результатов?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">Выбраны другие исходная и целевая схемы. Выполнить сравнение для просмотра его результатов?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">Исходный файл</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">Целевой файл</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">Исходная база данных</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Целевая база данных</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">Исходный сервер</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">Целевой сервер</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">По умолчанию</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Открыть</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">Выберите исходный файл</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">Выберите целевой файл</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">Сброс</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">Включить типы объектов</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">Сравнить сведения</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">Вы действительно хотите обновить целевой объект?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">Нажмите "Сравнить", чтобы обновить сравнение.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">Создать сценарий для развертывания изменений в целевом объекте</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">Нет изменений в сценарии</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">Применить изменения к целевому объекту</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">Нет изменений для применения</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">Обратите внимание, что операции включения и исключения могут занять некоторое время, чтобы вычислить затронутые зависимости</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Удалить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">Изменить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">Добавить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">Сравнение между исходным и целевым объектами</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">Инициализация сравнения. Это может занять некоторое время.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">Чтобы сравнить две схемы, сначала выберите исходную и целевую схему, а затем нажмите кнопку "Сравнить".</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">Различия в схемах не найдены.</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Тип</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">Имя источника</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">Включить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Действие</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">Имя цели</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">Создание сценария включено, когда целевой объект является базой данных</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">Применение включено, когда целевой объект является базой данных</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">Невозможно исключить {0}. Существуют включенные зависимости, например {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">Невозможно включить {0}. Существуют исключенные зависимости, например {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">Невозможно исключить {0}. Существуют включенные зависимости</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">Невозможно включить {0}. Существуют исключенные зависимости</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">Сравнить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Остановить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Создать сценарий</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Параметры</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Применить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">Сменить направление</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">Поменять местами источник и назначение</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">Выбор источника</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">Выберите целевой объект</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">Открыть файл SCMP</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">Загрузить источник, целевой объект и параметры, сохраненные в файле SCMP</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">Сохранить файл SCMP</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">Сохранить источник, целевой объект, параметры и исключенные элементы</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">Сохранить</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">Установить подключение к {0}?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">Выберите подключение</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,8 +663,8 @@
         <target state="translated">Роли базы данных</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
-        <target state="translated">DatabaseTriggers</target>
+        <source xml:lang="en">Database Triggers</source>
+        <target state="translated">Триггеры базы данных</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
         <source xml:lang="en">Defaults</source>
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">Форматы внешних файлов</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">Внешние потоки</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">Задания внешней потоковой передачи</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">Внешние таблицы</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">Файловые группы</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Файлы</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">Подписи</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">Хранимые процедуры</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">Симметричные ключи</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">Указывает, следует ли игнорировать или обновлять различия в порядке столбцов таблицы при публикации в базе данных.</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Исходная база данных</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Целевой объект</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">Файл</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">Файл приложения уровня данных (DACPAC)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">База данных</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Тип</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">Сервер</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">База данных</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">Нет активных подключений</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Сравнение схем</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Выбрана другая исходная схема. Выполнить сравнение для просмотра его результатов?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">Выбрана другая целевая схема. Выполнить сравнение для просмотра его результатов?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">Выбраны другие исходная и целевая схемы. Выполнить сравнение для просмотра его результатов?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Открыть</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">По умолчанию</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">Сравнить сведения</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">Вы действительно хотите обновить целевой объект?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">Нажмите "Сравнить", чтобы обновить сравнение.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">Создать сценарий для развертывания изменений в целевом объекте</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">Нет изменений в сценарии</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">Применить изменения к целевому объекту</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">Нет изменений для применения</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Удалить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">Изменить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">Добавить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">Сравнение схем</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Исходная база данных</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">Целевой объект</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">Инициализация сравнения. Это может занять некоторое время.</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">Чтобы сравнить две схемы, сначала выберите исходную и целевую схему, а затем нажмите кнопку "Сравнить".</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">Различия в схемах не найдены.</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">Сбой при сравнении схем: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Тип</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">Имя источника</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">Включить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Действие</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">Имя цели</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">Создание сценария включено, когда целевой объект является базой данных</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">Применение включено, когда целевой объект является базой данных</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Сравнить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">Сравнить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Остановить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Остановить</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">Сбой при сохранении файла SCMP: "{0}"</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">Сбой при отмене сравнения схем: "{0}"</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Создать сценарий</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">Сбой при создании сценария: "{0}"</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Параметры</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Параметры</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Применить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">Сбой при применении Сравнения схем "{0}"</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">Сменить направление</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">Поменять местами источник и назначение</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">Выбор источника</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">Выберите целевой объект</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">Открыть файл SCMP</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">Загрузить источник, целевой объект и параметры, сохраненные в файле SCMP</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Открыть</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">Сбой при открытии файла SCMP: "{0}"</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">Сохранить файл SCMP</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">Сохранить источник, целевой объект, параметры и исключенные элементы</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">Сохранить</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">Сбой при сохранении файла SCMP: "{0}"</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/ru/sql.ru.xlf
+++ b/resources/xlf/ru/sql.ru.xlf
@@ -1,2251 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">Копирование изображений не поддерживается</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">Начать работу</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">Показать раздел "Приступая к работе"</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">Приступая к р&amp;&amp;аботе</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">QueryHistory</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">Включено ли ведение Журнала запросов. Если этот параметр имеет значение False, выполняемые запросы не будут записываться в истории.</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Вид</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Журнал запросов</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">Журнал запросов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">Подключение: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">Выполняемая команда: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">Открытие нового запроса: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">Не удается выполнить подключение, так как информация о сервере не указана</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">Не удалось открыть URL-адрес из-за ошибки {0}</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">Будет выполнено подключение к серверу {0}</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">Вы действительно хотите выполнить подключение?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">&amp;&amp;Открыть</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">Файл с запросом на подключение</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">Выполняется одна или несколько задач. Вы действительно хотите выйти?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">Предварительные версии функций расширяют возможности Azure Data Studio, предоставляя полный доступ к новым функциям и улучшениям. Дополнительные сведения о предварительных версиях функций см. [здесь]({0}). Вы хотите включить предварительные версии функций?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">Да (рекомендуется)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">Больше не показывать</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">Включить или отключить журнал запросов</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Удалить</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">Очистить весь журнал</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">Открыть запрос</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Выполнить запрос</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">Включить или отключить ведение Журнала запросов</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">Приостановить ведение Журнала запросов</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">Начать ведение Журнала запросов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">Нет запросов для отображения.</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">Журнал запросов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Ошибка</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Предупреждение</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">Информация</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">Игнорировать</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">Сохранение результатов в другом формате отключено для этого поставщика данных.</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">Не удается сериализировать данные, так как ни один поставщик не зарегистрирован</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">Не удалось выполнить сериализацию. Произошла неизвестная ошибка</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">Требуется подключение для взаимодействия с adminservice</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Нет зарегистрированного обработчика</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">Выберите файл</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">Требуется подключение для взаимодействия со службой оценки</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Нет зарегистрированного обработчика</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">Сетка результатов и сообщения</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">Определяет семейство шрифтов.</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">Управляет насыщенностью шрифта.</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">Определяет размер шрифта в пикселях.</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">Управляет интервалом между буквами в пикселях.</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">Определяет высоту строки в пикселах</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">Определяет поле ячейки в пикселах</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">Автоматически устанавливать ширину столбцов на основе начальных результатов. При наличии большого числа столбцов или широких ячеек возможны проблемы с производительностью</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">Максимальная ширина в пикселях для столбцов, размер которых определяется автоматически</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Вид</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">Подключения к базе данных</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">Подключения к источнику данных</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">группы источника данных</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">Конфигурация запуска</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">Задайте значение TRUE, чтобы при запуске Azure Data Studio отображалось представление "Серверы" (по умолчанию); задайте значение FALSE, чтобы при запуске Azure Data Studio отображалось последнее открытое представление</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Отключить</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Обновить</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">Предварительные версии функции</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">Включить невыпущенные предварительные версии функции</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">Показывать диалоговое окно подключения при запуске</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">Уведомление об устаревших API</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">Включить/отключить уведомление об использовании устаревших API</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">Проблемы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">Выполняющихся задач: {0}</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">Вид</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">Задачи</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">&amp;&amp;Задачи</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">Максимальное количество недавно использованных подключений для хранения в списке подключений.</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">Ядро СУБД, используемое по умолчанию. Оно определяет поставщика языка по умолчанию в файлах .sql и используется по умолчанию при создании новых подключений.</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">Попытка проанализировать содержимое буфера обмена, когда открыто диалоговое окно подключения или выполняется вставка.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">Цветовая палитра группы серверов, используемых во вьюлете обозревателя объектов.</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">Автоматически разворачивать группы серверов во вьюлете обозревателя объектов.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(Предварительная версия.) Используйте новое дерево асинхронных серверов для представления серверов и диалогового окна подключения с поддержкой новых функций, таких как фильтрация динамических узлов.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">Идентификатор типа учетной записи</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(Необязательно) Значок, который используется для представления учетной записи в пользовательском интерфейсе. Путь к файлу или конфигурация с возможностью применения тем</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Путь к значку, когда используется светлая тема</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Путь к значку, когда используется темная тема</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">Передает значки поставщику учетной записи.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">Отображать панель редактирования данных SQL при запуске</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Минимальное значение для оси Y</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">Максимальное значение по оси Y</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Метка для оси Y</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">Минимальное значение по оси X</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">Максимальное значение по оси X</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">Метка для оси X</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Средство просмотра ресурсов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">Определяет свойство данных для набора данных диаграммы.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">Для каждого столбца в наборе результатов в строке 0 отображается значение, представляющее собой число, за которым следует название столбца. Например, "1 Healthy", "3 Unhealthy", где "Healthy" — название столбца, а 1 — значение в строке 1 ячейки 1</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">Отображает результаты в виде простой таблицы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">Отображает изображение, например, возвращенное с помощью запроса R, с использованием ggplot2</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">Каков ожидаемый формат изображения: JPEG, PNG или другой формат?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">Используется ли кодировка hex, base64 или другой формат кодировки?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Управление</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Панель мониторинга</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">Веб-представление, которое будет отображаться в этой вкладке.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">Узел управления, который будет отображаться на этой вкладке.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">Список мини-приложений, которые будут отображаться на этой вкладке.</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">Список мини-приложений, которые должны находиться внутри контейнера мини-приложений для расширения.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">Список мини-приложений или веб-представлений, которые будут отображаться в этой вкладке.</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">Ожидается, что мини-приложения или веб-представления размещаются в контейнере мини-приложений для расширения.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">Уникальный идентификатор этого контейнера.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">Контейнер, который будет отображаться в этой вкладке.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">Добавляет один или несколько контейнеров панелей мониторинга, которые пользователи могут добавить на свои панели мониторинга.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">В контейнере панелей мониторинга для расширения не указан идентификатор.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">В контейнере панелей мониторинга для расширения не указан контейнер.</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Для каждого пространства необходимо определить ровно один контейнер панелей мониторинга.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">В контейнере панелей мониторинга для расширения указан неизвестный тип контейнера.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">Уникальный идентификатор для этого раздела навигации. Будет передан расширению для любых запросов.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Необязательно) Значок, который используется для представления раздела навигации в пользовательском интерфейсе. Путь к файлу или к конфигурации с возможностью использования тем</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Путь к значку, когда используется светлая тема</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Путь к значку, когда используется темная тема</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">Название раздела навигации для отображения пользователю.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">Контейнер, который будет отображаться в разделе навигации.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">Список контейнеров панелей мониторинга, отображаемых в этом разделе навигации.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">Название в разделе навигации для расширения не указано.</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">Для расширения не указан контейнер в разделе навигации.</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">Для каждого пространства необходимо определить ровно один контейнер панелей мониторинга.</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION в NAV_SECTION является недопустимым контейнером для расширения.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">Представление на основе модели, которое будет отображаться в этой вкладке.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Резервное копирование</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Восстановить</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Восстановить</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">Открыть на портале Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">отключено</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">Не удается выполнить расширение, так как требуемый поставщик подключения "{0}" не найден</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">Действие отменено пользователем</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">Диалоговое окно брандмауэра отменено</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">Требуется подключение для взаимодействия с JobManagementService</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">Нет зарегистрированного обработчика</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">Произошла ошибка при загрузке браузера файлов.</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">Ошибка обозревателя файлов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">Общий идентификатор поставщика</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">Отображаемое имя поставщика</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">Псевдоним ядра записной книжки для поставщика</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">Путь к значку для типа сервера</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">Параметры подключения</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Уникальный идентификатор этой вкладки. Будет передаваться расширению при выполнении любых запросов.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">Название вкладки, отображаемое для пользователя.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">Описание этой вкладки, которое будет показано пользователю.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Условие, которое должно иметь значение TRUE, чтобы отображался этот элемент</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">Определяет типы соединений, с которыми совместима эта вкладка. Если не задано, используется значение по умолчанию "MSSQL".</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">Контейнер, который будет отображаться в этой вкладке.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">Будет ли эта вкладка отображаться всегда или только при добавлении ее пользователем.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">Следует ли использовать эту вкладку в качестве вкладки "Главная" для типа подключения.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">Уникальный идентификатор группы, к которой принадлежит эта вкладка, значение для домашней группы: "домашняя".</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(Необязательно.) Значок, который используется для представления этой вкладки в пользовательском интерфейсе. Путь к файлу или к конфигурации с возможностью использования тем</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">Путь к значку, когда используется светлая тема</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">Путь к значку, когда используется темная тема</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">Добавляет одну или несколько вкладок для пользователей, которые будут добавлены на их панель мониторинга.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">Название расширения не указано.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">Описание не указано.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">Не выбран контейнер для расширения.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">Для каждого пространства необходимо определить ровно один контейнер панелей мониторинга</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">Уникальный идентификатор этой группы вкладок.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">Название группы вкладок.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">Добавляет одну группу вкладок для пользователей или несколько, которые будут добавлены на их панель мониторинга.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">Не указан идентификатор для группы вкладок.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">Не указано название для группы вкладок.</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">Администрирование</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">Мониторинг</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">Производительность</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">Безопасность</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">Устранение неполадок</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Параметры</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">Вкладка "Базы данных"</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">Базы данных</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">Выполнено</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">Ошибка</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">Ошибка подключения</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">Сбой подключения из-за ошибки Kerberos.</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">Справка по настройке Kerberos доступна на странице {0}</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">Если вы подключались ранее, может потребоваться запустить kinit повторно.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Закрыть</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">Добавление учетной записи…</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">Обновление учетной записи было отменено пользователем</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">Результаты запроса</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Редактор запросов</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Создать запрос</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Редактор запросов</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">Если этот параметр имеет значение true, то при сохранении результата в формате CSV в файл будут включены заголовки столбцов</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">Пользовательский разделитель значений при сохранении в формате CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">Символы, используемые для разделения строк при сохранении результатов в файле CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">Символ, используемый для обрамления текстовых полей при сохранении результатов в файле CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">Кодировка файла, которая используется при сохранении результатов в формате CSV</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">Если этот параметр имеет значение true, выходные данные XML будут отформатированы при сохранении результатов в формате XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">Кодировка файла, которая используется при сохранении результатов в формате XML</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">Включить потоковую передачу результатов; имеется несколько небольших проблем с отображением</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">Параметры конфигурации для копирования результатов из представления результатов</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">Параметры конфигурации для копирования многострочных результатов из представления результатов</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(Экспериментальная функция.) Использование оптимизированной таблицы при выводе результатов. Некоторые функции могут отсутствовать и находиться в разработке.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">Должно ли время выполнения отображаться для отдельных пакетов</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">Включить перенос слов в сообщениях</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">Тип диаграммы по умолчанию, используемый при открытии средства просмотра диаграмм из результатов запроса</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">Цветовое выделение вкладок будет отключено</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">Верхняя граница каждой вкладки редактора будет окрашена в цвет соответствующей группы серверов</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">Цвет фона каждой вкладки редактора будет соответствовать связанной группе серверов</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">Управляет тем, как определяются цвета вкладок на основе группы серверов активного подключения</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">Управляет тем, следует ли отображать сведения о подключении для вкладки в названии.</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">Запрашивать сохранение созданных файлов SQL</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">Установка сочетания клавиш workbench.action.query.shortcut{0} для запуска текста ярлыка при вызове процедуры. В качестве параметра будет передан любой выбранный текст в редакторе запросов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">Задает шаблоны представления</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">Определяет шаблоны сеанса</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">Фильтры профилировщика</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Выполнение сценария в режиме создания</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Выполнение сценария в режиме удаления</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Выберите первые 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Выполнение сценария в режиме выполнения</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Выполнение сценария в режиме изменения</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Редактировать данные</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Выберите первые 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Давайте ненадолго прервемся</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Выполнение сценария в режиме создания</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Выполнение сценария в режиме выполнения</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Выполнение сценария в режиме изменения</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Выполнение сценария в режиме удаления</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Обновить</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">Не удалось зафиксировать строку: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">Начало выполнения запроса </target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">Начато выполнение запроса "{0}"</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">Строка {0}</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">Ошибка при сбое запроса: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">Сбой обновления ячейки: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">При создании диспетчера записных книжек не был передан URI</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">Поставщик записных книжек не существует</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Редактор записной книжки</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Создать записную книжку</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Создать записную книжку</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">Задать рабочую область и открыть</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">Ядро SQL: остановить выполнение записной книжки при возникновении ошибки в ячейке.</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(Предварительная версия.) Отображение всех ядер для текущего поставщика записной книжки.</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">Разрешить выполнение команд Azure Data Studio в записных книжках.</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">Разрешить редактирование текстовых ячеек в записных книжках по двойному щелчку мыши</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">Задать режим просмотра форматированного текста по умолчанию для текстовых ячеек</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(Предварительная версия.) Сохранение имени подключения в метаданных записной книжки.</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">Определяет высоту строки, используемую в области предварительного просмотра Markdown в записной книжке. Это значение задается относительно размера шрифта.</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">Вид</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">Поиск в записных книжках</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">Настройка стандартных масок для исключения файлов и папок при полнотекстовом поиске и быстром открытии. Наследует все стандартные маски от параметра "#files.exclude#". Дополнительные сведения о стандартных масках см. [здесь](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">Стандартная маска, соответствующая путям к файлам. Задайте значение true или false, чтобы включить или отключить маску.</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">Дополнительная проверка элементов того же уровня соответствующего файла. Используйте $(basename) в качестве переменной для соответствующего имени файла.</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">Этот параметр является устаревшим. Сейчас вместо него используется "search.usePCRE2".</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">Этот параметр является устаревшим. Используйте "search.usePCRE2" для расширенной поддержки регулярных выражений.</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">Когда параметр включен, процесс searchService будет поддерживаться в активном состоянии вместо завершения работы после часа бездействия. При этом кэш поиска файлов будет сохранен в памяти.</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Определяет, следует ли использовать GITIGNORE- и IGNORE-файлы по умолчанию при поиске файлов.</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">Определяет, следует ли использовать глобальные файлы ".gitignore" и ".ignore" по умолчанию при поиске файлов.</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">Определяет, следует ли включать результаты поиска глобальных символов в результаты для файлов Quick Open. </target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">Определяет, следует ли включать результаты из недавно открытых файлов в файл результата для Quick Open. </target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">Записи журнала сортируются по релевантности на основе используемого значения фильтра. Более релевантные записи отображаются первыми.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">Записи журнала сортируются по времени открытия. Недавно открытые записи отображаются первыми.</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">Управляет порядком сортировки журнала редактора для быстрого открытия при фильтрации.</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">Определяет, нужно ли следовать символическим ссылкам при поиске.</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">Поиск без учета регистра, если шаблон состоит только из букв нижнего регистра; в противном случае поиск с учетом регистра.</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">Определяет, должно ли представление поиска считывать или изменять общий буфер обмена поиска в macOS.</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">Управляет тем, будет ли панель поиска отображаться в виде представления в боковой колонке или в виде панели в области панели, чтобы освободить пространство по горизонтали.</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">Этот параметр является нерекомендуемым. Используйте вместо него контекстное меню представления поиска.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">Развернуты файлы менее чем с 10 результатами. Остальные свернуты.</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">Определяет, должны ли сворачиваться и разворачиваться результаты поиска.</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">Управляет тем, следует ли открывать окно предварительного просмотра замены при выборе или при замене соответствия.</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">Определяет, следует ли отображать номера строк для результатов поиска.</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">Следует ли использовать модуль обработки регулярных выражений PCRE2 при поиске текста. При использовании этого модуля будут доступны некоторые расширенные возможности регулярных выражений, такие как поиск в прямом направлении и обратные ссылки. Однако поддерживаются не все возможности PCRE2, а только те, которые также поддерживаются JavaScript.</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">Устарело. При использовании функций регулярных выражений, которые поддерживаются только PCRE2, будет автоматически использоваться PCRE2.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">Разместить панель действий справа, когда область поиска узкая, и сразу же после содержимого, когда область поиска широкая.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">Всегда размещать панель действий справа.</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">Управляет положением панели действий в строках в области поиска.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">Поиск во всех файлах при вводе текста.</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">Включение заполнения поискового запроса из ближайшего к курсору слова, когда активный редактор не имеет выделения.</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">Изменить запрос поиска рабочей области на выбранный текст редактора при фокусировке на представлении поиска. Это происходит при щелчке мыши или при активации команды workbench.views.search.focus.</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">Если параметр "#search.searchOnType#" включен, задает время ожидания в миллисекундах между началом ввода символа и началом поиска. Если параметр "search.searchOnType" отключен, не имеет никакого эффекта.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">Двойной щелчок выбирает слово под курсором.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">Двойной щелчок открывает результат в активной группе редакторов.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">Двойной щелчок открывает результат в группе редактора сбоку, создавая его, если он еще не существует.</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">Настройка эффекта двойного щелчка результата в редакторе поиска.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">Результаты сортируются по имена папок и файлов в алфавитном порядке.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">Результаты сортируются по именам файлов, игнорируя порядок папок, в алфавитном порядке.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">Результаты сортируются по расширениям файлов в алфавитном порядке.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">Результаты сортируются по дате последнего изменения файла в порядке убывания.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">Результаты сортируются по количеству на файл в порядке убывания.</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">Результаты сортируются по количеству на файл в порядке возрастания.</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">Определяет порядок сортировки для результатов поиска.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">Создать запрос</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Запуск</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">Объяснить</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">Действительное значение</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Отключить</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Изменить подключение</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Подключиться</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">Включить SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">Отключить SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">Выберите базу данных</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Не удалось изменить базу данных</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">Не удалось изменить базу данных {0}</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">Экспортировать в виде записной книжки</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Закрыть</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">Действие</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">Скопировать сведения</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">Добавить группу серверов</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">Изменить группу серверов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">Расширение</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">Не удалось создать сеанс обозревателя объектов</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">Несколько ошибок:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Ошибка при добавлении учетной записи</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">Ошибка правила брандмауэра</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">Некоторые из загруженных расширений используют устаревшие API. Подробные сведения см. на вкладке "Консоль" окна "Средства для разработчиков"</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Больше не показывать</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">Идентификатор представления. Используйте его для регистрации поставщика данных с помощью API-интерфейса "vscode.window.registerTreeDataProviderForView", а также для активации расширения с помощью регистрации события "onView:${id}" в "activationEvents".</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Понятное имя представления. Будет отображаться на экране</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">Условие, которое должно иметь значение TRUE, чтобы отображалось это представление</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">Добавляет представления в редактор</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">Добавляет представления в контейнер обозревателя данных на панели действий</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">Добавляет представления в контейнер добавленных представлений</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">Не удается зарегистрировать несколько представлений с одинаковым идентификатором "{0}" в контейнере представления "{1}"</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">Представление с идентификатором "{0}" уже зарегистрировано в контейнере представления "{1}"</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">Представления должны быть массивом</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">свойство "{0}" является обязательным и должно иметь тип string</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">свойство "{0}" может быть опущено или должно иметь тип string</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">{0} был заменен на {1} в параметрах пользователя.</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">{0} был заменен на {1} в параметрах рабочей области.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Управление</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Показать подробные сведения</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">Дополнительные сведения</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">Очистить все сохраненные учетные записи</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">Переключить задачи</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">Состояние подключения</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">Отображаемое для пользователя имя поставщика дерева</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">Идентификатор поставщика должен быть таким же, как при регистрации поставщика данных дерева и должен начинаться с connectionDialog/</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">Отображает результаты запроса в виде диаграммы на панели мониторинга</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">Задает сопоставление "имя столбца" -&gt; цвет. Например, добавьте "column1": red, чтобы задать для этого столбца красный цвет</target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">Указывает предпочтительное положение и видимость условных обозначений диаграммы. Это имена столбцов из вашего запроса и карта для сопоставления с каждой записью диаграммы</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">Если значение параметра dataDirection равно horizontal, то при указании значения TRUE для этого параметра для условных обозначений будут использоваться значения в первом столбце.</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">Если значение параметра dataDirection равно vertical, то при указании значения TRUE для этого парамтра для условных обозначений будут использованы имена столбцов.</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">Определяет, считываются ли данные из столбцов (по вертикали) или из строк (по горизонтали). Для временных рядов это игнорируется, так как для них всегда используется направление по вертикали.</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">Если параметр showTopNData установлен, отображаются только первые N данных на диаграмме.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Показать действия</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">Средство просмотра ресурсов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">Идентификатор ресурса.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">Понятное имя представления. Будет отображаться на экране</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">Путь к значку ресурса.</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">Добавляет ресурс в представление ресурсов</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">свойство "{0}" является обязательным и должно иметь тип string</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">свойство "{0}" может быть опущено или должно иметь тип string</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">Дерево средства просмотра ресурсов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">Условие, которое должно иметь значение TRUE, чтобы отображался этот элемент</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">Нужно ли скрывать заголовок мини-приложения, значение по умолчанию — false</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">Название контейнера</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">Строка компонента в сетке</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">Атрибут rowspan компонента сетки. Значение по умолчанию — 1. Используйте значение "*", чтобы задать количество строк в сетке.</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">Столбец компонента в сетке</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">Атрибут colspan компонента сетки. Значение по умолчанию — 1. Используйте значение "*", чтобы задать количество столбцов в сетке.</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">Уникальный идентификатор этой вкладки. Будет передаваться расширению при выполнении любых запросов.</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">Вкладка "Расширение" неизвестна или не установлена.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Включение или отключение мини-приложения свойств</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Значения свойств для отображения</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Отображаемое имя свойства</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">Значение в объекте сведений о базе данных</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">Укажите конкретные значения, которые нужно пропустить</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">Модель восстановления</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">Последнее резервное копирование базы данных</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">Последняя резервная копия журнала</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">Уровень совместимости</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">Владелец</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">Настраивает страницу панели мониторинга базы данных</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Поиск</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">Настраивает вкладки панели мониторинга базы данных</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">Включение или отключение мини-приложения свойств</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">Значения свойств для отображения</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">Отображаемое имя свойства</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">Значение в объекте сведений о сервере</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">Версия</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">Выпуск</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">Имя компьютера</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">Версия ОС</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Поиск</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">Настраивает страницу панели мониторинга сервера</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">Настраивает вкладки панели мониторинга сервера</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">Управление</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">Свойство icon может быть пропущено или должно быть строкой или литералом, например "{dark, light}"</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">Добавляет мини-приложение, которое может опрашивать сервер или базу данных и отображать результаты различными способами — в виде диаграмм, сводных данных и т. д.</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">Уникальный идентификатор, используемый для кэширования результатов анализа.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">SQL-запрос для выполнения. Он должен возвратить ровно один набор данных.</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[Необязательно] путь к файлу, который содержит запрос. Используйте, если параметр "query" не установлен</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[Необязательно] Интервал автоматического обновления в минутах. Если значение не задано, то автоматическое обновление не будет выполняться.</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">Используемые действия</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Целевая база данных для этого действия; чтобы указать имя столбца на основе данных, можно использовать формат "${ columnName }".</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Целевой сервер для этого действия; чтобы указать имя столбца на основе данных, можно использовать формат "${ columnName }".</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">Целевой пользователь для этого действия; чтобы указать имя столбца на основе данных, можно использовать формат "${ columnName }".</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">Идентификатор аналитических данных</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">Добавляет аналитические сведения на палитру панели мониторинга.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Резервное копирование</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">Для использования резервного копирования необходимо включить предварительные версии функции</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">Команда резервного копирования не поддерживается для баз данных SQL Azure.</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">Команда резервного копирования не поддерживается в контексте сервера. Выберите базу данных и повторите попытку.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Восстановить</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">Чтобы использовать восстановление, необходимо включить предварительные версии функции</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">Команда восстановления не поддерживается для баз данных SQL Azure.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Показать рекомендации</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">Установить расширения</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">Создать расширение…</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">Не удалось подключиться к сеансу редактирования данных</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">Открыть расширения панели мониторинга</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">Расширения панели мониторинга не установлены. Чтобы просмотреть рекомендуемые расширения, перейдите в Диспетчер расширений.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">Выбранный путь</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">Файлы типа</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Отменить</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">Профиль подключения не был передан во всплывающий элемент аналитических данных</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">Ошибка аналитических данных</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">Произошла ошибка при чтении файла запроса: </target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">Произошла ошибка при синтаксическом анализе конфигурации аналитических данных; не удалось найти массив/строку запроса или файл запроса</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Учетная запись Azure</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Клиент Azure</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">Показать подключения</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Серверы</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Подключения</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">Журнал задач для отображения отсутствует.</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">Журнал задач</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">Ошибка выполнения задачи</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">Очистить список</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">Список последних подключений очищен</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">Вы действительно хотите удалить все подключения из списка?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Удалить</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">Получить текущую строку подключения</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">Строка подключения недоступна</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">Активные подключения отсутствуют</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Обновить</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">Изменить подключение</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Отключить</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">Новое подключение</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">Новая группа серверов</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">Изменить группу серверов</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">Показать активные подключения</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">Показать все подключения</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Последние подключения</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">Удалить подключение</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">Удалить группу</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">Запуск</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">Не удалось отменить изменения. Ошибка: </target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Остановить</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">Показать панель SQL</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">Закрыть панель SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Профилировщик</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">Нет соединения</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">Сеанс Профилировщика XEvent был неожиданно остановлен на сервере {0}.</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">Ошибка при запуске нового сеанса</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">В сеансе Профилировщика XEvent для {0} были потеряны события.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2257,743 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">Группы серверов</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">Скрыть текстовые подписи</target>
       </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">Имя группы серверов</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">Необходимо указать имя группы.</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">Описание группы</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">Цвет группы</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">Показать текстовые подписи</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">Ошибка при добавлении учетной записи</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">Элемент</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Значение</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">Подробные сведения об аналитике</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">Свойство</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Значение</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">Аналитические данные</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">Элементы</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">Сведения об элементе</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">Не удается запустить автоматическую авторизацию OAuth. Она уже выполняется.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">Сортировка по событиям</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">Сортировка по столбцу</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Профилировщик</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">Очистить все</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">Применить</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">Фильтры</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">Удалить это предложение</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">Сохранить фильтр</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">Загрузить фильтр</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">Добавить предложение</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">Поле</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">Оператор</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Значение</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">Имеет значение NULL</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">Не имеет значение NULL</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">Содержит</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">Не содержит</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">Начинается с</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">Не начинается с</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Сохранить в формате CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Сохранить в формате JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Сохранить в формате Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Сохранить в формате XML</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Копировать</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Копировать с заголовками</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Выбрать все</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">Определяет свойство для отображения на панели мониторинга</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">Какое значение использовать в качестве метки для свойства</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">Значение объекта, используемое для доступа к значению</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">Укажите игнорируемые значения</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">Значение по умолчанию, которое отображается в том случае, если значение игнорируется или не указано.</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">Особые свойства панели мониторинга</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">Идентификатор варианта приложения</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">Условие использования этого варианта приложения</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">Поле для сравнения</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">Какой оператор использовать для сравнения</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">Значение для сравнения поля</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">Свойства для отображения на странице базы данных</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">Отображаемые свойства для страницы сервера</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">Определяет, что этот поставщик поддерживает панель мониторинга</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">Идентификатор поставщика (пример: MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">Значения свойства для отображения на панели мониторинга</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">Недопустимое значение</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}.{1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Загрузка</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Загрузка завершена</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">пустой</target>
-      </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">установить все флажки в столбце {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">Отсутствует зарегистрированное представление в виде дерева с идентификатором "{0}".</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">Не удалось инициализировать сеанс изменения данных: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">Идентификатор поставщика записных книжек.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">Расширения файлов, которые должны быть зарегистрированы для этого поставщика записных книжек</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">Какие ядра следует использовать в качестве стандартных для этого поставщика записных книжек</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">Добавляет поставщиков записных книжек.</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">Название магической команды ячейки, например, "%%sql".</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">Язык ячейки, который будет использоваться, если эта магическая команда ячейки включена в ячейку</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">Необязательная цель выполнения, указанная в этой магической команде, например, Spark vs SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">Необязательный набор ядер, для которых это действительно, например, python3, pyspark, sql</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">Определяет язык записной книжки.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">При нажатии клавиши F5 необходимо выбрать ячейку кода. Выберите ячейку кода для выполнения.</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">Для выполнения очистки результата требуется выбрать ячейку кода. Выберите ячейку кода для выполнения.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">Максимальное число строк:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">Выберите представление</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">Выберите сеанс</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">Выберите сеанс:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">Выберите представление:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Текст</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">Метка</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">Значение</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Подробные сведения</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">Прошедшее время</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">Число строк</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} строк</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">Выполнение запроса…</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">Состояние выполнения</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">Сводка по выбранным элементам</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">Среднее значение: {0}  Количество: {1}  Сумма: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">Выбрать язык SQL</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">Изменить поставщика языка SQL</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">Вариант языка SQL</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">Изменить поставщика ядра SQL</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">Подключение с использованием {0} уже существует. Чтобы изменить его, отключите или смените существующее подключение.</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">Активные текстовые редакторы отсутствуют</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">Выбрать поставщик языка</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">Не удалось отобразить диаграмму Plotly: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Не удается найти отрисовщик {0} для выходных данных. Он содержит следующие типы MIME: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(безопасный)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">Выберите первые 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">Давайте ненадолго прервемся</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">Выполнение сценария в режиме выполнения</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">Выполнение сценария в режиме изменения</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">Редактировать данные</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">Выполнение сценария в режиме создания</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">Выполнение сценария в режиме удаления</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">В качестве параметра этого метода необходимо указать NotebookProvider с действительным providerId</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">В качестве параметра этого метода необходимо указать NotebookProvider с действительным providerId</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">поставщики записных книжек не найдены</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">Диспетчер не найден</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">Notebook Manager для записной книжки {0} не содержит диспетчера серверов. Невозможно выполнить операции над ним</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">Notebook Manager для записной книжки {0} не включает диспетчер содержимого. Невозможно выполнить операции над ним</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">Notebook Manager для записной книжки {0} не содержит диспетчер сеанса. Невозможно выполнить действия над ним</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">Не удалось получить маркер учетной записи Azure для подключения</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">Подключение не принято</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">Вы действительно хотите отменить это подключение?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">Закрыть</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">Загрузка ядер…</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">Изменение ядра…</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">Присоединиться к </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">Ядро </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">Загрузка контекстов…</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">Изменить подключение</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">Выберите подключение</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">Нет ядра</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">Очистить результаты</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">Доверенный</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">Не доверенный</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">Свернуть ячейки</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">Развернуть ячейки</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">Создать записную книжку</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Найти следующую строку</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Найти предыдущую строку</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">План запроса</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Обновить</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">Шаг {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">Необходимо выбрать вариант из списка</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">Поле выбора</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Подключение</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">Идет подключение</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">Тип подключения</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Последние соединения</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Сохраненные подключения</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">Сведения о подключении</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Подключиться</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Последние подключения</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">Недавние подключения отсутствуют</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Сохраненные подключения</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">Сохраненные подключения отсутствуют</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">данные недоступны</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">Дерево обозревателя файлов</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">Выбрать все/отменить выбор</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">С</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">Показать фильтр</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">До</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Выбрать все</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">Создание правила брандмауэра</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Поиск</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">Результатов: {0}</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">Выбрано: {0}</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">Сортировка по возрастанию</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">Сортировка по убыванию</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
+        <target state="translated">ОК</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">Очистка</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">Отмена</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">Ваш клиентский IP-адрес не имеет доступа к серверу. Войдите в учетную запись Azure и создайте правило брандмауэра, чтобы разрешить доступ.</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">Дополнительные сведения о параметрах брандмауэра</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">Правило брандмауэра</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">Добавить мой клиентский IP-адрес</target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">Добавить диапазон IP-адресов моей подсети</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">Параметры фильтра</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">Все файлы</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Загрузка</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">Не удалось найти файл запроса по любому из следующих путей:
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">Ошибка загрузки…</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">Вам необходимо обновить учетные данные для этой учетной записи.</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">Показать или скрыть дополнительную информацию</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">Включение автоматических проверок обновлений. Azure Data Studio будет периодически проверять наличие обновлений в автоматическом режиме.</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">Включите, чтобы скачивать и устанавливать новые версии Azure Data Studio в Windows в фоновом режиме</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">Отображение заметок о выпуске после обновления. Заметки о выпуске будут открыты в новом окне веб-браузера.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">Меню действий инструментов панели мониторинга</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">Меню заголовка ячейки записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">Меню раздела записной книжки</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">Меню панели инструментов записной книжки</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">Меню действий раздела контейнера представления обозревателя данных</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">Контекстное меню элемента обозревателя данных</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">Контекстное меню элемента обозревателя объектов</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">Контекстное меню дерева просмотра диалогового окна подключения</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">Контекстное меню элемента сетки данных</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">Устанавливает политику безопасности для скачивания расширений.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">Ваша политика расширений запрещает устанавливать расширения. Измените политику расширений и повторите попытку.</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">Установка расширения {0} из VSIX завершена. Перезагрузите Azure Data Studio, чтобы включить это расширение.</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">Перезапустите Azure Data Studio, чтобы завершить удаление этого расширения.</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">Перезапустите Azure Data Studio, чтобы включить обновленное расширение.</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">Перезапустите Azure Data Studio, чтобы включить это расширение локально.</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">Перезапустите Azure Data Studio, чтобы включить это расширение.</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">Перезапустите Azure Data Studio, чтобы отключить это расширение.</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">Перезапустите Azure Data Studio, чтобы завершить удаление расширения {0}.</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">Перезапустите Azure Data Studio, чтобы включить это расширение в {0}.</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">Установка расширения {0} завершена. Перезагрузите Azure Data Studio, чтобы включить это расширение.</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">Перезагрузите Azure Data Studio, чтобы завершить переустановку расширения {0}.</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Marketplace</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Необходимо указать тип сценария для рекомендаций по расширениям.</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">Не удалось установить расширение "{0}", так как оно несовместимо с Azure Data Studio "{1}".</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Создать запрос</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Создать &amp;&amp;запрос</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Новая записная книжка</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">Управляет объемом памяти, который доступен Azure Data Studio после перезапуска при попытке открытия больших файлов. Действие этого параметра аналогично указанию параметра "--max-memory=НОВЫЙ_РАЗМЕР" в командной строке.</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">Хотите изменить язык пользовательского интерфейса Azure Data Studio на {0} и выполнить перезапуск?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">Чтобы использовать Azure Data Studio в {0}, необходимо перезапустить Azure Data Studio.</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">Новый файл SQL</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Новая записная книжка</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Установить расширение из пакета VSIX</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">Необходимо выбрать вариант из списка</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">Поле выбора</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">Показать записные книжки</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">Результаты поиска</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">Путь поиска не найден: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Записные книжки</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">Копирование изображений не поддерживается</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">Фокус на текущем запросе</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Выполнить запрос</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">Выполнить текущий запрос</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">Копировать запрос с результатами</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">Запрос и результаты скопированы.</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">Выполнить текущий запрос с фактическим планом</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">Отменить запрос</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">Обновить кэш IntelliSense</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">Переключить результаты запроса</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">Переключить фокус между запросом и результатами</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">Для выполнения ярлыка требуется параметр редактора.</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">Синтаксический анализ запроса</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">Команды выполнены</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">Не удалось выполнить команду: </target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">Подключитесь к серверу</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">Группа серверов с таким именем уже существует.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">Выполнено</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">Ошибка</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">Выполняется</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">Не запущена</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">Отмененный</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">выполняется отмена</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">Не удается отобразить диаграмму с указанными данными.</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">Мини-приложение, используемое на панелях мониторинга</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">Ошибка при открытии ссылки: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">Ошибка при выполнении команды "{0}": {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Не удалось выполнить копирование. Ошибка: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">Показать диаграмму</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">Показать таблицу</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Дважды щелкните, чтобы изменить&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;Добавьте содержимое здесь…&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">Произошла ошибка при обновлении узла "{0}": {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Готово</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">Создать сценарий</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Далее</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">Назад</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">Вкладки не инициализированы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated"> требуется.</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">Введены недопустимые данные. Ожидается числовое значение.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">Путь к файлу резервной копии</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">Целевая база данных</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Восстановить</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Восстановление базы данных</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">База данных</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">Файл резервной копии</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">Восстановление базы данных</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Скрипт</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">Источник</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">Восстановить из</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">Требуется путь к файлу резервной копии.</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">Пожалуйста, введите один или несколько путей файлов, разделенных запятыми</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">База данных</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">Назначение</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">Восстановить в</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">План восстановления</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">Резервные наборы данных для восстановления</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">Восстановить файлы базы данных как</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">Восстановление сведений о файле базы данных</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">Логическое имя файла</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">Тип файла</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">Исходное имя файла</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">Восстановить как</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">Параметры восстановления</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">Резервная копия заключительного фрагмента журнала</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">Подключения к серверу</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">Общие</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">Файлы</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">Параметры</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">Копировать ячейку</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">Готово</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">Копировать и открыть</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">Код пользователя</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">Веб-сайт</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">Индекс {0} является недопустимым.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">Описание сервера (необязательно)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">Дополнительные свойства</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">Отменить</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">Формат nbformat v{0}.{1} не распознан</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">Формат этого файла не соответствует допустимому формату записной книжки</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">Неизвестный тип ячейки {0}</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Тип выходных данных {0} не распознан</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">Данные для {0} должны представлять собой строку или массив строк</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">Тип выходных данных {0} не распознан</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Приветствие</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Пакет администрирования SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">Пакет администрирования SQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">Пакет администрирования для SQL Server — это набор популярных расширений для администрирования баз данных, которые помогут управлять SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">Создавайте и выполняйте скрипты PowerShell с помощью расширенного редактора запросов Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">Виртуализация данных</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">Виртуализируйте данные с помощью SQL Server 2019 и создавайте внешние таблицы с помощью интерактивных мастеров</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">Подключайтесь к базам данных Postgres, отправляйте запросы и управляйте ими с помощью Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">Поддержка {0} уже добавлена.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">После установки дополнительной поддержки для {0} окно будет перезагружено.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">Установка дополнительной поддержки для {0}...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">Не удается найти поддержку для {0} с идентификатором {1}.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Создать подключение</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Создать запрос</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Создать записную книжку</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Развернуть сервер</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">Приветствие</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">Создать</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">Открыть…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">Открыть файл…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">Открыть папку…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">Начать обзор</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">Закрыть панель краткого обзора</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">Вы хотите ознакомиться с кратким обзором Azure Data Studio?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">Добро пожаловать!</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">Открыть папку {0} с путем {1}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">Установить</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">Установить раскладку клавиатуры {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">Установить дополнительную поддержку для {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">Установлено</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">Раскладка клавиатуры {0} уже установлена</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">Поддержка {0} уже установлена</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">OK</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">Подробные сведения</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">Цвет фона страницы приветствия.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">Редактор профилировщика для текста события. Только для чтения.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">Не удалось сохранить результаты.</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">Выберите файл результатов</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (с разделением запятыми)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Книга Excel</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">Простой текст</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">Сохранение файла…</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">Результаты сохранены в {0}</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Открыть файл</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">Скрыть текстовые подписи</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">Показать текстовые подписи</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">редактор кода в представлении модели для модели представления.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">Сведения</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">Предупреждение</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">Ошибка</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">Показать подробные сведения</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Копировать</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Закрыть</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">Назад</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">Скрыть подробные сведения</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">Учетные записи</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">Связанные учетные записи</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Закрыть</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">Связанная учетная запись не существует. Добавьте учетную запись.</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">Добавить учетную запись</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">Облака не включены. Перейдите в раздел "Параметры", откройте раздел "Конфигурация учетной записи Azure" и включите хотя бы одно облако</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">Вы не выбрали поставщик проверки подлинности. Повторите попытку.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">Сбой выполнения из-за непредвиденной ошибки: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">Общее время выполнения: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">Начато выполнение запроса в строке {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">Запущено выполнение пакета {0}</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">Время выполнения пакета: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">Не удалось выполнить копирование. Ошибка: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Запуск</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">Создать подключение</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">Создать запрос</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">Создать записную книжку</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Открыть файл</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">Открыть файл</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">Развернуть</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">Новое развертывание…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">Последние</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">Подробнее…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">Нет последних папок</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Справка</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">Приступая к работе</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Документация</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">Сообщить о проблеме или отправить запрос на добавление новой возможности</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">Репозиторий GitHub</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">Заметки о выпуске</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Отображать страницу приветствия при запуске</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">Настроить</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Расширения</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">Скачайте необходимые расширения, включая пакет администрирования SQL Server и другие.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">Сочетания клавиш</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">Найдите любимые команды и настройте их</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">Цветовая тема</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">Настройте редактор и код удобным образом.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">Дополнительные сведения</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">Найти и выполнить все команды</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">Быстро обращайтесь к командам и выполняйте поиск по командам с помощью палитры команд ({0})</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">Ознакомьтесь с изменениями в последнем выпуске</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">Ежемесячные записи в блоге с обзором новых функций</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">Следите за нашими новостями в Twitter</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">Будьте в курсе того, как сообщество использует Azure Data Studio, и общайтесь с техническими специалистами напрямую.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">Подключиться</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">Отключить</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">Запустить</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">Создание сеанса</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">Приостановить</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">Возобновить</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">Остановить</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">Очистить данные</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">Вы действительно хотите очистить данные?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">Автоматическая прокрутка: вкл</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">Автоматическая прокрутка: выкл</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">Переключить свернутую панель</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">Редактирование столбцов</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">Найти следующую строку</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">Найти предыдущую строку</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">Запустить профилировщик</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">Фильтр…</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">Очистить фильтр</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">Вы действительно хотите очистить фильтры?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">События (отфильтровано): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">События: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">Число событий</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">данные недоступны</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">Результаты</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">Сообщения</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">Не было получено ни одного сценария при вызове метода выбора сценария для объекта </target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">Выбрать</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">Создать</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">Insert</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">Обновить</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Удалить</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">При выполнении сценария в режиме {0} для объекта {1} не было возвращено ни одного сценария.</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">Не удалось создать сценарий</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">При выполнении сценария в режиме {0} не было возвращено ни одного сценария</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">Цвет фона заголовка таблицы</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">Цвет переднего плана заголовка таблицы</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">Цвет фоны списка или таблицы для выбранного элемента и элемента, на котором находится фокус, когда список или таблица активны</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">Цвет контура ячейки.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">Фоновый цвет отключенного поля ввода.</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">Цвет переднего плана отключенного поля ввода.</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">Цвет контура кнопки в фокусе.</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">Цвет переднего плана отключенного флажка.</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">Цвет фона таблицы для Агента SQL.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">Цвет фона ячейки таблицы для Агента SQL.</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">Цвет фона таблицы Агента SQL при наведении.</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">Цвет фона заголовка Агента SQL.</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">Цвет границы ячейки таблицы для Агента SQL.</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">Цвет сообщений об ошибках в результатах.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">Имя резервной копии</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">Модель восстановления</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">Тип резервной копии</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">Файл резервной копии</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">Алгоритм</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">Сертификат или асимметричный ключ</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">Носитель</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">Создать резервную копию в существующем наборе носителей</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">Создать резервную копию на новом наборе носителей</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">Добавить к существующему резервному набору данных</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">Перезаписать все существующие резервные наборы данных</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">Имя нового набора носителей</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">Описание нового набора носителей</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">Рассчитать контрольную сумму перед записью на носитель</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">Проверить резервную копию после завершения</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">Продолжать при ошибке</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">Истечение срока</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">Установить время хранения резервной копии в днях</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">Только архивное копирование</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">Расширенная конфигурация</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">Сжатие</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">Настройка сжатия резервной копии</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">Шифрование</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">Журнал транзакций</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">Усечь журнал транзакций</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">Резервное копирование заключительного фрагмента журнала</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">Надежность</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">Требуется имя носителя</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">Нет доступных сертификатов или ассиметричных ключей.</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">Добавить файл</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">Удалить файлы</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">Некорректные данные. Значение должно быть больше или равно 0.</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Скрипт</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">Резервное копирование</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">Поддерживается только резервное копирование в файл</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">Требуется путь к файлу резервной копии</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">Сохранение результатов в другом формате отключено для этого поставщика данных.</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">Не удается сериализировать данные, так как ни один поставщик не зарегистрирован</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">Не удалось выполнить сериализацию. Произошла неизвестная ошибка</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">Отсутствует зарегистрированный поставщик данных, который может предоставить сведения о просмотрах.</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">Цвет фона заголовка таблицы</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Обновить</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">Цвет переднего плана заголовка таблицы</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Свернуть все</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">Цвет фоны списка или таблицы для выбранного элемента и элемента, на котором находится фокус, когда список или таблица активны</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">Ошибка при выполнении команды {1}: {0}. Это, скорее всего, вызвано расширением, добавляющим {1}.</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">Цвет контура ячейки.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">Фоновый цвет отключенного поля ввода.</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">Цвет переднего плана отключенного поля ввода.</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">Цвет контура кнопки в фокусе.</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">Цвет переднего плана отключенного флажка.</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">Цвет фона таблицы для Агента SQL.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">Цвет фона ячейки таблицы для Агента SQL.</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">Цвет фона таблицы Агента SQL при наведении.</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">Цвет фона заголовка Агента SQL.</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">Цвет границы ячейки таблицы для Агента SQL.</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">Цвет сообщений об ошибках в результатах.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">Выберите активную ячейку и повторите попытку</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">Некоторые из загруженных расширений используют устаревшие API. Подробные сведения см. на вкладке "Консоль" окна "Средства для разработчиков"</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">Выполнить ячейку</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">Отменить выполнение</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">Ошибка при последнем запуске. Щелкните, чтобы запустить повторно</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Больше не показывать</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">Ошибка при отмене задачи.</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">Скрипт</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">Показать или скрыть дополнительную информацию</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Загрузка</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">Домашняя страница</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">В разделе "{0}" имеется недопустимое содержимое. Свяжитесь с владельцем расширения.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">Задания</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Записные книжки</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">Предупреждения</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">Прокси-серверы</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">Операторы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">Свойства сервера</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">Свойства базы данных</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">Выбрать все/отменить выбор</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">Показать фильтр</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">ОК</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">Очистка</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">Последние подключения</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Серверы</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">Серверы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">Файлы резервной копии</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">Все файлы</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">Поиск: введите условие поиска и нажмите клавишу ВВОД, чтобы выполнить поиск, или ESCAPE для отмены</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">Поиск</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">Не удалось изменить базу данных</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">Последнее вхождение</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Включено</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">Задержка между ответами (в секундах)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">Имя категории</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">Адрес электронной почты</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Включено</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">Имя учетной записи</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">Имя учетных данных</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Описание</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Включено</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">Загрузка объектов</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">Загрузка баз данных</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">Загрузка объектов завершена.</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">Загрузка баз данных завершена.</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">Поиск по имени типа (t:, v:, f: или sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">Поиск по базам данных</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">Не удалось загрузить объекты</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">Не удалось загрузить базы данных</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">Загрузка свойств</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">Загрузка свойств завершена</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">Не удалось загрузить свойства панели мониторинга</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">Загрузка {0}</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">Загрузка {0} завершена</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">Автоматическое обновление: выключено</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">Последнее обновление: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">Результаты для отображения отсутствуют</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">Шаги</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">Сохранить в формате CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">Сохранить в формате JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">Сохранить в формате Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">Сохранить в формате XML</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">Кодировка результатов не будет сохранена при экспорте в JSON; не забудьте выполнить сохранение с требуемой кодировкой после создания файла.</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">Сохранение в файл не поддерживается резервным источником данных</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Копировать</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">Копировать с заголовками</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">Выбрать все</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">Развернуть</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">Восстановить</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Диаграмма</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">Визуализатор</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">При нажатии клавиши F5 необходимо выбрать ячейку кода. Выберите ячейку кода для выполнения.</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">Для выполнения очистки результата требуется выбрать ячейку кода. Выберите ячейку кода для выполнения.</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">Идентификатор шага</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Готово</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">Имя шага</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">Сообщение</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">Создать сценарий</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Далее</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">Назад</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">Вкладки не инициализированы</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Найти</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">Отсутствует зарегистрированное представление в виде дерева с идентификатором "{0}".</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Найти</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">В качестве параметра этого метода необходимо указать NotebookProvider с действительным providerId</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Предыдущее соответствие</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">поставщики записных книжек не найдены</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Следующее соответствие</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">Диспетчер не найден</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">Notebook Manager для записной книжки {0} не содержит диспетчера серверов. Невозможно выполнить операции над ним</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">Notebook Manager для записной книжки {0} не включает диспетчер содержимого. Невозможно выполнить операции над ним</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">Notebook Manager для записной книжки {0} не содержит диспетчер сеанса. Невозможно выполнить действия над ним</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">В качестве параметра этого метода необходимо указать NotebookProvider с действительным providerId</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Управление</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Показать подробные сведения</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">Дополнительные сведения</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">Очистить все сохраненные учетные записи</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">Предварительные версии функции</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">Включить невыпущенные предварительные версии функции</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">Показывать диалоговое окно подключения при запуске</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">Уведомление об устаревших API</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">Включить/отключить уведомление об использовании устаревших API</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">Не удалось подключиться к сеансу редактирования данных</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Профилировщик</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">Нет соединения</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">Сеанс Профилировщика XEvent был неожиданно остановлен на сервере {0}.</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">Ошибка при запуске нового сеанса</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">В сеансе Профилировщика XEvent для {0} были потеряны события.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Показать действия</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Средство просмотра ресурсов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">Сведения</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Предупреждение</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Ошибка</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">Показать подробные сведения</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Копировать</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">Закрыть</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">В результате поиска было получено слишком большое число результатов. Будут показаны только первые 999 результатов.</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">Назад</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} из {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Результаты отсутствуют</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">Скрыть подробные сведения</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">Горизонтальная линейчатая диаграмма</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">ОК</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">Линейчатая диаграмма</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">Строка</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">Круговая диаграмма</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">Точечная диаграмма</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">Временной ряд</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Образ</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">Подсчет</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">Таблицы</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">Круговая диаграмма</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">Не удалось получить строки для набора данных, чтобы построить диаграмму.</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">Тип диаграммы "{0}" не поддерживается.</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">Параметры</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated"> требуется.</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">Введены недопустимые данные. Ожидается числовое значение.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">Подключено к</target>
-      </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
-        <target state="translated">Отключено</target>
-      </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">Несохраненные подключения</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">Индекс {0} является недопустимым.</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">Обзор (предварительная версия)</target>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">пустой</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">Для фильтрации списка введите здесь значение</target>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">установить все флажки в столбце {0}</target>
       </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">Фильтрация подключений</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">Применение фильтра</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">Удаление фильтра</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">Фильтр применен</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">Фильтр удален</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Сохраненные подключения</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">Сохраненные подключения</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">Дерево обозревателя подключений</target>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Показать действия</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Это расширение рекомендуется Azure Data Studio.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Загрузка</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Загрузка завершена</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">Больше не показывать</target>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">Недопустимое значение</target>
       </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">В Azure Data Studio есть рекомендации по расширениям.</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">В Azure Data Studio есть рекомендации по расширениям для визуализации данных.
-После установки можно выбрать значок "Визуализатор" для визуализации результатов запроса.</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">Установить все</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">Показать рекомендации</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">Необходимо указать тип сценария для рекомендаций по расширениям.</target>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}.{1}</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">Эта страница функции находится на этапе предварительной версии. Предварительные версии функций представляют собой новые функции, которые в будущем станут постоянной частью продукта. Они стабильны, но требуют дополнительного улучшения специальных возможностей. Мы будем рады вашим отзывам о функциях, пока они находятся в разработке.</target>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">Загрузка</target>
       </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">Предварительная версия</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">Создать подключение</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">Подключение к экземпляру базы данных с помощью диалогового окна подключения.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">Выполнить запрос</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">Взаимодействие с данными через редактор запросов.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">Создать записную книжку</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">Создание записной книжки с помощью собственного редактора записных книжек.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">Развернуть сервер</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">Создание нового экземпляра реляционной службы данных на выбранной вами платформе.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">Ресурсы</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">Журнал</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">Расположение</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">Показать больше</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">Отображать страницу приветствия при запуске</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">Полезные ссылки</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">Приступая к работе</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">Ознакомьтесь с возможностями, предлагаемыми Azure Data Studio, и узнайте, как использовать их с максимальной эффективностью.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">Документация</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">Посетите центр документации, где можно найти примеры, руководства и ссылки на PowerShell, API-интерфейсы и т. д.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Обзор Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Общие сведения о записных книжках в Azure Data Studio | Данные предоставлены</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Расширения</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">Показать все</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">Дополнительные сведения </target>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">Загрузка завершена</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">Дата создания: </target>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">редактор кода в представлении модели для модели представления.</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Ошибка записной книжки: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">Не удалось найти компонент для типа {0}</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">Ошибка задания: </target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">Изменение типов редакторов для несохраненных файлов не поддерживается</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">Закреплено</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Выберите первые 1000</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">Последние запуски</target>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Давайте ненадолго прервемся</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">Предыдущие запуски</target>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Выполнение сценария в режиме выполнения</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Выполнение сценария в режиме изменения</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Редактировать данные</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Выполнение сценария в режиме создания</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Выполнение сценария в режиме удаления</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">Не было получено ни одного сценария при вызове метода выбора сценария для объекта </target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">Выбрать</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">Создать</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">Insert</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Удалить</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">При выполнении сценария в режиме {0} для объекта {1} не было возвращено ни одного сценария.</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">Не удалось создать сценарий</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">При выполнении сценария в режиме {0} не было возвращено ни одного сценария</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
+        <target state="translated">отключено</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
+        <target state="translated">Расширение</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">Цвет фона активной вкладки для вертикальных вкладок</target>
+      </trans-unit>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">Цвет границ панели мониторинга</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">Цвет заголовка мини-приложения панели мониторинга</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">Цвет вложенного текста мини-приложения панели мониторинга</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">Цвет значений свойств, отображаемых в компоненте контейнера свойств</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">Цвет имен свойств, отображаемых в компоненте контейнера свойств</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">Цвет тени переполнения панели инструментов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">Идентификатор типа учетной записи</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(Необязательно) Значок, который используется для представления учетной записи в пользовательском интерфейсе. Путь к файлу или конфигурация с возможностью применения тем</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Путь к значку, когда используется светлая тема</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Путь к значку, когда используется темная тема</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">Передает значки поставщику учетной записи.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">Просмотреть применимые правила</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">Просмотреть применимые правила для {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">Вызвать оценку</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">Вызвать оценку для {0}</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">Экспортировать как скрипт</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">Просмотреть все правила и дополнительные сведения в GitHub</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">Создать отчет в формате HTML</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">Отчет сохранен. Вы хотите открыть его?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">Открыть</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">База данных {0} полностью соответствует рекомендациям. Отлично!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">Диаграмма</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">Операция</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">Объект</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">Оценка стоимости</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">Оценка стоимости поддерева</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">Фактических строк</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">Оценка строк</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">Фактическое число выполнений</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">Приблизительные расходы на ЦП</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">Приблизительные затраты на операции ввода/вывода</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">Параллельный</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">Фактическое число повторных привязок</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">Приблизительное число повторных привязок</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">Фактическое число сбросов на начало</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">Приблизительное число возвратов</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">Секционированный</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">Основные операции</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">Подключения не найдены.</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">Добавить подключение</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">Добавить учетную запись…</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;По умолчанию&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Загрузка…</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">Группа серверов</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;По умолчанию&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">Добавить группу…</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;Не сохранять&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} является обязательным.</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0} будет обрезан.</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">Запомнить пароль</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">Учетная запись</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">Обновите учетные данные учетной записи</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Клиент Azure AD</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">Имя (необязательно)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">Дополнительно…</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">Необходимо выбрать учетную запись</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">База данных</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">Файлы и файловые группы</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">Полное</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">Разностное</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">Журнал транзакций</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">Диск</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL-адрес</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">Использовать параметр сервера по умолчанию</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">Сжимать резервные копии</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">Не сжимать резервные копии</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">Сертификат сервера</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">Асимметричный ключ</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">Вы не открыли папку, содержащую записные книжки или книги. </target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">Открыть записные книжки</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">Результирующий набор включает только подмножество всех соответствий. Чтобы уменьшить число результатов, сузьте условия поиска.</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">Идет поиск… </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">Не найдено результатов в "{0}", исключая "{1}", — </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">Результаты в "{0}" не найдены — </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">Результаты не найдены за исключением "{0}" — </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">Результаты не найдены. Просмотрите параметры для настроенных исключений и проверьте свои GITIGNORE-файлы —</target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">Повторить поиск</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Отменить поиск</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">Выполните поиск во всех файлах</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">Открыть параметры</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">Поиск вернул результатов: {0} в файлах: {1}</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">Переключить свертывание и развертывание</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">Отменить поиск</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">Развернуть все</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">Свернуть все</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">Очистить результаты поиска</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">Подключения</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">Подключайтесь, выполняйте запросы и управляйте подключениями из SQL Server, Azure и других сред.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">Далее</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Записные книжки</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">Начните создавать свои записные книжки или коллекцию записных книжек в едином расположении.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">Расширения</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">Расширьте функциональные возможности Azure Data Studio, установив расширения, разработанные корпорацией Майкрософт (нами) и сторонним сообществом (вами).</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">Параметры</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">Настройте Azure Data Studio на основе своих предпочтений. Вы можете настроить такие параметры, как автосохранение и размер вкладок, изменить сочетания клавиш и выбрать цветовую тему по своему вкусу.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">Страница приветствия</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">На странице приветствия можно просмотреть сведения об основных компонентах, недавно открывавшихся файлах и рекомендуемых расширениях. Дополнительные сведения о том, как начать работу с Azure Data Studio, можно получить из наших видеороликов и документации.</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">Готово</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">Приветственный обзор</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">Скрыть приветственный обзор</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">Дополнительные сведения</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">Справка</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">Удалить строку</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">Отменить изменения в текущей строке</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">Панель сообщений</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">Копировать</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">Копировать все</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">Открыть на портале Azure</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">Загрузка</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">Имя резервной копии</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">Загрузка завершена</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">Модель восстановления</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">Тип резервной копии</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">Файл резервной копии</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">Алгоритм</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">Сертификат или асимметричный ключ</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">Носитель</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">Создать резервную копию в существующем наборе носителей</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">Создать резервную копию на новом наборе носителей</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">Добавить к существующему резервному набору данных</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">Перезаписать все существующие резервные наборы данных</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">Имя нового набора носителей</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">Описание нового набора носителей</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">Рассчитать контрольную сумму перед записью на носитель</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">Проверить резервную копию после завершения</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">Продолжать при ошибке</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">Истечение срока</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">Установить время хранения резервной копии в днях</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">Только архивное копирование</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">Расширенная конфигурация</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">Сжатие</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">Настройка сжатия резервной копии</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">Шифрование</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">Журнал транзакций</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">Усечь журнал транзакций</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">Резервное копирование заключительного фрагмента журнала</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">Надежность</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">Требуется имя носителя</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">Нет доступных сертификатов или ассиметричных ключей.</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">Добавить файл</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">Удалить файлы</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">Некорректные данные. Значение должно быть больше или равно 0.</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Скрипт</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Резервное копирование</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">Поддерживается только резервное копирование в файл</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">Требуется путь к файлу резервной копии</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">Щелкните</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">Добавить код</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">или</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">Добавить текст</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">для добавления ячейки кода или текстовой ячейки</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Резервное копирование</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">Стандартный поток ввода:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">Для использования резервного копирования необходимо включить предварительные версии функции</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">Команда резервного копирования не поддерживается вне контекста базы данных. Выберите базу данных и повторите попытку.</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">Команда резервного копирования не поддерживается для баз данных SQL Azure.</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">Резервное копирование</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">Развернуть содержимое ячеек кода</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">База данных</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">Свернуть содержимое ячеек кода</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">Файлы и файловые группы</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">Полное</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">Разностное</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">Журнал транзакций</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">Диск</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL-адрес</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">Использовать параметр сервера по умолчанию</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">Сжимать резервные копии</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">Не сжимать резервные копии</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">Сертификат сервера</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">Асимметричный ключ</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">XML Showplan</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">Сетка результатов</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Добавить ячейку</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Ячейка кода</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Текстовая ячейка</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">Переместить ячейку вниз</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">Переместить ячейку вверх</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">Удалить</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Добавить ячейку</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Ячейка кода</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Текстовая ячейка</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">Ошибка ядра SQL</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">Для выполнения ячеек записной книжки необходимо выбрать подключение</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">Отображаются первые {0} строк.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Последний запуск</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Следующий запуск</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">Включено</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Статус</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">Категория</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">Готово к запуску</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">Расписание</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Результат последнего запуска</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Предыдущие запуски</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Шаги для этого задания недоступны.</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Ошибка: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">Не удалось найти компонент для типа {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Найти</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">Найти</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">Предыдущее соответствие</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">Следующее соответствие</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Закрыть</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">В результате поиска было получено слишком большое число результатов. Будут показаны только первые 999 результатов.</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} из {1}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">Результаты отсутствуют</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">Схема</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">Тип</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">Выполнить запрос</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">Не удается найти отрисовщик {0} для выходных данных. Он содержит следующие типы MIME: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">безопасный </target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">Не удалось найти компонент для селектора {0}</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">Ошибка при отрисовке компонента: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Загрузка…</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">Загрузка…</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Изменить</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">Выход</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">Обновить</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Показать действия</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">Удалить мини-приложение</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">Щелкните, чтобы открепить</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">Щелкните, чтобы закрепить</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">Открыть установленные компоненты</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">Свернуть мини-приложение</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">Развернуть мини-приложение</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} является неизвестным контейнером.</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">Имя</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">Целевая база данных</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">Последний запуск</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">Следующий запуск</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">Статус</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">Результат последнего запуска</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">Предыдущие запуски</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">Шаги для этого задания недоступны.</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">Ошибка: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Ошибка записной книжки: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">Ошибка загрузки…</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">Показать действия</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">Совпадающие элементы не найдены</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">Список поиска отфильтрован до одного элемента</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">Список поиска отфильтрован до указанного числа элементов: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">Сбой</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">Выполнено</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">Повторить попытку</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">Отменено</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">Выполняется</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">Состояние неизвестно</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">Идет выполнение</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">Ожидание потока</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">Между попытками</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">Бездействие</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">Приостановлено</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[Устаревший]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">Да</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">Нет</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">Не запланировано</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">Никогда не запускать</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">Полужирный</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">Курсив</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">Подчеркнутый</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">Выделить цветом</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Код</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">Ссылка</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">Список</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">Упорядоченный список</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">Изображение</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Переключить предварительный просмотр Markdown — отключено</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">Заголовок</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">Заголовок 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">Заголовок 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">Заголовок 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">Абзац</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">Вставка ссылки</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">Вставка изображения</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">Представление форматированного текста</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">Разделенное представление</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Представление Markdown</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">Создать аналитические сведения</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">Не удается создать аналитические данные, так как активным редактором не является редактор SQL</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">Мое мини-приложение</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">Настройка диаграммы</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">Копировать как изображение</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">Не удалось найти диаграмму для сохранения</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">Сохранить как изображение</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">Диаграмма сохранена по следующему пути: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Диаграмма</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">Горизонтальная линейчатая диаграмма</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">Линейчатая диаграмма</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">Строка</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">Круговая диаграмма</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">Точечная диаграмма</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">Временной ряд</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Образ</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">Подсчет</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">Таблицы</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">Круговая диаграмма</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">Не удалось получить строки для набора данных, чтобы построить диаграмму.</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">Тип диаграммы "{0}" не поддерживается.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Встроенные диаграммы</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">Максимальное количество строк для отображения диаграмм. Предупреждение: увеличение этого параметра может сказаться на производительности.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">Закрыть</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">Группа серверов с таким именем уже существует.</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">Серии {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">Таблица не содержит допустимое изображение</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">Превышено максимальное количество строк для встроенных диаграмм, используются только первые {0} строк. Чтобы настроить это значение, откройте настройки пользователя и выполните поиск: “builtinCharts.maxRowCount”.</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Больше не показывать</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">Подключение: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">Выполняемая команда: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">Открытие нового запроса: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">Не удается выполнить подключение, так как информация о сервере не указана</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">Не удалось открыть URL-адрес из-за ошибки {0}</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">Будет выполнено подключение к серверу {0}</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">Вы действительно хотите выполнить подключение?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">&amp;&amp;Открыть</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">Файл с запросом на подключение</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">{0} был заменен на {1} в параметрах пользователя.</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">{0} был заменен на {1} в параметрах рабочей области.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">Максимальное количество недавно использованных подключений для хранения в списке подключений.</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">Ядро СУБД, используемое по умолчанию. Оно определяет поставщика языка по умолчанию в файлах .sql и используется по умолчанию при создании новых подключений.</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">Попытка проанализировать содержимое буфера обмена, когда открыто диалоговое окно подключения или выполняется вставка.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">Состояние подключения</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">Общий идентификатор поставщика</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">Отображаемое имя поставщика</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">Псевдоним ядра записной книжки для поставщика</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">Путь к значку для типа сервера</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">Параметры подключения</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">Отображаемое для пользователя имя поставщика дерева</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">Идентификатор поставщика должен быть таким же, как при регистрации поставщика данных дерева и должен начинаться с connectionDialog/</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">Уникальный идентификатор этого контейнера.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">Контейнер, который будет отображаться в этой вкладке.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">Добавляет один или несколько контейнеров панелей мониторинга, которые пользователи могут добавить на свои панели мониторинга.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">В контейнере панелей мониторинга для расширения не указан идентификатор.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">В контейнере панелей мониторинга для расширения не указан контейнер.</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Для каждого пространства необходимо определить ровно один контейнер панелей мониторинга.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">В контейнере панелей мониторинга для расширения указан неизвестный тип контейнера.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">Узел управления, который будет отображаться на этой вкладке.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">В разделе "{0}" имеется недопустимое содержимое. Свяжитесь с владельцем расширения.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">Список мини-приложений или веб-представлений, которые будут отображаться в этой вкладке.</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">Ожидается, что мини-приложения или веб-представления размещаются в контейнере мини-приложений для расширения.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">Представление на основе модели, которое будет отображаться в этой вкладке.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">Уникальный идентификатор для этого раздела навигации. Будет передан расширению для любых запросов.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Необязательно) Значок, который используется для представления раздела навигации в пользовательском интерфейсе. Путь к файлу или к конфигурации с возможностью использования тем</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Путь к значку, когда используется светлая тема</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Путь к значку, когда используется темная тема</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">Название раздела навигации для отображения пользователю.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">Контейнер, который будет отображаться в разделе навигации.</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">Список контейнеров панелей мониторинга, отображаемых в этом разделе навигации.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">Название в разделе навигации для расширения не указано.</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">Для расширения не указан контейнер в разделе навигации.</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">Для каждого пространства необходимо определить ровно один контейнер панелей мониторинга.</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION в NAV_SECTION является недопустимым контейнером для расширения.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">Веб-представление, которое будет отображаться в этой вкладке.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">Список мини-приложений, которые будут отображаться на этой вкладке.</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">Список мини-приложений, которые должны находиться внутри контейнера мини-приложений для расширения.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Изменить</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">Выход</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Показать действия</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">Удалить мини-приложение</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">Щелкните, чтобы открепить</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">Щелкните, чтобы закрепить</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">Открыть установленные компоненты</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">Свернуть мини-приложение</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">Развернуть мини-приложение</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} является неизвестным контейнером.</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">Создать аналитические сведения</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Уникальный идентификатор этой вкладки. Будет передаваться расширению при выполнении любых запросов.</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">Не удается создать аналитические данные, так как активным редактором не является редактор SQL</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">Название вкладки, отображаемое для пользователя.</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">Мое мини-приложение</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">Описание этой вкладки, которое будет показано пользователю.</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">Настройка диаграммы</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Условие, которое должно иметь значение TRUE, чтобы отображался этот элемент</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">Копировать как изображение</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">Определяет типы соединений, с которыми совместима эта вкладка. Если не задано, используется значение по умолчанию "MSSQL".</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">Не удалось найти диаграмму для сохранения</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">Контейнер, который будет отображаться в этой вкладке.</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">Сохранить как изображение</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">Будет ли эта вкладка отображаться всегда или только при добавлении ее пользователем.</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">Следует ли использовать эту вкладку в качестве вкладки "Главная" для типа подключения.</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">Диаграмма сохранена по следующему пути: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">Уникальный идентификатор группы, к которой принадлежит эта вкладка, значение для домашней группы: "домашняя".</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(Необязательно.) Значок, который используется для представления этой вкладки в пользовательском интерфейсе. Путь к файлу или к конфигурации с возможностью использования тем</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">Путь к значку, когда используется светлая тема</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">Путь к значку, когда используется темная тема</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">Добавляет одну или несколько вкладок для пользователей, которые будут добавлены на их панель мониторинга.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">Название расширения не указано.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">Описание не указано.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">Не выбран контейнер для расширения.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">Для каждого пространства необходимо определить ровно один контейнер панелей мониторинга</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">Уникальный идентификатор этой группы вкладок.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">Название группы вкладок.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">Добавляет одну группу вкладок для пользователей или несколько, которые будут добавлены на их панель мониторинга.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">Не указан идентификатор для группы вкладок.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">Не указано название для группы вкладок.</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">Администрирование</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">Мониторинг</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">Производительность</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">Безопасность</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">Устранение неполадок</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Параметры</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">Вкладка "Базы данных"</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">Базы данных</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">Добавить код</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Управление</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">Добавить текст</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Панель мониторинга</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">Создать файл</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">Управление</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">Не удалось отобразить содержимое: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">Свойство icon может быть пропущено или должно быть строкой или литералом, например "{dark, light}"</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">Добавить ячейку</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">Определяет свойство для отображения на панели мониторинга</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">Ячейка кода</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">Какое значение использовать в качестве метки для свойства</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">Текстовая ячейка</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">Значение объекта, используемое для доступа к значению</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">Выполнить все</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">Укажите игнорируемые значения</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">Ячейка</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">Значение по умолчанию, которое отображается в том случае, если значение игнорируется или не указано.</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">Код</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">Особые свойства панели мониторинга</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">Текст</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">Идентификатор варианта приложения</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">Выполнить ячейки</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">Условие использования этого варианта приложения</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; Назад</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">Поле для сравнения</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">Далее &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">Какой оператор использовать для сравнения</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">ячейка с URI {0} не найдена в этой модели</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">Значение для сравнения поля</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">Не удалось выполнить ячейки. Дополнительные сведения об ошибке см. в выходных данных текущей выбранной ячейки.</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">Свойства для отображения на странице базы данных</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">Отображаемые свойства для страницы сервера</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">Определяет, что этот поставщик поддерживает панель мониторинга</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">Идентификатор поставщика (пример: MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">Значения свойства для отображения на панели мониторинга</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">Условие, которое должно иметь значение TRUE, чтобы отображался этот элемент</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">Нужно ли скрывать заголовок мини-приложения, значение по умолчанию — false</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">Название контейнера</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">Строка компонента в сетке</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">Атрибут rowspan компонента сетки. Значение по умолчанию — 1. Используйте значение "*", чтобы задать количество строк в сетке.</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">Столбец компонента в сетке</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">Атрибут colspan компонента сетки. Значение по умолчанию — 1. Используйте значение "*", чтобы задать количество столбцов в сетке.</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">Уникальный идентификатор этой вкладки. Будет передаваться расширению при выполнении любых запросов.</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">Вкладка "Расширение" неизвестна или не установлена.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">Свойства базы данных</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Включение или отключение мини-приложения свойств</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Значения свойств для отображения</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Отображаемое имя свойства</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">Значение в объекте сведений о базе данных</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">Укажите конкретные значения, которые нужно пропустить</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">Модель восстановления</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">Последнее резервное копирование базы данных</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">Последняя резервная копия журнала</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">Уровень совместимости</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">Владелец</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">Настраивает страницу панели мониторинга базы данных</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Поиск</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">Настраивает вкладки панели мониторинга базы данных</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">Свойства сервера</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">Включение или отключение мини-приложения свойств</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">Значения свойств для отображения</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">Отображаемое имя свойства</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">Значение в объекте сведений о сервере</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">Версия</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">Выпуск</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">Имя компьютера</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">Версия ОС</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Поиск</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">Настраивает страницу панели мониторинга сервера</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">Настраивает вкладки панели мониторинга сервера</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">Домашняя страница</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Не удалось изменить базу данных</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">Показать действия</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">Совпадающие элементы не найдены</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">Список поиска отфильтрован до одного элемента</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">Список поиска отфильтрован до указанного числа элементов: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">Схема</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">Тип</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">Загрузка объектов</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">Загрузка баз данных</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">Загрузка объектов завершена.</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">Загрузка баз данных завершена.</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">Поиск по имени типа (t:, v:, f: или sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">Поиск по базам данных</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">Не удалось загрузить объекты</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">Не удалось загрузить базы данных</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Выполнить запрос</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">Загрузка {0}</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">Загрузка {0} завершена</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">Автоматическое обновление: выключено</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">Последнее обновление: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">Результаты для отображения отсутствуют</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">Добавляет мини-приложение, которое может опрашивать сервер или базу данных и отображать результаты различными способами — в виде диаграмм, сводных данных и т. д.</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">Уникальный идентификатор, используемый для кэширования результатов анализа.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">SQL-запрос для выполнения. Он должен возвратить ровно один набор данных.</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[Необязательно] путь к файлу, который содержит запрос. Используйте, если параметр "query" не установлен</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[Необязательно] Интервал автоматического обновления в минутах. Если значение не задано, то автоматическое обновление не будет выполняться.</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">Используемые действия</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Целевая база данных для этого действия; чтобы указать имя столбца на основе данных, можно использовать формат "${ columnName }".</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Целевой сервер для этого действия; чтобы указать имя столбца на основе данных, можно использовать формат "${ columnName }".</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">Целевой пользователь для этого действия; чтобы указать имя столбца на основе данных, можно использовать формат "${ columnName }".</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">Идентификатор аналитических данных</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">Добавляет аналитические сведения на палитру панели мониторинга.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">Не удается отобразить диаграмму с указанными данными.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">Отображает результаты запроса в виде диаграммы на панели мониторинга</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">Задает сопоставление "имя столбца" -&gt; цвет. Например, добавьте "column1": red, чтобы задать для этого столбца красный цвет</target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">Указывает предпочтительное положение и видимость условных обозначений диаграммы. Это имена столбцов из вашего запроса и карта для сопоставления с каждой записью диаграммы</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">Если значение параметра dataDirection равно horizontal, то при указании значения TRUE для этого параметра для условных обозначений будут использоваться значения в первом столбце.</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">Если значение параметра dataDirection равно vertical, то при указании значения TRUE для этого парамтра для условных обозначений будут использованы имена столбцов.</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">Определяет, считываются ли данные из столбцов (по вертикали) или из строк (по горизонтали). Для временных рядов это игнорируется, так как для них всегда используется направление по вертикали.</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">Если параметр showTopNData установлен, отображаются только первые N данных на диаграмме.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Минимальное значение для оси Y</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">Максимальное значение по оси Y</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Метка для оси Y</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">Минимальное значение по оси X</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">Максимальное значение по оси X</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">Метка для оси X</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">Определяет свойство данных для набора данных диаграммы.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">Для каждого столбца в наборе результатов в строке 0 отображается значение, представляющее собой число, за которым следует название столбца. Например, "1 Healthy", "3 Unhealthy", где "Healthy" — название столбца, а 1 — значение в строке 1 ячейки 1</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">Отображает изображение, например, возвращенное с помощью запроса R, с использованием ggplot2</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">Каков ожидаемый формат изображения: JPEG, PNG или другой формат?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">Используется ли кодировка hex, base64 или другой формат кодировки?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">Отображает результаты в виде простой таблицы</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">Загрузка свойств</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">Загрузка свойств завершена</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">Не удалось загрузить свойства панели мониторинга</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">Подключения к базе данных</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">Подключения к источнику данных</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">группы источника данных</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">Сохраненные подключения сортируются по датам их добавления.</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">Сохраненные подключения сортируются по отображаемым именам в алфавитном порядке.</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">Управляет порядком сортировки сохраненных подключений и групп подключений.</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">Конфигурация запуска</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">Задайте значение TRUE, чтобы при запуске Azure Data Studio отображалось представление "Серверы" (по умолчанию); задайте значение FALSE, чтобы при запуске Azure Data Studio отображалось последнее открытое представление</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">Идентификатор представления. Используйте его для регистрации поставщика данных с помощью API-интерфейса "vscode.window.registerTreeDataProviderForView", а также для активации расширения с помощью регистрации события "onView:${id}" в "activationEvents".</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Понятное имя представления. Будет отображаться на экране</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">Условие, которое должно иметь значение TRUE, чтобы отображалось это представление</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">Добавляет представления в редактор</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">Добавляет представления в контейнер обозревателя данных на панели действий</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">Добавляет представления в контейнер добавленных представлений</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">Не удается зарегистрировать несколько представлений с одинаковым идентификатором "{0}" в контейнере представления "{1}"</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">Представление с идентификатором "{0}" уже зарегистрировано в контейнере представления "{1}"</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">Представления должны быть массивом</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">свойство "{0}" является обязательным и должно иметь тип string</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">свойство "{0}" может быть опущено или должно иметь тип string</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Серверы</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Подключения</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">Показать подключения</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Отключить</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">Отображать панель редактирования данных SQL при запуске</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Запуск</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">Не удалось отменить изменения. Ошибка: </target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Остановить</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">Показать панель SQL</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">Закрыть панель SQL</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">Максимальное число строк:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">Удалить строку</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">Отменить изменения в текущей строке</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Сохранить в формате CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Сохранить в формате JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Сохранить в формате Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Сохранить в формате XML</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Копировать</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Копировать с заголовками</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Выбрать все</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">Вкладки панели мониторинга ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">Идентификатор</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">Название</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Описание</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">Аналитические данные панели мониторинга ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">Идентификатор</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">Когда</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">Получает информацию о расширении из коллекции</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">Идентификатор расширения</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">Расширение "{0}" не найдено.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Показать рекомендации</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">Установить расширения</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">Создать расширение…</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">Больше не показывать</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">В Azure Data Studio есть рекомендации по расширениям.</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">В Azure Data Studio есть рекомендации по расширениям для визуализации данных.
+После установки можно выбрать значок "Визуализатор" для визуализации результатов запроса.</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">Установить все</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">Показать рекомендации</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">Необходимо указать тип сценария для рекомендаций по расширениям.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Это расширение рекомендуется Azure Data Studio.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">Задания</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Записные книжки</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">Предупреждения</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">Прокси-серверы</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">Операторы</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">Последнее вхождение</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Включено</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">Задержка между ответами (в секундах)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">Имя категории</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">Просмотреть применимые правила</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">Идентификатор шага</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">Просмотреть применимые правила для {0}</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">Имя шага</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">Вызвать оценку</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">Вызвать оценку для {0}</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">Экспортировать как скрипт</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">Просмотреть все правила и дополнительные сведения в GitHub</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">Создать отчет в формате HTML</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">Отчет сохранен. Вы хотите открыть его?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">Открыть</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">Отмена</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">Сообщение</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">Данные</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">Подключение</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">Редактор запросов</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Записная книжка</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">Панель мониторинга</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">Профилировщик</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">Шаги</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">Вкладки панели мониторинга ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">Идентификатор</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">Название</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">Описание</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">Аналитические данные панели мониторинга ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">Идентификатор</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">Имя</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">Когда</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Последний запуск</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Следующий запуск</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Включено</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Статус</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">Категория</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">Готово к запуску</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">Расписание</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Результат последнего запуска</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Предыдущие запуски</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Шаги для этого задания недоступны.</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Ошибка: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">Таблица не содержит допустимое изображение</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">Дата создания: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Ошибка записной книжки: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">Ошибка задания: </target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">Закреплено</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">Последние запуски</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">Предыдущие запуски</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">Еще</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">Изменить</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">Целевая база данных</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Закрыть</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">Последний запуск</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">Преобразовать ячейку</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">Следующий запуск</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">Запустить ячейки выше</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">Статус</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">Запустить ячейки ниже</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">Результат последнего запуска</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">Вставить ячейку кода выше</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">Предыдущие запуски</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">Вставить ячейку кода ниже</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">Шаги для этого задания недоступны.</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">Вставить текст выше</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">Ошибка: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">Вставить текст ниже</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">Свернуть ячейку</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">Развернуть ячейку</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">Преобразовать в ячейку параметра</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">Удалить ячейку параметра</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">Очистить результат</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Ошибка записной книжки: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">Произошла ошибка во время запуска сеанса записной книжки</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">Не удалось запустить сервер по неизвестной причине</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">Адрес электронной почты</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">Ядро {0} не найдено. Будет использоваться ядро по умолчанию.</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Включено</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">Серии {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">Имя учетной записи</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">Закрыть</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">Имя учетных данных</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="ru">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated">Число внедренных параметров
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">Описание</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">Выберите подключение, на котором будут выполняться ячейки для этого ядра</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">Не удалось удалить ячейку.</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">Не удалось изменить ядро. Будет использоваться ядро {0}. Ошибка: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">Не удалось изменить ядро из-за ошибки: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">Не удалось изменить контекст: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">Не удалось запустить сеанс: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">При закрытии записной книжки произошла ошибка сеанса клиента: {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">Не удается найти диспетчер записных книжек для поставщика {0}</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">Включено</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">Еще</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">Изменить</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Закрыть</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">Преобразовать ячейку</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">Запустить ячейки выше</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">Запустить ячейки ниже</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">Вставить ячейку кода выше</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">Вставить ячейку кода ниже</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">Вставить текст выше</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">Вставить текст ниже</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">Свернуть ячейку</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">Развернуть ячейку</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">Преобразовать в ячейку параметра</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">Удалить ячейку параметра</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">Очистить результат</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Добавить ячейку</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Ячейка кода</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Текстовая ячейка</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">Переместить ячейку вниз</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">Переместить ячейку вверх</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Удалить</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Добавить ячейку</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Ячейка кода</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Текстовая ячейка</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">Параметры</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">Выберите активную ячейку и повторите попытку</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">Выполнить ячейку</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">Отменить выполнение</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">Ошибка при последнем запуске. Щелкните, чтобы запустить повторно</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">Развернуть содержимое ячеек кода</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">Свернуть содержимое ячеек кода</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">Полужирный</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">Курсив</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">Подчеркнутый</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">Выделить цветом</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Код</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">Ссылка</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">Список</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">Упорядоченный список</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">Изображение</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Переключить предварительный просмотр Markdown — отключено</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">Заголовок</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">Заголовок 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">Заголовок 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">Заголовок 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">Абзац</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">Вставка ссылки</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">Вставка изображения</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">Представление форматированного текста</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Разделенное представление</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Представление Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Не удается найти отрисовщик {0} для выходных данных. Он содержит следующие типы MIME: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">безопасный </target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">Не удалось найти компонент для селектора {0}</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">Ошибка при отрисовке компонента: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">Щелкните</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">Добавить код</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">или</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">Добавить текст</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">для добавления ячейки кода или текстовой ячейки</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">Добавить ячейку кода</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">Добавить текстовую ячейку</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">Стандартный поток ввода:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Дважды щелкните, чтобы изменить&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;Добавьте содержимое здесь…&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Найти</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Найти</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Предыдущее соответствие</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Следующее соответствие</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Закрыть</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">В результате поиска было получено слишком большое число результатов. Будут показаны только первые 999 результатов.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} из {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Результаты отсутствуют</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">Добавить код</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">Добавить текст</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">Создать файл</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">Не удалось отобразить содержимое: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">Добавить ячейку</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">Ячейка кода</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">Текстовая ячейка</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">Выполнить все</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">Ячейка</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">Код</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Текст</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">Выполнить ячейки</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; Назад</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">Далее &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">ячейка с URI {0} не найдена в этой модели</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Не удалось выполнить ячейки. Дополнительные сведения об ошибке см. в выходных данных текущей выбранной ячейки.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Создать записную книжку</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Создать записную книжку</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">Задать рабочую область и открыть</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">Ядро SQL: остановить выполнение записной книжки при возникновении ошибки в ячейке.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(Предварительная версия.) Отображение всех ядер для текущего поставщика записной книжки.</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">Разрешить выполнение команд Azure Data Studio в записных книжках.</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">Разрешить редактирование текстовых ячеек в записных книжках по двойному щелчку мыши</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">Текст отображается как форматированный текст (другое название — WYSIWYG).</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">Markdown отображается слева, а предварительный просмотр отрисованного текста — справа.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">Текст отображается как Markdown.</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">Режим правки по умолчанию, используемый для текстовых ячеек</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(Предварительная версия.) Сохранение имени подключения в метаданных записной книжки.</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">Определяет высоту строки, используемую в области предварительного просмотра Markdown в записной книжке. Это значение задается относительно размера шрифта.</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(Предварительный просмотр) Показать преобразованный для просмотра блокнот в редакторе несовпадений.</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">Максимальное количество изменений, сохраняемых в журнале отмены для редактора форматированного текста записной книжки.</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">Поиск в записных книжках</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">Настройка стандартных масок для исключения файлов и папок при полнотекстовом поиске и быстром открытии. Наследует все стандартные маски от параметра "#files.exclude#". Дополнительные сведения о стандартных масках см. [здесь](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">Стандартная маска, соответствующая путям к файлам. Задайте значение true или false, чтобы включить или отключить маску.</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">Дополнительная проверка элементов того же уровня соответствующего файла. Используйте $(basename) в качестве переменной для соответствующего имени файла.</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">Этот параметр является устаревшим. Сейчас вместо него используется "search.usePCRE2".</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">Этот параметр является устаревшим. Используйте "search.usePCRE2" для расширенной поддержки регулярных выражений.</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">Когда параметр включен, процесс searchService будет поддерживаться в активном состоянии вместо завершения работы после часа бездействия. При этом кэш поиска файлов будет сохранен в памяти.</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Определяет, следует ли использовать GITIGNORE- и IGNORE-файлы по умолчанию при поиске файлов.</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">Определяет, следует ли использовать глобальные файлы ".gitignore" и ".ignore" по умолчанию при поиске файлов.</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">Определяет, следует ли включать результаты поиска глобальных символов в результаты для файлов Quick Open. </target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">Определяет, следует ли включать результаты из недавно открытых файлов в файл результата для Quick Open. </target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">Записи журнала сортируются по релевантности на основе используемого значения фильтра. Более релевантные записи отображаются первыми.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">Записи журнала сортируются по времени открытия. Недавно открытые записи отображаются первыми.</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">Управляет порядком сортировки журнала редактора для быстрого открытия при фильтрации.</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">Определяет, нужно ли следовать символическим ссылкам при поиске.</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">Поиск без учета регистра, если шаблон состоит только из букв нижнего регистра; в противном случае поиск с учетом регистра.</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">Определяет, должно ли представление поиска считывать или изменять общий буфер обмена поиска в macOS.</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">Управляет тем, будет ли панель поиска отображаться в виде представления в боковой колонке или в виде панели в области панели, чтобы освободить пространство по горизонтали.</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">Этот параметр является нерекомендуемым. Используйте вместо него контекстное меню представления поиска.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">Развернуты файлы менее чем с 10 результатами. Остальные свернуты.</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">Определяет, должны ли сворачиваться и разворачиваться результаты поиска.</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">Управляет тем, следует ли открывать окно предварительного просмотра замены при выборе или при замене соответствия.</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">Определяет, следует ли отображать номера строк для результатов поиска.</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">Следует ли использовать модуль обработки регулярных выражений PCRE2 при поиске текста. При использовании этого модуля будут доступны некоторые расширенные возможности регулярных выражений, такие как поиск в прямом направлении и обратные ссылки. Однако поддерживаются не все возможности PCRE2, а только те, которые также поддерживаются JavaScript.</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">Устарело. При использовании функций регулярных выражений, которые поддерживаются только PCRE2, будет автоматически использоваться PCRE2.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">Разместить панель действий справа, когда область поиска узкая, и сразу же после содержимого, когда область поиска широкая.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">Всегда размещать панель действий справа.</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">Управляет положением панели действий в строках в области поиска.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">Поиск во всех файлах при вводе текста.</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">Включение заполнения поискового запроса из ближайшего к курсору слова, когда активный редактор не имеет выделения.</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">Изменить запрос поиска рабочей области на выбранный текст редактора при фокусировке на представлении поиска. Это происходит при щелчке мыши или при активации команды workbench.views.search.focus.</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">Если параметр "#search.searchOnType#" включен, задает время ожидания в миллисекундах между началом ввода символа и началом поиска. Если параметр "search.searchOnType" отключен, не имеет никакого эффекта.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">Двойной щелчок выбирает слово под курсором.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">Двойной щелчок открывает результат в активной группе редакторов.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">Двойной щелчок открывает результат в группе редактора сбоку, создавая его, если он еще не существует.</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">Настройка эффекта двойного щелчка результата в редакторе поиска.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">Результаты сортируются по имена папок и файлов в алфавитном порядке.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">Результаты сортируются по именам файлов, игнорируя порядок папок, в алфавитном порядке.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">Результаты сортируются по расширениям файлов в алфавитном порядке.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">Результаты сортируются по дате последнего изменения файла в порядке убывания.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">Результаты сортируются по количеству на файл в порядке убывания.</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">Результаты сортируются по количеству на файл в порядке возрастания.</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">Определяет порядок сортировки для результатов поиска.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">Загрузка ядер…</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">Изменение ядра…</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">Присоединиться к </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">Ядро </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">Загрузка контекстов…</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Изменить подключение</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">Выберите подключение</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">Нет ядра</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Эта записная книжка не может работать с параметрами, так как ядро не поддерживается. Используйте поддерживаемые ядра и формат. [Подробнее](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Эта записная книжка не может работать с параметрами до тех пор, пока не будет добавлена ячейка параметров. [Подробнее] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">Эта записная книжка не может работать с параметрами до тех пор, пока в ячейку параметров не будут добавлены параметры. [Подробнее](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">Очистить результаты</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">Доверенный</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">Не доверенный</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">Свернуть ячейки</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">Развернуть ячейки</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">Запустить с параметрами</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">Создать записную книжку</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Найти следующую строку</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Найти предыдущую строку</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">Результаты поиска</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">Путь поиска не найден: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Записные книжки</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">Вы не открыли папку, содержащую записные книжки или книги. </target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">Открыть записные книжки</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">Результирующий набор включает только подмножество всех соответствий. Чтобы уменьшить число результатов, сузьте условия поиска.</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">Идет поиск… </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">Не найдено результатов в "{0}", исключая "{1}", — </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">Результаты в "{0}" не найдены — </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">Результаты не найдены за исключением "{0}" — </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">Результаты не найдены. Просмотрите параметры для настроенных исключений и проверьте свои GITIGNORE-файлы —</target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">Повторить поиск</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">Выполните поиск во всех файлах</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">Открыть параметры</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">Поиск вернул результатов: {0} в файлах: {1}</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">Переключить свертывание и развертывание</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">Отменить поиск</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">Развернуть все</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Свернуть все</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">Очистить результаты поиска</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">Поиск: введите условие поиска и нажмите клавишу ВВОД, чтобы выполнить поиск, или ESCAPE для отмены</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">Поиск</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">ячейка с URI {0} не найдена в этой модели</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">Не удалось выполнить ячейки. Дополнительные сведения об ошибке см. в выходных данных текущей выбранной ячейки.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">Запустите эту ячейку, чтобы просмотреть выходные данные.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">Это пустое представление. Добавьте ячейку в это представление, нажав кнопку "Вставить ячейки".</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Не удалось выполнить копирование. Ошибка: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">Показать диаграмму</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">Показать таблицу</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">Не удается найти отрисовщик {0} для выходных данных. Он содержит следующие типы MIME: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(безопасный)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">Не удалось отобразить диаграмму Plotly: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">Подключения не найдены.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">Добавить подключение</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">Цветовая палитра группы серверов, используемых во вьюлете обозревателя объектов.</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">Автоматически разворачивать группы серверов во вьюлете обозревателя объектов.</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(Предварительная версия.) Используйте новое дерево асинхронных серверов для представления серверов и диалогового окна подключения с поддержкой новых функций, таких как фильтрация динамических узлов.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">Данные</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Подключение</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Редактор запросов</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Записная книжка</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">Панель мониторинга</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Профилировщик</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">Встроенные диаграммы</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">Задает шаблоны представления</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">Определяет шаблоны сеанса</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">Фильтры профилировщика</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Подключиться</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Отключить</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Запустить</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">Создание сеанса</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">Приостановить</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">Возобновить</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">Остановить</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">Очистить данные</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">Вы действительно хотите очистить данные?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">Автоматическая прокрутка: вкл</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">Автоматическая прокрутка: выкл</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">Переключить свернутую панель</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">Редактирование столбцов</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">Найти следующую строку</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">Найти предыдущую строку</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">Запустить профилировщик</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">Фильтр…</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">Очистить фильтр</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">Вы действительно хотите очистить фильтры?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">Выберите представление</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">Выберите сеанс</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">Выберите сеанс:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">Выберите представление:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">Текст</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">Метка</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Значение</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Подробные сведения</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Найти</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">Найти</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">Предыдущее соответствие</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">Следующее соответствие</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Закрыть</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">В результате поиска было получено слишком большое число результатов. Будут показаны только первые 999 результатов.</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} из {1}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">Результаты отсутствуют</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">Редактор профилировщика для текста события. Только для чтения.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">События (отфильтровано): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">События: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">Число событий</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">Сохранить в формате CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">Сохранить в формате JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">Сохранить в формате Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">Сохранить в формате XML</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">Кодировка результатов не будет сохранена при экспорте в JSON; не забудьте выполнить сохранение с требуемой кодировкой после создания файла.</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">Сохранение в файл не поддерживается резервным источником данных</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Копировать</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">Копировать с заголовками</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">Выбрать все</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">Развернуть</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Восстановить</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">Диаграмма</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">Визуализатор</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">Выбрать язык SQL</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">Изменить поставщика языка SQL</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">Вариант языка SQL</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">Изменить поставщика ядра SQL</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">Подключение с использованием {0} уже существует. Чтобы изменить его, отключите или смените существующее подключение.</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">Активные текстовые редакторы отсутствуют</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">Выбрать поставщик языка</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">XML Showplan</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">Сетка результатов</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">Превышено максимальное количество строк для фильтрации или сортировки. Чтобы обновить его, можно перейти к параметрам пользователя и изменить параметр queryEditor.results.inMemoryDataProcessingThreshold</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">Фокус на текущем запросе</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Выполнить запрос</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">Выполнить текущий запрос</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">Копировать запрос с результатами</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">Запрос и результаты скопированы.</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">Выполнить текущий запрос с фактическим планом</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">Отменить запрос</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">Обновить кэш IntelliSense</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">Переключить результаты запроса</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">Переключить фокус между запросом и результатами</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">Для выполнения ярлыка требуется параметр редактора.</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">Синтаксический анализ запроса</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">Команды выполнены</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">Не удалось выполнить команду: </target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">Подключитесь к серверу</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">Панель сообщений</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">Копировать</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">Копировать все</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">Результаты запроса</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Создать запрос</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">Редактор запросов</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">Если этот параметр имеет значение true, то при сохранении результата в формате CSV в файл будут включены заголовки столбцов</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">Пользовательский разделитель значений при сохранении в формате CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">Символы, используемые для разделения строк при сохранении результатов в файле CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">Символ, используемый для обрамления текстовых полей при сохранении результатов в файле CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">Кодировка файла, которая используется при сохранении результатов в формате CSV</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">Если этот параметр имеет значение true, выходные данные XML будут отформатированы при сохранении результатов в формате XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">Кодировка файла, которая используется при сохранении результатов в формате XML</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">Включить потоковую передачу результатов; имеется несколько небольших проблем с отображением</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">Параметры конфигурации для копирования результатов из представления результатов</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">Параметры конфигурации для копирования многострочных результатов из представления результатов</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(Экспериментальная функция.) Использование оптимизированной таблицы при выводе результатов. Некоторые функции могут отсутствовать и находиться в разработке.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">Определяет максимальное количество строк, разрешенных для фильтрации и сортировки в памяти. Если число будет превышено, сортировка и фильтрация будут отключены. Предупреждение. Увеличение этого параметра может сказаться на производительности.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">Следует ли открывать файл в Azure Data Studio после сохранения результата.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">Должно ли время выполнения отображаться для отдельных пакетов</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">Включить перенос слов в сообщениях</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">Тип диаграммы по умолчанию, используемый при открытии средства просмотра диаграмм из результатов запроса</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">Цветовое выделение вкладок будет отключено</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">Верхняя граница каждой вкладки редактора будет окрашена в цвет соответствующей группы серверов</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">Цвет фона каждой вкладки редактора будет соответствовать связанной группе серверов</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">Управляет тем, как определяются цвета вкладок на основе группы серверов активного подключения</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">Управляет тем, следует ли отображать сведения о подключении для вкладки в названии.</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">Запрашивать сохранение созданных файлов SQL</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">Установка сочетания клавиш workbench.action.query.shortcut{0} для запуска текста ярлыка при вызове процедуры или выполнении запроса. В качестве параметра будет передан любой выбранный текст в редакторе запросов в конце запроса, или вы можете сослаться на него с помощью {arg}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">Создать запрос</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">Запуск</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">Объяснить</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">Действительное значение</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Отключить</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">Изменить подключение</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Подключиться</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">Включить SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">Отключить SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">Выберите базу данных</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">Не удалось изменить базу данных</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">Не удалось изменить базу данных: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">Экспортировать в виде записной книжки</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">Результаты</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">Сообщения</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">Прошедшее время</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">Число строк</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} строк</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">Выполнение запроса…</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">Состояние выполнения</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">Сводка по выбранным элементам</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">Среднее значение: {0}  Количество: {1}  Сумма: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">Сетка результатов и сообщения</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">Определяет семейство шрифтов.</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">Управляет насыщенностью шрифта.</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">Определяет размер шрифта в пикселях.</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">Управляет интервалом между буквами в пикселях.</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">Определяет высоту строки в пикселах</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">Определяет поле ячейки в пикселах</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">Автоматически устанавливать ширину столбцов на основе начальных результатов. При наличии большого числа столбцов или широких ячеек возможны проблемы с производительностью</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">Максимальная ширина в пикселях для столбцов, размер которых определяется автоматически</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">Включить или отключить журнал запросов</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Удалить</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Очистить весь журнал</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">Открыть запрос</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">Выполнить запрос</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">Включить или отключить ведение Журнала запросов</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Приостановить ведение Журнала запросов</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Начать ведение Журнала запросов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">Выполнено</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">Ошибка</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">Нет запросов для отображения.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">Журнал запросов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">QueryHistory</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">Включено ли ведение Журнала запросов. Если этот параметр имеет значение False, выполняемые запросы не будут записываться в истории.</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">Очистить весь журнал</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">Приостановить ведение Журнала запросов</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">Начать ведение Журнала запросов</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Вид</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Журнал запросов</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">Журнал запросов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">План запроса</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">Операция</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">Объект</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">Оценка стоимости</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">Оценка стоимости поддерева</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">Фактических строк</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">Оценка строк</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">Фактическое число выполнений</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">Приблизительные расходы на ЦП</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">Приблизительные затраты на операции ввода/вывода</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">Параллельный</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">Фактическое число повторных привязок</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">Приблизительное число повторных привязок</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">Фактическое число сбросов на начало</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">Приблизительное число возвратов</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">Секционированный</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">Основные операции</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">Средство просмотра ресурсов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">Ошибка при открытии ссылки: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">Ошибка при выполнении команды "{0}": {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">Дерево средства просмотра ресурсов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">Идентификатор ресурса.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">Понятное имя представления. Будет отображаться на экране</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">Путь к значку ресурса.</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">Добавляет ресурс в представление ресурсов</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">свойство "{0}" является обязательным и должно иметь тип string</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">свойство "{0}" может быть опущено или должно иметь тип string</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Восстановить</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Восстановить</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">Чтобы использовать восстановление, необходимо включить предварительные версии функции</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">Команда восстановления не поддерживается вне контекста сервера. Выберите сервер или базу данных и повторите попытку.</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">Команда восстановления не поддерживается для баз данных SQL Azure.</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Восстановить</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Выполнение сценария в режиме создания</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Выполнение сценария в режиме удаления</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Выберите первые 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Выполнение сценария в режиме выполнения</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Выполнение сценария в режиме изменения</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">Редактировать данные</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">Выберите первые 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">Давайте ненадолго прервемся</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">Выполнение сценария в режиме создания</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">Выполнение сценария в режиме выполнения</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">Выполнение сценария в режиме изменения</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">Выполнение сценария в режиме удаления</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">Произошла ошибка при обновлении узла "{0}": {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">Выполняющихся задач: {0}</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">Вид</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">Задачи</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">&amp;&amp;Задачи</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">Переключить задачи</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">Выполнено</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">Ошибка</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">Выполняется</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">Не запущена</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">Отмененный</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">выполняется отмена</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">Журнал задач для отображения отсутствует.</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">Журнал задач</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">Ошибка выполнения задачи</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">Не удалось отменить задачу.</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Скрипт</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">Отсутствует зарегистрированный поставщик данных, который может предоставить сведения о просмотрах.</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">Свернуть все</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">Ошибка при выполнении команды {1}: {0}. Это, скорее всего, вызвано расширением, добавляющим {1}.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">ОК</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Закрыть</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">Предварительные версии функций расширяют возможности Azure Data Studio, предоставляя полный доступ к новым функциям и улучшениям. Дополнительные сведения о предварительных версиях функций см. [здесь]({0}). Вы хотите включить предварительные версии функций?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">Да (рекомендуется)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">Больше не показывать</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">Эта страница функции находится на этапе предварительной версии. Предварительные версии функций представляют собой новые функции, которые в будущем станут постоянной частью продукта. Они стабильны, но требуют дополнительного улучшения специальных возможностей. Мы будем рады вашим отзывам о функциях, пока они находятся в разработке.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">Предварительная версия</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">Создать подключение</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">Подключение к экземпляру базы данных с помощью диалогового окна подключения.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">Выполнить запрос</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">Взаимодействие с данными через редактор запросов.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">Создать записную книжку</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">Создание записной книжки с помощью собственного редактора записных книжек.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Развернуть сервер</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">Создание нового экземпляра реляционной службы данных на выбранной вами платформе.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">Ресурсы</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">Журнал</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">Имя</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">Расположение</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">Показать больше</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Отображать страницу приветствия при запуске</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">Полезные ссылки</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">Приступая к работе</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">Ознакомьтесь с возможностями, предлагаемыми Azure Data Studio, и узнайте, как использовать их с максимальной эффективностью.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Документация</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">Посетите центр документации, где можно найти примеры, руководства и ссылки на PowerShell, API-интерфейсы и т. д.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">Видео</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Обзор Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Общие сведения о записных книжках в Azure Data Studio | Данные предоставлены</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Расширения</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">Показать все</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">Дополнительные сведения </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">Подключения</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">Подключайтесь, выполняйте запросы и управляйте подключениями из SQL Server, Azure и других сред.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">Далее</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Записные книжки</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">Начните создавать свои записные книжки или коллекцию записных книжек в едином расположении.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Расширения</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">Расширьте функциональные возможности Azure Data Studio, установив расширения, разработанные корпорацией Майкрософт (нами) и сторонним сообществом (вами).</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">Параметры</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">Настройте Azure Data Studio на основе своих предпочтений. Вы можете настроить такие параметры, как автосохранение и размер вкладок, изменить сочетания клавиш и выбрать цветовую тему по своему вкусу.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">Страница приветствия</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">На странице приветствия можно просмотреть сведения об основных компонентах, недавно открывавшихся файлах и рекомендуемых расширениях. Дополнительные сведения о том, как начать работу с Azure Data Studio, можно получить из наших видеороликов и документации.</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">Готово</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">Приветственный обзор</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">Скрыть приветственный обзор</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">Дополнительные сведения</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Справка</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Приветствие</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Пакет администрирования SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">Пакет администрирования SQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">Пакет администрирования для SQL Server — это набор популярных расширений для администрирования баз данных, которые помогут управлять SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">Агент SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">Приложение SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">Импорт SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">Пакет приложения уровня данных SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">Создавайте и выполняйте скрипты PowerShell с помощью расширенного редактора запросов Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">Виртуализация данных</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">Виртуализируйте данные с помощью SQL Server 2019 и создавайте внешние таблицы с помощью интерактивных мастеров</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">Подключайтесь к базам данных Postgres, отправляйте запросы и управляйте ими с помощью Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">Поддержка {0} уже добавлена.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">После установки дополнительной поддержки для {0} окно будет перезагружено.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">Установка дополнительной поддержки для {0}...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">Не удается найти поддержку для {0} с идентификатором {1}.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Создать подключение</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Создать запрос</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Создать записную книжку</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">Развернуть сервер</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">Приветствие</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">Создать</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">Открыть…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">Открыть файл…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">Открыть папку…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">Начать обзор</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">Закрыть панель краткого обзора</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">Вы хотите ознакомиться с кратким обзором Azure Data Studio?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">Добро пожаловать!</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">Открыть папку {0} с путем {1}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">Установить</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">Установить раскладку клавиатуры {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">Установить дополнительную поддержку для {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">Установлено</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">Раскладка клавиатуры {0} уже установлена</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">Поддержка {0} уже установлена</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">Подробные сведения</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">Цвет фона страницы приветствия.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">Запуск</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">Создать подключение</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">Создать запрос</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">Создать записную книжку</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Открыть файл</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Открыть файл</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">Развернуть</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">Новое развертывание…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Последние</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">Подробнее…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">Нет последних папок</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">Справка</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">Приступая к работе</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">Документация</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">Сообщить о проблеме или отправить запрос на добавление новой возможности</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">Репозиторий GitHub</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">Заметки о выпуске</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">Отображать страницу приветствия при запуске</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">Настроить</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">Расширения</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">Скачайте необходимые расширения, включая пакет администрирования SQL Server и другие.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">Сочетания клавиш</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">Найдите любимые команды и настройте их</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">Цветовая тема</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">Настройте редактор и код удобным образом.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">Дополнительные сведения</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">Найти и выполнить все команды</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">Быстро обращайтесь к командам и выполняйте поиск по командам с помощью палитры команд ({0})</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">Ознакомьтесь с изменениями в последнем выпуске</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">Ежемесячные записи в блоге с обзором новых функций</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">Следите за нашими новостями в Twitter</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">Будьте в курсе того, как сообщество использует Azure Data Studio, и общайтесь с техническими специалистами напрямую.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">Учетные записи</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">Связанные учетные записи</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Закрыть</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">Связанная учетная запись не существует. Добавьте учетную запись.</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">Добавить учетную запись</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">Облака не включены. Перейдите в раздел "Параметры", откройте раздел "Конфигурация учетной записи Azure" и включите хотя бы одно облако</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">Вы не выбрали поставщик проверки подлинности. Повторите попытку.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Ошибка при добавлении учетной записи</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">Вам необходимо обновить учетные данные для этой учетной записи.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Закрыть</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">Добавление учетной записи…</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">Обновление учетной записи было отменено пользователем</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Учетная запись Azure</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Клиент Azure</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">Копировать и открыть</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">Код пользователя</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">Веб-сайт</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">Не удается запустить автоматическую авторизацию OAuth. Она уже выполняется.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">Требуется подключение для взаимодействия с adminservice</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Нет зарегистрированного обработчика</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">Требуется подключение для взаимодействия со службой оценки</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Нет зарегистрированного обработчика</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">Дополнительные свойства</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Отменить</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">Описание сервера (необязательно)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">Очистить список</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">Список последних подключений очищен</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">Вы действительно хотите удалить все подключения из списка?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">Удалить</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">Получить текущую строку подключения</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">Строка подключения недоступна</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">Активные подключения отсутствуют</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">Обзор</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">Для фильтрации списка введите здесь значение</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">Фильтрация подключений</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">Применение фильтра</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">Удаление фильтра</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">Фильтр применен</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">Фильтр удален</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Сохраненные подключения</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">Сохраненные подключения</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">Дерево обозревателя подключений</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">Ошибка подключения</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">Сбой подключения из-за ошибки Kerberos.</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">Справка по настройке Kerberos доступна на странице {0}</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">Если вы подключались ранее, может потребоваться запустить kinit повторно.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">Подключение</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">Идет подключение</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">Тип подключения</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">Недавние</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">Сведения о подключении</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">Подключиться</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Последние подключения</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">Недавние подключения отсутствуют</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">Не удалось получить маркер учетной записи Azure для подключения</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">Подключение не принято</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">Вы действительно хотите отменить это подключение?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">Добавить учетную запись…</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;По умолчанию&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Загрузка…</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">Группа серверов</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;По умолчанию&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">Добавить группу…</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;Не сохранять&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} является обязательным.</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0} будет обрезан.</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">Запомнить пароль</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">Учетная запись</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">Обновите учетные данные учетной записи</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Клиент Azure AD</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">Имя (необязательно)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">Дополнительно…</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">Необходимо выбрать учетную запись</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">Подключено к</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">Отключено</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">Несохраненные подключения</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">Открыть расширения панели мониторинга</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">ОК</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">Расширения панели мониторинга не установлены. Чтобы просмотреть рекомендуемые расширения, перейдите в Диспетчер расширений.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">Шаг {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">Готово</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">Не удалось инициализировать сеанс изменения данных: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">ОК</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">Закрыть</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">Действие</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">Скопировать сведения</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">Ошибка</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">Предупреждение</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">Информация</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">Игнорировать</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">Выбранный путь</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">Файлы типа</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">ОК</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">Отменить</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">Выберите файл</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">Дерево обозревателя файлов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">Произошла ошибка при загрузке браузера файлов.</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">Ошибка обозревателя файлов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">Все файлы</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">Копировать ячейку</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">Профиль подключения не был передан во всплывающий элемент аналитических данных</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">Ошибка аналитических данных</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">Произошла ошибка при чтении файла запроса: </target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">Произошла ошибка при синтаксическом анализе конфигурации аналитических данных; не удалось найти массив/строку запроса или файл запроса</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">Элемент</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Значение</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">Подробные сведения об аналитике</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">Свойство</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Значение</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">Аналитические данные</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">Элементы</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">Сведения об элементе</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">Не удалось найти файл запроса по любому из следующих путей:
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">Сбой</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">Выполнено</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">Повторить попытку</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">Отменено</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">Выполняется</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">Состояние неизвестно</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">Идет выполнение</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">Ожидание потока</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">Между попытками</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">Бездействие</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">Приостановлено</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[Устаревший]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">Не запланировано</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">Никогда не запускать</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">Требуется подключение для взаимодействия с JobManagementService</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">Нет зарегистрированного обработчика</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">Произошла ошибка во время запуска сеанса записной книжки</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">Не удалось запустить сервер по неизвестной причине</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">Ядро {0} не найдено. Будет использоваться ядро по умолчанию.</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="ru">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="ru">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="ru">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">Изменение типов редакторов для несохраненных файлов не поддерживается</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated">Число внедренных параметров
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">Выберите подключение, на котором будут выполняться ячейки для этого ядра</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">Не удалось удалить ячейку.</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">Не удалось изменить ядро. Будет использоваться ядро {0}. Ошибка: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">Не удалось изменить ядро из-за ошибки: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">Не удалось изменить контекст: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">Не удалось запустить сеанс: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">При закрытии записной книжки произошла ошибка сеанса клиента: {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">Не удается найти диспетчер записных книжек для поставщика {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">При создании диспетчера записных книжек не был передан URI</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">Поставщик записных книжек не существует</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">Представление с именем {0} уже существует в этой записной книжке.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">Ошибка ядра SQL</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">Для выполнения ячеек записной книжки необходимо выбрать подключение</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">Отображаются первые {0} строк.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">Форматированный текст</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">Комбинированный режим</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">Формат nbformat v{0}.{1} не распознан</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">Формат этого файла не соответствует допустимому формату записной книжки</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">Неизвестный тип ячейки {0}</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Тип выходных данных {0} не распознан</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">Данные для {0} должны представлять собой строку или массив строк</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">Тип выходных данных {0} не распознан</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">Идентификатор поставщика записных книжек.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">Расширения файлов, которые должны быть зарегистрированы для этого поставщика записных книжек</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">Какие ядра следует использовать в качестве стандартных для этого поставщика записных книжек</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">Добавляет поставщиков записных книжек.</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">Название магической команды ячейки, например, "%%sql".</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">Язык ячейки, который будет использоваться, если эта магическая команда ячейки включена в ячейку</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">Необязательная цель выполнения, указанная в этой магической команде, например, Spark vs SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">Необязательный набор ядер, для которых это действительно, например, python3, pyspark, sql</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">Определяет язык записной книжки.</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Загрузка…</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">Обновить</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">Изменить подключение</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">Отключить</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">Новое подключение</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">Новая группа серверов</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">Изменить группу серверов</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">Показать активные подключения</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">Показать все подключения</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">Удалить подключение</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">Удалить группу</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">Не удалось создать сеанс обозревателя объектов</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">Несколько ошибок:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">Не удается выполнить расширение, так как требуемый поставщик подключения "{0}" не найден</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">Действие отменено пользователем</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">Диалоговое окно брандмауэра отменено</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">Загрузка…</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">Последние подключения</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Серверы</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">Серверы</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">Сортировка по событиям</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">Сортировка по столбцу</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">Профилировщик</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">Очистить все</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">Применить</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">Фильтры</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">Удалить это предложение</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">Сохранить фильтр</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">Загрузить фильтр</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">Добавить предложение</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">Поле</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">Оператор</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">Значение</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">Имеет значение NULL</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">Не имеет значение NULL</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">Содержит</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">Не содержит</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">Начинается с</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">Не начинается с</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">Не удалось зафиксировать строку: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">Начало выполнения запроса </target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">Начато выполнение запроса "{0}"</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">Строка {0}</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">Ошибка при сбое запроса: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">Сбой обновления ячейки: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">Сбой выполнения из-за непредвиденной ошибки: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">Общее время выполнения: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">Начато выполнение запроса в строке {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">Запущено выполнение пакета {0}</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">Время выполнения пакета: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">Не удалось выполнить копирование. Ошибка: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">Не удалось сохранить результаты.</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">Выберите файл результатов</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (с разделением запятыми)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Книга Excel</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">Простой текст</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">Сохранение файла…</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">Результаты сохранены в {0}</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">Открыть файл</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">С</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">До</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">Создание правила брандмауэра</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">Ваш клиентский IP-адрес не имеет доступа к серверу. Войдите в учетную запись Azure и создайте правило брандмауэра, чтобы разрешить доступ.</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">Дополнительные сведения о параметрах брандмауэра</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">Правило брандмауэра</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">Добавить мой клиентский IP-адрес</target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">Добавить диапазон IP-адресов моей подсети</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">Ошибка при добавлении учетной записи</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">Ошибка правила брандмауэра</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">Путь к файлу резервной копии</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">Целевая база данных</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">Восстановить</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Восстановление базы данных</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">База данных</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">Файл резервной копии</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">Восстановление базы данных</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">Скрипт</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">Источник</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">Восстановить из</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">Требуется путь к файлу резервной копии.</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">Пожалуйста, введите один или несколько путей файлов, разделенных запятыми</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">База данных</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">Назначение</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">Восстановить в</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">План восстановления</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">Резервные наборы данных для восстановления</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">Восстановить файлы базы данных как</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">Восстановление сведений о файле базы данных</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">Логическое имя файла</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">Тип файла</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">Исходное имя файла</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">Восстановить как</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">Параметры восстановления</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">Резервная копия заключительного фрагмента журнала</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">Подключения к серверу</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">Общие</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">Файлы</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">Параметры</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">Файлы резервной копии</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">Все файлы</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">Группы серверов</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">OK</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">Отмена</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">Имя группы серверов</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">Необходимо указать имя группы.</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">Описание группы</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">Цвет группы</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">Добавить группу серверов</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">Изменить группу серверов</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">Выполняется одна или несколько задач. Вы действительно хотите выйти?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">Да</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">Нет</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="ru">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">Начать работу</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">Показать раздел "Приступая к работе"</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">Приступая к р&amp;&amp;аботе</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hans/admin-tool-ext-win.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/admin-tool-ext-win.zh-Hans.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/zh-hans/agent.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/agent.zh-Hans.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">新建计划</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">确定</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">计划名称</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">计划</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">创建代理</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">编辑代理</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">常规</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">代理名称</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">凭据名称</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">说明</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">子系统</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">操作系统(CmdExec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">副本快照</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">复制事务日志读取器</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">副本分发服务器</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">副本合并</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">复制队列读取器</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">SQL Server Analysis Services 查询</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">SQL Server Analysis Services 命令</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">SQL Server Integration Services 包</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">对以下子系统有效</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">作业计划</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">可用计划:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">说明</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">创建运算符</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">编辑运算符</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">常规</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">通知</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">已启用</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">电子邮件名称</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">寻呼机电子邮件名称</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">星期一</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">星期二</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">星期三</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">星期四</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">星期五</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">星期六</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">星期日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">工作日开始</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">工作日结束</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">寻呼机待机计划</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">警报列表</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">警报名称</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">电子邮件</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">寻呼机</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">常规</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">作业计划</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">步骤</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">计划</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">警报</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">可用计划:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">通知</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">作业名称不能为空。</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">名称</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">所有者</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">ID</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">类别</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">说明</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">已启用</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">作业步骤列表</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">步骤</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">类型</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">成功时</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">失败时</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">新建步骤</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">编辑步骤</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">删除步骤</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">将步骤向上移动</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">将步骤向下移动</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">启动步骤</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">作业完成时要执行的操作</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">电子邮件</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">页面</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">写入 Windows 应用程序事件日志</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">自动删除作业</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">计划列表</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">选择时间表</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">计划名称</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">警报列表</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">新建警报</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">警报名称</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">已启用</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">类型</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">新建作业</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">编辑作业</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">要发送的其他通知消息</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">响应之间的延迟</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">延迟分钟数</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">创建运算符</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">编辑运算符</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">常规</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">通知</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">已启用</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">电子邮件名称</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">寻呼机电子邮件名称</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">星期一</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">星期二</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">星期三</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">星期四</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">星期五</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">星期六</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">星期日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">工作日开始</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">工作日结束</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">寻呼机待机计划</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">警报列表</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">警报名称</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">电子邮件</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">寻呼机</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">代理更新失败“{0}”</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">常规</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">已成功更新代理“{0}”</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">步骤</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">已成功创建代理“{0}”</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">计划</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">警报</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">通知</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">作业名称不能为空。</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">所有者</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">类别</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">说明</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">已启用</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">作业步骤列表</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">步骤</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">类型</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">成功时</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">失败时</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">新建步骤</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">编辑步骤</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">删除步骤</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">将步骤向上移动</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">将步骤向下移动</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">启动步骤</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">作业完成时要执行的操作</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">电子邮件</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">页面</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">写入 Windows 应用程序事件日志</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">自动删除作业</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">计划列表</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">选择时间表</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">删除计划</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">警报列表</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">新建警报</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">警报名称</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">已启用</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">类型</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">新建作业</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">编辑作业</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">步骤更新失败“{0}”</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">必须提供作业名称</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">必须提供步骤名称</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">步骤更新失败“{0}”</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">必须提供作业名称</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">必须提供步骤名称</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">此功能正在开发中。如果想尝试最新的更新，请查看最新的预览体验计划内部版本。</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">已成功更新模板</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">模板更新失败</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">必须先保存笔记本，然后才能进行计划。请保存，然后重试计划。</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">添加新连接</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">选择连接</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">请选择有效的连接</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">此功能正在开发中。如果想尝试最新的更新，请查看最新的预览体验计划内部版本。</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">创建代理</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">编辑代理</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">常规</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">代理名称</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">凭据名称</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">说明</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">子系统</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">操作系统(CmdExec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">副本快照</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">复制事务日志读取器</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">副本分发服务器</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">副本合并</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">复制队列读取器</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">SQL Server Analysis Services 查询</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">SQL Server Analysis Services 命令</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">SQL Server Integration Services 包</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">代理更新失败“{0}”</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">已成功更新代理“{0}”</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">已成功创建代理“{0}”</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">新建笔记本作业</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">编辑笔记本作业</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">常规</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">笔记本详细信息</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">笔记本路径</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">存储数据库</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">执行数据库</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">选择数据库</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">作业详细信息</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">所有者</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">计划列表</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">选择时间表</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">删除计划</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">说明</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">从电脑中选择要计划的笔记本</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">选择一个数据库以存储所有笔记本作业元数据和结果</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">选择数据库以运行笔记本查询</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">笔记本完成时</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">笔记本失败时</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">笔记本成功时</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">必须提供笔记本名称</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">必须提供模板路径</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">笔记本路径无效</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">选择存储数据库</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">选择执行数据库</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">具有类似名称的作业已存在</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">笔记本更新失败 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">未能创建笔记本 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">已成功更新笔记本 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">已成功创建笔记本 '{0}'</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hans/azurecore.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/azurecore.zh-Hans.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">为帐户 {0} ({1})订阅 {2} ({3})租户 {4} 提取资源组时出错: {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">提取帐户 {0} ({1})订阅 {2} ({3})租户 {4} 的位置时出错: {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">查询无效</target>
@@ -379,8 +383,8 @@
         <target state="translated">SQL Server - Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
-        <target state="translated">已启用 Azure Arc 的 PostgreSQL 超大规模</target>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
+        <target state="translated">启用 Azure Arc 的 PostgreSQL 超大规模</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
         <source xml:lang="en">Unable to open link, missing required values</source>
@@ -411,15 +415,15 @@
         <target state="translated">使用 Azure 身份验证时出现不明错误</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
-        <target state="translated">找不到 ID 为“{0}”的指定租户。</target>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
+        <target state="translated">找不到带有 ID '{0}' 的指定租户。</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
         <source xml:lang="en">Something failed with the authentication, or your tokens have been deleted from the system. Please try adding your account to Azure Data Studio again.</source>
         <target state="translated">身份验证失败，或者你的令牌已从系统中删除。请尝试再次将帐户添加到 Azure Data Studio。</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">令牌检索失败，出现错误。请打开开发人员工具以查看错误</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">未能获取帐户 {0} 的凭据。请转到“帐户”对话框并刷新帐户。</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">已限制来自此帐户的请求。要重试，请选择少量订阅。</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">加载 Azure 资源时出错: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Azure 数据资源管理器群集</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hans/big-data-cluster.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/big-data-cluster.zh-Hans.xlf
@@ -60,6 +60,126 @@
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">如果为 true，则忽略针对 SQL Server 大数据群集终结点(如 HDFS、Spark 和控制器)的 SSL 验证错误</target>
       </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">SQL Server 大数据群集</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">借助 SQL Server 大数据群集，可部署在 Kubernetes 上运行的 SQL Server、Spark 和 HDFS 容器的可扩展群集</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">部署目标</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">新的 Azure Kubernetes 服务群集</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">现有 Azure Kubernetes 服务群集</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">现有 Kubernetes 群集(kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">现有 Azure Red Hat OpenShift 群集</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">现有 OpenShift 群集</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">SQL Server 大数据群集设置</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">群集名称</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">控制器用户名</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">密码</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">确认密码</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Azure 设置</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">订阅 ID</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">使用默认 Azure 订阅</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">资源组名称</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">区域</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">AKS 群集名称</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">VM 大小</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">VM 计数</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">存储类名称</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">数据容量(GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">日志容量(GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">我接受 {0}、{1} 和 {2}。</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Microsoft 隐私声明</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">azdata 许可条款</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">SQL Server 许可条款</target>
+      </trans-unit>
     </body>
   </file>
   <file original="extensions/big-data-cluster/dist/bigDataCluster/utils" source-language="en" datatype="plaintext" target-language="zh-Hans">

--- a/resources/xlf/zh-hans/cms.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/cms.zh-Hans.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">正在加载…</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">加载已保存的服务器时出现意外错误 {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">正在加载…</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">中央管理服务器组已具有名称为 {0} 的注册服务器</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">无法将 Azure SQL 数据库服务器用作中央管理服务器</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">无法将 Azure SQL Server 用作中央管理服务器</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/zh-hans/dacpac.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/dacpac.zh-Hans.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">数据层应用程序包</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">文件夹的完整路径，其中已默认保存 .DACPAC 和 .BACPAC 文件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">目标服务器</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">源服务器</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">源数据库</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">目标数据库</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">文件位置</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">选择文件</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">设置摘要</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">设置</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">数据库名称</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">打开</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">升级现有数据库</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">新建数据库</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">列出的部署操作中有 {0} 个可能导致数据丢失。请确保在部署出现问题时有备份或快照可用。</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">尽管可能会丢失数据，仍要继续</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">列出的部署操作不会导致数据丢失。</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">保存</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">文件位置</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">版本(采用 x.x.x.x 格式，x 表示数字)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">打开</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">将数据层应用程序 .dacpac 文件部署到 SQL Server 的实例 [部署 Dacpac]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">将架构和数据从数据库导出到逻辑 .bacpac 文件格式 [导出 Bacpac]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">数据库名称</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">升级现有数据库</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">新建数据库</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">目标数据库</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">目标服务器</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">源服务器</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">源数据库</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">版本</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">设置</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">默认</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">数据层应用程序向导</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">生成脚本</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">关闭向导后，可在任务视图中查看脚本生成的状态。生成的脚本将在完成后打开。</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">默认</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">部署计划操作</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">SQL Server 实例上已经存在同名数据库。</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">未定义名称</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">文件名不能以句号结尾</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">文件名不能为空白</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">无效的文件字符</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">此文件名保留供 Windows 使用。请选择其他名称，然后重试</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">文件名已保留。请选择其他名称，然后重试</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">文件名不能以空格结尾</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">文件名超过 255 个字符</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">生成部署计划失败“{0}”</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">生成部署脚本失败 '{0}'</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">{0} 操作失败“{1}”</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">关闭向导后，可在任务视图中查看脚本生成的状态。生成的脚本将在完成后打开。</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hans/import.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/import.zh-Hans.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">平面文件导入配置</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[可选] 将调试输出记录到控制台(“查看”-&gt;“输出”)，然后从下拉列表中选择相应的输出通道</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">{0} 已启动</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">正在启动 {0}</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">未能启动 {0}: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">正在将 {0} 安装到 {1}</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">正在安装 {0} 服务</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">安装于 {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">正在下载 {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">正在下载 {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">{0} 下载完毕</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">已提取 {0} ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">提供反馈</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">服务组件无法启动</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">数据库所在的服务器</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">创建表的数据库</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">文件位置无效。请尝试其他输入文件</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">浏览</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">打开</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">要导入的文件的位置</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">新建表名</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">表架构</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">导入数据</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">下一步</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">列名</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">数据类型</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">主键</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">允许 Null</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">此操作分析了输入文件的结构并生成了下方的前 50 行预览。</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">此操作不成功。请尝试其他输入文件。</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">刷新</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">导入信息</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ 已成功将数据插入表中。</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">此操作分析了输入文件的结构并生成了下方的前 50 行预览。</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">此操作不成功。请尝试其他输入文件。</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">刷新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">导入数据</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">下一步</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">列名</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">数据类型</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">主键</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">允许 Null</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">数据库所在的服务器</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">创建表的数据库</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">浏览</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">打开</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">要导入的文件的位置</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">新建表名</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">表架构</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">请在使用此向导之前连接到服务器。</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">SQL Server 导入扩展不支持此类连接</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">导入新文件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">提供反馈</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">服务组件无法启动</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">服务已启动</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">正在启动服务</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">未能启动导入服务{0}</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">正在将 {0} 服务安装到 {1}</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">正在安装服务</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">已安装</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">正在下载 {0}</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">正在下载服务</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">完成！</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hans/notebook.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/notebook.zh-Hans.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">笔记本使用的预先存在的 python 安装的本地路径。</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">不显示更新 Python 的提示。</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">在关闭所有笔记本后关闭服务器之前等待的时间 (以分钟为单位)。(输入 0 则不关闭)</target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">覆盖笔记本编辑器中的编辑器默认设置。设置包括背景色、当前线条颜色和边框</target>
@@ -49,6 +57,10 @@
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
         <target state="translated">用户为当前工作区固定的笔记本</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,24 +151,24 @@
         <target state="translated">Jupyter 书籍</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">保存书籍</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">保存 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="translated">信任工作簿</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">信任 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">搜索书籍</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">搜索 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
         <target state="translated">笔记本</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="translated">提供的工作簿</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">提供的 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
@@ -174,17 +186,29 @@
         <source xml:lang="en">Close Jupyter Book</source>
         <target state="translated">关闭 Jupyter Book</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="translated">关闭 Jupyter Notebook</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">关闭笔记本</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">移除笔记本</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">添加笔记本</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">添加 Markdown 文件</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
         <target state="translated">在工作簿中展示</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="translated">创建工作簿(预览)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">创建 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
@@ -263,8 +287,8 @@
         <target state="translated">选择文件夹</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="translated">选择工作簿</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">选择 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
@@ -283,40 +307,40 @@
         <target state="translated">打开外部链接</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="translated">工作簿现在在工作区中受信任。</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">现在，此工作区信任 Jupyter Book。</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="translated">此工作区中的工作簿受信任。</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">此工作区已信任 Jupyter Book。</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="translated">此工作区中的工作簿不再受信任</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">此工作区不再信任 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="translated">此工作区中的工作簿不受信任。</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">此工作区已不信任 Jupyter Book。</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="translated">现已在工作区中固定工作簿 {0}。</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">现在，Jupyter Book {0} 固定在此工作区。</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="translated">工作簿 {0} 不再固定在此工作区中</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Jupyter Book {0} 不再固定在此工作区</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="translated">未能在指定的工作簿中找到目录文件。</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">在指定 Jupyter Book 中找不到目录文件。</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="translated">当前未在 Viewlet 中选择任何工作簿。</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">当前，Viewlet 中未选中任何 Jupyter Book。</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="translated">选择工作簿部分</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">选择 Jupyter Book 部分</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
@@ -339,12 +363,12 @@
         <target state="translated">缺少配置文件</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="translated">打开书籍 {0} 失败: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">打开 Jupyter Book {0} 失败: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="translated">未能读取工作簿 {0}: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">无法读取 Jupyter Book {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
@@ -363,8 +387,8 @@
         <target state="translated">打开链接 {0} 失败: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="translated">关闭工作簿 {0} 失败: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">关闭 Jupyter Book {0} 失败: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
@@ -373,12 +397,16 @@
  此文件已重命名为 {2}，以防数据丢失。</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="translated">编辑工作簿 {0} 时出错: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">编辑 Jupyter Book {0} 时出错: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="translated">选择要编辑的工作簿或部分时出错: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">选择要编辑的 Jupyter Book 或部分时出错: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">找不到 {1} 中的 {0} 部分。</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
@@ -393,8 +421,8 @@
         <target state="translated">位置</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="translated">添加远程工作簿</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">添加远程 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
@@ -409,8 +437,8 @@
         <target state="translated">版本</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="translated">工作簿</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter Book</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
@@ -421,8 +449,8 @@
         <target state="translated">语言</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="translated">提供的链接当前没有工作簿可用</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">当前，提供的链接中无可用 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
@@ -445,44 +473,44 @@
         <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="translated">正在下载远程工作簿</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">正在下载远程 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="translated">远程工作簿下载已完成</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">已下载远程 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="translated">下载远程工作簿时出错</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">下载远程 Jupyter Book 时出错</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="translated">解压缩远程工作簿时出错</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">解压缩远程 Jupyter Book 时出错</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="translated">创建远程工作簿目录时出错</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">创建远程 Jupyter Book 目录时出错</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="translated">正在下载远程工作簿</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">下载远程 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
         <target state="translated">找不到资源</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="translated">找不到工作簿</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">找不到 Jupyter Book</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
         <target state="translated">找不到版本</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="translated">所选工作簿无效</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">选中的 Jupyter Book 无效</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
@@ -492,21 +520,21 @@
         <source xml:lang="en">Downloading to {0}</source>
         <target state="translated">正在下载到 {0}</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="translated">新建组</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">新 Jupyter 书籍(预览)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="translated">分组用于整理笔记本。</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Jupyter 书籍用于整理笔记本。</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="translated">浏览位置...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">了解详细信息。</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="translated">选择内容文件夹</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">内容文件夹</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
@@ -524,7 +552,7 @@
         <source xml:lang="en">Save location</source>
         <target state="translated">保存位置</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
         <target state="translated">内容文件夹(可选)</target>
       </trans-unit>
@@ -533,8 +561,44 @@
         <target state="translated">内容文件夹路径不存在</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="translated">保存位置路径不存在</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">保存位置路径不存在。</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">尝试访问时出错: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">新笔记本(预览)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">新建 Markdown (预览)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">文件扩展名</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">文件已存在。是否确实要覆盖此文件?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">标题</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">文件名</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">保存位置路径无效。</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">目标文件夹中已存在文件 {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">另一个 Python 安装正在进行中。请等待它完成。</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">将关闭活动 Python 笔记本会话以进行更新。是否要立即继续?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">Python {0} 现已在 Azure Data Studio 中提供。当前 Python 版本 (3.6.6) 将于 2021 年 12 月不再受支持。是否要立即更新到 Python {0}?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">将安装 Python {0} ，并将替换 Python 3.6.6。某些包可能不再与新版本兼容，或者可能需要重新安装。将创建一个笔记本来帮助你重新安装所有 pip 包。是否要立即继续更新?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">安装笔记本依赖项失败，错误: {0}</target>
@@ -603,6 +679,18 @@
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
         <target state="translated">获取 Python 用户路径时遇到错误: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">不再询问</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">此处理程序不支持操作 {0}</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">无法打开链接 {0}，因为仅支持 HTTP 和 HTTPS 链接</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">无法打开链接 {0} 因为仅支持 HTTP、HTTPS、文件链接</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/zh-hans/profiler.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/profiler.zh-Hans.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/zh-hans/resource-deployment.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/resource-deployment.zh-Hans.xlf
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">使用 Docker 运行 SQL Server 容器映像</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">SQL Server 大数据群集</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">借助 SQL Server 大数据群集，可部署在 Kubernetes 上运行的 SQL Server、Spark 和 HDFS 容器的可扩展群集</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">版本</target>
@@ -45,34 +37,6 @@
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
         <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">部署目标</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">新的 Azure Kubernetes 服务群集</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">现有 Azure Kubernetes 服务群集</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">现有 Kubernetes 群集(kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="translated">现有 Azure Red Hat OpenShift 群集</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="translated">现有 OpenShift 群集</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">端口</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">SQL Server 大数据群集设置</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">群集名称</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">控制器用户名</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">密码</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">确认密码</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Azure 设置</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">订阅 ID</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">使用默认 Azure 订阅</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">资源组名称</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">区域</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">AKS 群集名称</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">VM 大小</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">VM 计数</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">存储类名称</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">数据容量(GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">日志容量(GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">Windows 上的 SQL Server</target>
@@ -170,21 +70,9 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">在 Windows 上运行 SQL Server，选择版本以开始使用。</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">我接受 {0}、{1} 和 {2}。</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
         <target state="translated">Microsoft 隐私声明</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">azdata 许可条款</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">SQL Server 许可条款</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
@@ -485,6 +373,22 @@
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
         <target state="translated">接受 EULA 并选择</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">部署此资源需要“{0}”扩展，现在是否希望安装此扩展?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">安装</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">正在安装扩展“{0}”...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">未知扩展“{0}”</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
@@ -1096,10 +1000,6 @@
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">未能加载扩展: {0}，在 package.json 的资源类型定义中检测到错误，请查看调试控制台以了解详细信息。</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">未定义资源类型: {0}</target>
@@ -2222,13 +2122,13 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Deployment pre-requisites</source>
         <target state="translated">部署先决条件</target>
       </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="translated">若要继续，必须接受最终用户许可协议(EULA)条款</target>
-      </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
         <target state="translated">仍未发现某些工具。请确保它们已安装，正在运行且可发现</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">若要继续，必须接受最终用户许可协议(EULA)条款</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
@@ -2378,6 +2278,10 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Azure Data CLI</source>
         <target state="translated">Azure 数据 CLI</target>
       </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">必须安装 Azure Data CLI 以部署此资源。请通过扩展库安装，然后重试。</target>
+      </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
         <target state="translated">检索版本信息时出错。有关详细信息，请参阅输出通道“{0}”</target>
@@ -2385,46 +2289,6 @@ Select a different subscription containing at least one server</source>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
         <target state="translated">检索版本信息时出错。{0}收到无效输出，获取版本命令输出:“{1}”</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="translated">正在删除以前下载的 Azdata.msi (如果存在)…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="translated">正在下载 Azdata.msi 并安装 azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="translated">正在显示安装日志…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="translated">正在访问 azdata-cli 的 brew 存储库…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="translated">正在更新 azdata-cli 安装的 brew 存储库…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="translated">正在安装 azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="translated">正在更新存储库信息…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="translated">正在获取 azdata 安装所需的包…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="translated">正在下载并安装 azdata 的签名密钥…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="translated">正在添加 azdata 存储库信息…</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hans/schema-compare.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/schema-compare.zh-Hans.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">确定</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">源</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">目标</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">文件</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">数据层应用程序文件(.dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">数据库</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">类型</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">服务器</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">数据库</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">架构比较</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">已选择其他源架构。是否进行比较以查看比较结果?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">已选择其他目标架构。是否进行比较以查看比较结果?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">已选择其他源和目标架构。是否进行比较以查看比较结果?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">源文件</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">目标文件</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">源数据库</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">目标数据库</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">源服务器</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">目标服务器</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">默认</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">打开</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">选择源文件</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">选择目标文件</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">重置</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">包括对象类型</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">比较详细信息</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">确定要更新目标吗?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">按“比较”以刷新比较结果。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">生成脚本以将更改部署到目标</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">未更改脚本</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">将更改应用到目标</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">没有可应用的更改</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">请注意，包括/排除操作可能需要一点时间来计算受影响的依赖项</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">删除</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">更改</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">添加</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">源和目标之间的比较</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">初始化比较。这可能需要一段时间。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">要比较两个架构，请先选择源架构和目标架构，然后按“比较”。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">未找到架构差异。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">类型</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">源名称</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">包括</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">操作</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">目标名称</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">当目标为数据库时启用生成脚本</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">当目标为数据库时启用应用</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">无法排除 {0}。存在包括的依赖项，例如 {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">无法包括 {0}。存在被排除的依赖项，如 {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">无法排除 {0}。存在包括的依赖项</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">无法包括 {0}。存在排除的依赖项</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">比较</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">生成脚本</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">选项</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">应用</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">切换方向</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">切换源和目标</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">选择源</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">选择目标</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">打开 .scmp 文件</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">加载保存在 .smp 文件中的源、目标和选项</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">保存 .smp 文件</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">保存源、目标、选项和已排除的元素</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">保存</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">是否要连接到 {0}?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">选择连接</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,7 +663,7 @@
         <target state="translated">数据库角色</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
+        <source xml:lang="en">Database Triggers</source>
         <target state="translated">数据库触发器</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">外部文件格式</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">外部流</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">外部流式处理作业</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">外部表</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">文件组</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">文件</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,11 +771,11 @@
         <target state="translated">签名</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
+        <source xml:lang="en">Stored Procedures</source>
         <target state="translated">存储过程</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
+        <source xml:lang="en">Symmetric Keys</source>
         <target state="translated">对称密钥</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">指定在发布到数据库时忽略还是更新表列顺序的差异。</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">源</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">目标</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">文件</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">数据层应用程序文件(.dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">数据库</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">类型</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">服务器</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">数据库</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">无活动连接</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">架构比较</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">已选择其他源架构。是否进行比较以查看比较结果?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">已选择其他目标架构。是否进行比较以查看比较结果?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">已选择其他源和目标架构。是否进行比较以查看比较结果?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">打开</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">默认</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">比较详细信息</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">确定要更新目标吗?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">按“比较”以刷新比较结果。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">生成脚本以将更改部署到目标</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">未更改脚本</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">将更改应用到目标</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">没有可应用的更改</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">删除</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">更改</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">添加</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">架构比较</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">源</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">目标</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">初始化比较。这可能需要一段时间。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">要比较两个架构，请先选择源架构和目标架构，然后按“比较”。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">未找到架构差异。</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">架构比较失败: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">类型</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">源名称</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">包括</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">操作</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">目标名称</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">当目标为数据库时启用生成脚本</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">当目标为数据库时启用应用</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">比较</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">比较</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">保存 scmp 失败:“{0}”</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">取消架构比较失败:“{0}”</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">生成脚本</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">生成脚本失败:“{0}”</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">选项</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">选项</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">应用</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">架构比较应用失败“{0}”</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">切换方向</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">切换源和目标</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">选择源</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">选择目标</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">打开 .scmp 文件</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">加载保存在 .smp 文件中的源、目标和选项</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">打开</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">打开 scmp 失败:“{0}”</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">保存 .smp 文件</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">保存源、目标、选项和已排除的元素</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">保存</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">保存 scmp 失败:“{0}”</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hans/sql.zh-Hans.xlf
+++ b/resources/xlf/zh-hans/sql.zh-Hans.xlf
@@ -1,2559 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">不支持复制图像</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">开始</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">显示入门</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">入门(&amp;&amp;S)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">QueryHistory</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">是否启用查询历史记录捕获。若为 false，则不捕获所执行的查询。</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">查看</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">查询历史记录(&amp;&amp;Q)</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">查询历史记录</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">正在连接: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">正在运行命令: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">正在打开新查询: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">无法连接，因为未提供服务器信息</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">由于错误 {0} 而无法打开 URL</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">这将连接到服务器 {0}</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">确定要连接吗?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">打开(&amp;&amp;O)</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">正在连接查询文件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">一个或多个任务正在运行中。确定要退出吗?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">预览功能可让你全面访问新功能和改进功能，从而提升你在 Azure Data Studio 中的体验。有关预览功能的详细信息，请访问[此处]({0})。是否要启用预览功能?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">是(推荐)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">否，不再显示</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">切换查询历史记录</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">删除</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">清除所有历史记录</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">打开查询</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">运行查询</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">切换查询历史记录捕获</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">暂停查询历史记录捕获</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">开始查询历史记录捕获</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">没有可显示的查询。</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">查询历史记录</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">错误</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">警告</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">信息</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">忽略</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">已禁止此数据提供程序将结果保存为其他格式。</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">无法序列化数据，因为尚未注册任何提供程序</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">出现未知错误，序列化失败</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">需要连接才能与 adminservice 交互</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">未注册处理程序</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">选择文件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">需要连接才能与评估服务交互</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">未注册处理程序</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">结果网格和消息</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">控制字体系列。</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">控制字体粗细。</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">控制字体大小(像素)。</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">控制字母间距(像素)。</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">控制行高(像素)</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">控制单元格边距(像素)</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">自动调整初始结果的列宽。如果存在大量的列或大型单元格，可能出现性能问题</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">自动调整大小的列的最大宽度(像素)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">查看</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">数据库连接</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">数据源连接</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">数据源组</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">启动配置</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">如果要在 Azure Data Studio 启动时默认显示“服务器”视图，则为 true；如果应显示上次打开的视图，则为 false</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">断开连接</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">刷新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">预览功能</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">启用未发布的预览功能</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">在启动时显示连接对话框</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">过时的 API 通知</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">启用/禁用过时的 API 使用通知</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">问题</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} 个正在执行的任务</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">查看</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">任务</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">任务(&amp;&amp;T)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">连接列表中保存的最近使用的连接数量上限</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">要使用的默认 SQL 引擎。这将驱动 .sql 文件中的默认语言提供程序，以及创建新连接时使用的默认语言提供程序。</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">在打开连接对话框或执行粘贴时尝试分析剪贴板的内容。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">在对象资源管理器 viewlet 中使用的服务器组面板。</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">在对象资源管理器 viewlet 中自动展开服务器组。</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(预览)使用“服务器”视图和“连接”对话框的新异步服务器树，支持动态节点筛选等新功能。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">帐户类型的标识符</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(可选) UI 中用于表示帐户的图标。可以是文件路径或可设置主题的配置</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">使用浅色主题时的图标路径</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">使用深色主题时的图标路径</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">向帐户提供者提供图标。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">启动时显示“编辑数据 SQL”窗格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">Y 轴的最小值</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">y 轴的最大值</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">y 轴的标签</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">x 轴的最小值</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">x 轴的最大值</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">x 轴的标签</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">资源查看器</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">指示图表数据集的数据属性。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">对于结果集中的每一列，将行 0 中的值显示为计数后跟列名称。例如支持“1 正常”、“3 不正常”，其中“正常”是列名称，1 表示第 1 行单元格 1 中的值</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">在简单表中显示结果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">显示图像，例如由 R 查询使用 ggplot2 返回的图像</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">期望的格式 - 是 JPEG、PNG 还是其他格式?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">这是以十六进制、base64 还是其他格式进行编码的?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">仪表板</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">将在此选项卡中显示的 Web 视图。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">将在此选项卡中显示的 controlhost。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">将在此选项卡中显示的小组件列表。</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">扩展预期小组件容器中存在控件列表。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">将在此选项卡中显示的小组件或 Web 视图的列表。</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">扩展预期小组件容器中存在小组件或 Web 视图。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">此容器的唯一标识符。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">将在选项卡中显示的容器。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">提供一个或多个仪表板容器，让用户添加其仪表板。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">仪表板容器中未指定用于扩展的 ID。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">仪表板容器中未指定用于扩展的容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">必须在每个空间定义恰好 1 个仪表板容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">仪表板容器中为扩展定义了未知的容器类型。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">此导航部分的唯一标识符。将传递到任何请求的扩展。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(可选) UI 中用于表示此导航部分的图标。可以是文件路径或可设置主题的配置</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">使用浅色主题时的图标路径</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">使用深色主题时的图标路径</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">要向用户显示的导航部分的标题。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">将在此导航部分显示的容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">将在此导航部分显示的仪表板容器的列表。</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">未在导航部分为扩展指定标题。</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">未在导航部分为扩展指定容器。</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">必须在每个空间定义恰好 1 个仪表板容器。</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION 内的 NAV_SECTION 是一个无效的扩展容器。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">将在此选项卡中显示的由模型支持的视图。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">备份</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">还原</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">还原</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">在 Azure 门户中打开</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">已断开连接</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">无法展开，因为未找到所需的连接提供程序“{0}”</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">用户已取消</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">防火墙对话已取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">需要连接才能与 JobManagementService 交互</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">未注册处理程序</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">加载文件浏览器时出错。</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">文件浏览器错误</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">提供程序的公用 ID</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">提供程序的显示名称</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">提供程序的笔记本内核别名</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">服务器类型的图标路径</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">连接选项</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">此选项卡的唯一标识符。将传递到任何请求的扩展。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">将向用户显示的选项卡标题。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">将向用户显示的此选项卡的说明。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">此条件必须为 true 才能显示此项</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">定义此选项卡兼容的连接类型。如果未设置，则默认为 "MSSQL"</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">将在此选项卡中显示的容器。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">是始终显示此选项卡还是仅当用户添加时显示。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">此选项卡是否应用作连接类型的“开始”选项卡。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">此选项卡所属组的唯一标识符，主页组的值: 主页。</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(可选) UI 中用于表示此选项卡的图标。可以是文件路径或可设置主题的配置</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">使用浅色主题时的图标路径</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">使用深色主题时的图标路径</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">提供一个或多个选项卡，让用户添加到其仪表板。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">没有为扩展指定标题。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">没有可显示的已指定说明。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">没有为扩展指定容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">必须在每个空间定义恰好 1 个仪表板容器</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">此选项卡组的唯一标识符。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">选项卡组的标题。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">为用户提供一个或多个选项卡组以添加到他们的仪表板。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">没有为选项卡组指定 ID。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">没有为选项卡组指定标题。</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">监视</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">性能</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">安全性</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">疑难解答</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">设置</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">数据库选项卡</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">数据库</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">成功</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">失败</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">连接错误</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">由于 Kerberos 错误，连接失败。</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">可在 {0} 处获取有关配置 Kerberos 的帮助</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">如果之前已连接，可能需要重新运行 kinit。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">关闭</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">正在添加帐户...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">用户已取消刷新帐户</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">查询结果</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">查询编辑器</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">新建查询</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">查询编辑器</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">为 true 时，将在将结果保存为 CSV 时包含列标题</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">保存为 CSV 时在值之间使用的自定义分隔符</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">将结果保存为 CSV 时用于分隔行的字符</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">将结果保存为 CSV 时用于封装文本字段的字符</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">将结果保存为 CSV 时使用的文件编码</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">为 true 时，将在将结果保存为 XML 时设置 XML 输出的格式</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">将结果保存为 XML 时使用的文件编码</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">启用结果流式处理；包含极少轻微的可视化问题</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">用于从“结果视图”复制结果的配置选项</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">用于从“结果视图”复制多行结果的配置选项</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(实验性)在出现的结果中使用优化的表。某些功能可能缺失或处于准备阶段。</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">是否应显示每个批处理的执行时间</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">自动换行消息</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">从“查询结果”打开“图表查看器”时要使用的默认图表类型</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">将禁用选项卡着色</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">每个编辑器选项卡的上边框颜色将与相关服务器组匹配</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">每个编辑器选项卡的背景色将与相关服务器组匹配</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">控制如何根据活动连接的服务器组为选项卡着色</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">控制是否显示标题中选项卡的连接信息。</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">提示保存生成的 SQL 文件</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">将键绑定 workbench.action.query.shortcut{0} 设置为以过程调用的方式运行快捷方式文本。查询编辑器中的任何选定文本都将作为参数传递</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">指定视图模板</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">指定会话模板</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">探查器筛选器</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">执行 Create 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">执行 Drop 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">选择前 1000 项</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">执行 Execute 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">执行 Alter 脚本</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">编辑数据</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">选择前 1000 项</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">选取 10 个</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">执行 Create 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">执行 Execute 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">执行 Alter 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">执行 Drop 脚本</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">刷新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">提交行失败:</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">开始执行查询的位置:</target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">已开始执行查询 "{0}"</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">第 {0} 行</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">取消查询失败: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">更新单元格失败:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">创建笔记本管理器时未传递 URI</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">笔记本提供程序不存在</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">笔记本编辑器</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新建笔记本</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新建笔记本</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">设置工作区并打开</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">SQL 内核: 在单元格中发生错误时停止笔记本执行。</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(预览)显示当前笔记本提供程序的所有内核。</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">允许笔记本运行 Azure Data Studio 命令。</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">启用双击来编辑笔记本中的文本单元格</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">默认为文本单元格设置格式文本视图模式</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(预览)在笔记本元数据中保存连接名称。</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">控制笔记本 Markdown 预览中使用的行高。此数字与字号相关。</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">查看</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">搜索笔记本</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">配置glob模式以在全文本搜索和快速打开中排除文件和文件夹。从“＃files.exclude＃”设置继承所有glob模式。在[此处](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)了解更多关于glob模式的信息</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">匹配文件路径所依据的 glob 模式。设置为 true 或 false 可启用或禁用该模式。</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">对匹配文件的同级文件的其他检查。使用 $(basename) 作为匹配文件名的变量。</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated">此设置已被弃用，将回退到 "search.usePCRE2"。</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">已弃用。请考虑使用 "search.usePCRE2" 获取对高级正则表达式功能的支持。</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">启用后，搜索服务进程将保持活动状态，而不是在一个小时不活动后关闭。这将使文件搜索缓存保留在内存中。</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">控制在搜索文件时是否使用 `.gitignore` 和 `.ignore` 文件。</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">控制在搜索文件时是否使用全局 `.gitignore` 和 `.ignore` 文件。</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">控制 Quick Open 文件结果中是否包括全局符号搜索的结果。</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">是否在 Quick Open 的文件结果中包含最近打开的文件。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">历史记录条目按与筛选值的相关性排序。首先显示更相关的条目。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">历史记录条目按最近时间排序。首先显示最近打开的条目。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">控制在快速打开中筛选时编辑器历史记录的排序顺序。</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">控制是否在搜索中跟踪符号链接。</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">若搜索词全为小写，则不区分大小写进行搜索，否则区分大小写进行搜索。</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">控制“搜索”视图是否读取或修改 macOS 的共享查找剪贴板。</target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">控制搜索功能是显示在侧边栏，还是显示在水平空间更大的面板区域。</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">此设置已弃用。请改用搜索视图的上下文菜单。</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">结果少于10个的文件将被展开。其他的则被折叠。</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">控制是折叠还是展开搜索结果。</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">控制在选择或替换匹配项时是否打开“替换预览”视图。</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">控制是否显示搜索结果所在的行号。</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">是否在文本搜索中使用 pcre2 正则表达式引擎。这允许使用一些高级正则表达式功能, 如前瞻和反向引用。但是, 并非所有 pcre2 功能都受支持-仅支持 javascript 也支持的功能。</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">弃用。当使用仅 PCRE2 支持的正则表达式功能时，将自动使用 PCRE2。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">当搜索视图较窄时将操作栏置于右侧，当搜索视图较宽时，将它紧接在内容之后。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">始终将操作栏放置在右侧。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">在搜索视图中控制操作栏的位置。</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">在键入时搜索所有文件。</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">当活动编辑器没有选定内容时，从离光标最近的字词开始进行种子设定搜索。</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">聚焦搜索视图时，将工作区搜索查询更新为编辑器的所选文本。单击时或触发 `workbench.views.search.focus` 命令时会发生此情况。</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">启用"#search.searchOnType"后，控制键入的字符与开始搜索之间的超时(以毫秒为单位)。禁用"搜索.searchOnType"时无效。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">双击选择光标下的单词。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">双击将在活动编辑器组中打开结果。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">双击将在编辑器组中的结果打开到一边，如果尚不存在，则创建一个结果。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">配置在搜索编辑器中双击结果的效果。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">结果按文件夹和文件名按字母顺序排序。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">结果按文件名排序，忽略文件夹顺序，按字母顺序排列。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">结果按文件扩展名的字母顺序排序。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">结果按文件的最后修改日期按降序排序。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">结果按每个文件的计数降序排序。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">结果按每个文件的计数以升序排序。</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">控制搜索结果的排序顺序。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">新建查询</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">运行</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">解释</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">实际</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">断开连接</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">更改连接</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">连接</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">启用 SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">禁用 SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">选择数据库</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">未能更改数据库</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">未能更改数据库 {0}</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">导出为笔记本</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">关闭</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">操作</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">复制详细信息</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">添加服务器组</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">编辑服务器组</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">扩展</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">未能创建对象资源管理器会话</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">多个错误:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">添加帐户时出错</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">防火墙规则错误</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">某些加载的扩展正在使用过时的 API，请在“开发人员工具”窗口的“控制台”选项卡中查找详细信息</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">不再显示</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">视图的标识符。使用标识符通过 "vscode.window.registerTreeDataProviderForView" API 注册数据提供程序。同时将 "onView:${id}" 事件注册到 "activationEvents" 以触发激活扩展。</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">用户可读的视图名称。将显示它</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">为真时才显示此视图的条件</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">向编辑器提供视图</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">向“活动”栏中的“数据资源管理器”容器提供视图</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">向“提供的视图”容器提供视图</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">无法在视图容器“{1}”中注册多个具有相同 ID (“{0}”) 的视图</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">视图容器“{1}”中已注册有 ID 为“{0}”的视图</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">视图必须为数组</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">属性“{0}”是必需的，其类型必须是 "string"</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">属性“{0}”可以省略，否则其类型必须是 "string"</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">{0} 已被替换为用户设置中的 {1}。</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">{0} 已被替换为工作区设置中的 {1}。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">显示详细信息</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">了解更多</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">清除所有保存的帐户</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">切换任务</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">连接状态</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">树提供程序的用户可见名称</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">提供程序的 ID，必须与注册树数据提供程序时的 ID 相同，且必须以 "connectionDialog/" 开头</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">将查询结果显示为仪表板上的图表</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">映射“列名称”-&gt;“颜色”。例如，添加 'column1': red 以确保此列使用红色</target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">表示图表图例的首选位置和可见性。这些是查询中的列名称，并映射到每个图表条目的标签</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">如果 dataDirection 为 horizontal，则将其设置为 true 将使用第一列的值作为图例。</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">如果 dataDirection 为 vertical，则将其设置为 true 将使用列名称作为图例。</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">定义是从列(垂直)还是从行(水平)读取数据。对于时序，将忽略此设置，因为方向必须为垂直。</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">如果设置了 showTopNData，则只在图表中显示前 N 个数据。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">仪表板中使用的小组件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">显示操作</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">资源查看器</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">资源的标识符。</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">用户可读的视图名称。将显示它</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">资源图标的路径。</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">将资源分配给资源视图</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">属性“{0}”是必需的，其类型必须是 "string"</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">属性“{0}”可以省略，否则其类型必须是 "string"</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">资源查看器树</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">仪表板中使用的小组件</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">仪表板中使用的小组件</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">仪表板中使用的小组件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">此条件必须为 true 才能显示此项</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">是否隐藏小组件的标题，默认值为 false</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">容器的标题</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">网格中组件的行</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">网格中组件的行跨度。默认值为 1。使用 "*" 设置为网格中的行数。</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">网格中组件的列</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">网格中组件的列跨度。默认值为 1。使用 "*" 设置为网格中的列数。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">此选项卡的唯一标识符。将传递到任何请求的扩展。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">扩展选项卡未知或未安装。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">启用或禁用属性小组件</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">要显示的属性值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">属性的显示名称</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">数据库信息对象中的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">指定要忽略的特定值</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">恢复模式</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">上次数据库备份</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">上次日志备份</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">兼容级别</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">所有者</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">自定义数据库仪表板页面</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">搜索</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">自定义数据库仪表板选项卡</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">启用或禁用属性小组件</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">要显示的属性值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">属性的显示名称</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">服务器信息对象中的值</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">版本</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">版本</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">计算机名</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">OS 版本</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">搜索</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">自定义服务器仪表板页面</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">自定义服务器仪表板选项卡</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">可以省略属性 "icon"，若不省略则必须是字符串或文字，例如 "{dark, light}"</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">添加一个可以查询服务器或数据库并以多种方式(如图表、总数等)显示结果的小组件。</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">用于缓存见解结果的唯一标识符。</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">要运行的 SQL 查询。将返回恰好 1 个结果集。</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[可选] 包含查询的文件的路径。未设置“查询”时使用</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[可选] 自动刷新间隔(分钟数)；如果未设置，则不自动刷新</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">要使用的操作</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">操作的目标数据库；可使用格式 "${ columnName }" 以便由数据确定列名。</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">操作的目标服务器；可使用格式 "${ columnName }" 以便由数据确定列名。</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">操作的目标用户；可使用格式 "${ columnName }" 以便由数据确定列名。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">见解的标识符</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">向仪表板提供见解。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">备份</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">必须启用预览功能才能使用备份</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL 数据库不支持备份命令。</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">服务器上下文中不支持备份命令。请选择数据库，然后重试。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">还原</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">必须启用预览功能才能使用还原</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL 数据库不支持还原命令。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">显示建议</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">安装扩展</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">创作扩展...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">编辑数据会话连接失败</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">打开仪表板扩展</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">目前尚未安装仪表板扩展。转“到扩展管理器”以浏览推荐的扩展。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">选定的路径</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">文件类型</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">放弃</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">未将连接配置文件传递到见解浮出控件</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">见解错误</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">读取以下查询文件时出错:</target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">分析见解配置时出错；找不到查询数组/字符串或查询文件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Azure 帐户</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Azure 租户</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">显示连接</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">服务器</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">连接</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">没有可显示的任务历史记录。</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">任务历史记录</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">任务错误</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">清空列表</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">已清空最新连接列表</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">确定要删除列表中的所有连接吗?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">删除</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">获取当前连接字符串</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">连接字符串不可用</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">没有可用的活动连接</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">刷新</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">编辑连接</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">断开连接</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">新建连接</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">新建服务器组</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">编辑服务器组</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">显示活动连接</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">显示所有连接</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的连接</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">删除连接</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">删除组</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">运行</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">释放编辑失败，出现错误:</target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">显示 SQL 窗格</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">关闭 SQL 窗格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">探查器</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">未连接</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">XEvent 探查器会话在服务器 {0} 上意外停止。</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">启动新会话时出错</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">{0} 的 XEvent 探查器会话缺失事件。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">正在加载</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">加载完毕</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">服务器组</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">服务器组名称</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">组名称是必需的。</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">组描述</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">组颜色</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">添加帐户时出错</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">项</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">见解详细信息</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">属性</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">见解</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">项</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">项详细信息</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">无法启动自动 OAuth。自动 OAuth 已在进行中。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">按事件排序</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">按列排序</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">探查器</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">全部清除</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">应用</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">筛选器</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">删除此子句</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">保存筛选器</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">加载筛选器</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">添加子句</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">字段</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">运算符</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">为 Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">不为 Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">包含</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">不包含</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">开头为</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">开头不为</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">另存为 CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">另存为 JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">另存为 Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">另存为 XML</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">复制</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">带标头复制</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">全选</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">定义要在仪表板上显示的属性</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">用作属性标签的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">对象中要针对该值访问的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">指定要忽略的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">在忽略或没有值时显示的默认值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">用于定义仪表板属性的风格</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">风格的 ID</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">使用这种风格的条件</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">用于比较的字段</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">用于比较的运算符</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">用于和字段比较的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">数据库页面要显示的属性</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">服务器页面要显示的属性</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">定义此提供程序支持仪表板</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">提供程序 ID (如 MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">要在仪表板上显示的属性值</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">值无效</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}。{1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2565,435 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">空白</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">隐藏文本标签</target>
       </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">选中列中的所有复选框: {0}</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">显示文本标签</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">未注册 ID 为 "{0}" 的树状视图。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">初始化编辑数据会话失败:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">笔记本提供程序的标识符。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">应向此笔记本提供程序注册哪些文件扩展名</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">此笔记本提供程序应标配哪些内核</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">提供笔记本提供程序。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">单元格魔术方法的名称，如 "%%sql"。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">单元格中包含此单元格魔术方法时要使用的单元格语言</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">此魔术方法指示的可选执行目标，例如 Spark 和 SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">可选内核集，对于 python3、pyspark 和 sql 等有效</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">提供笔记本语言。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">需要选择代码单元格才能使用 F5 快捷键。请选择要运行的代码单元格。</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">需要选择代码单元格才能清除结果。请选择要运行的代码单元格。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">最大行数:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">选择视图</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">选择会话</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">选择会话:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">选择视图:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">文本</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">标签</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">详细信息</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">已用时间</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">行数</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} 行</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">正在执行查询…</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">执行状态</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">选择摘要</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">平均值: {0} 计数: {1} 总和: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">选择 SQL 语言</target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">更改 SQL 语言提供程序</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">SQL 语言风格</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">更改 SQL 引擎提供程序</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">使用引擎 {0} 的连接已存在。若要更改，请先断开或更改连接</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">当前没有活动的文本编辑器</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">选择语言提供程序</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">显示 Plotly 图形时出错: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">未找到 {0} 呈现器用于输出。它具有以下 MIME 类型: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(安全)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">选择前 1000 项</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">选取 10 个</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">执行 Execute 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">执行 Alter 脚本</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">编辑数据</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">执行 Create 脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">执行 Drop 脚本</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">必须向此方法传递具有有效 providerId 的 NotebookProvider</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">必须向此方法传递具有有效 providerId 的 NotebookProvider</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">未找到笔记本提供程序</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">未找到管理器</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">笔记本 {0} 的笔记本管理器没有服务器管理器。无法对其执行操作</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">笔记本 {0} 的笔记本管理器没有内容管理器。无法对其执行操作</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">笔记本 {0} 的笔记本管理器没有会话管理器。无法对其执行操作</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">未能获取 Azure 帐户令牌用于连接</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">连接未被接受</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">确定要取消此连接吗?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">关闭</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">正在加载内核…</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">正在更改内核…</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">附加到</target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">内核</target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">正在加载上下文…</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">更改连接</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">选择连接</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">无内核</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">清除结果</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">受信任</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">不受信任</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">折叠单元格</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">展开单元格</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">无</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新建笔记本</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">查找下一个字符串</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">查找上一个字符串</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">查询计划</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">刷新</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">步骤 {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">必须是列表中的选项</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">选择框</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">连接</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">正在连接</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">连接类型</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的连接</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存的连接</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">连接详细信息</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">连接</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的连接</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">没有最近的连接</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存的连接</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">没有保存的连接</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">无可用数据</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">文件浏览器树</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">全选/取消全选</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">从</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">显示筛选器</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">到</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">全选</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">新建防火墙规则</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜索</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} 个结果</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">已选择 {0} 项</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">升序排序</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">降序排序</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">确定</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">清除</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">你的客户端 IP 地址无权访问此服务器。请登录到 Azure 帐户，然后新建一个防火墙规则以启用访问。</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">详细了解防火墙设置</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">防火墙规则</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">添加我的客户端 IP</target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">添加我的子网 IP 范围</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">筛选器选项</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">所有文件</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">正在加载</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">在下述所有路径中都找不到查询文件:
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">正在加载错误…</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">需要刷新此帐户的凭据。</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">切换更多</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">启用自动更新检查。Azure Data Studio 将定期自动检查更新。</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">启用在 Windows 上后台下载和安装新的 Azure Data Studio 版本</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">更新后显示发行说明。发行说明会在新的 Web 浏览器窗口中打开。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">仪表板工具栏操作菜单</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">笔记本单元格标题菜单</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">笔记本标题菜单</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">笔记本工具栏菜单</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">dataexplorer 视图容器标题操作菜单</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">dataexplorer 项上下文菜单</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">对象资源管理器项上下文菜单</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">连接对话框的浏览树上下文菜单</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">数据网格项上下文菜单</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">设置用于下载扩展的安全策略。</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">扩展策略不允许安装扩展。请更改扩展策略，然后重试。</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">已完成从 VSIX 安装 {0} 扩展的过程。请重新加载 Azure Data Studio 以启用它。</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以完成此扩展的卸载。</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以启用更新的扩展。</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以在本地启用此扩展。</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以启用此扩展。</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以禁用此扩展。</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以完成扩展 {0} 的卸载。</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以在 {0} 中启用此扩展。</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">安装扩展 {0} 已完成。请重新加载 Azure Data Studio 以启用它。</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">请重新加载 Azure Data Studio 以完成扩展 {0} 的重新安装。</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">市场</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">必须提供扩展建议的方案类型。</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">无法安装扩展名 '{0}'，因为它不兼容 Azure Data Studio '{1}'。</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新建查询</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">新建查询(&amp;&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">新建笔记本(&amp;&amp;N)</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">在打开大型文件时，控制 Azure Data Studio 可在重启后使用的内存。在命令行中指定 `--max-memory=新的大小` 参数可达到相同效果。</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">是否要将 Azure Data Studio 的 UI 语言更改为 {0} 并重启?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">若要在 {0} 中使用 Azure Data Studio，Azure Data Studio需要重启。</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">新建 SQL 文件</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新建笔记本</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">从 VSIX 包安装扩展</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">必须是列表中的选项</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">选择框</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">显示笔记本</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">搜索结果</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">找不到搜索路径: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">笔记本</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">不支持复制图像</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">关注当前查询</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">运行查询</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">运行当前查询</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">复制查询和结果</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">已成功复制查询和结果。</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">使用实际计划运行当前查询</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">取消查询</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">刷新 IntelliSense 缓存</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">切换查询结果</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">在查询和结果之间切换焦点</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">需要编辑器参数才能执行快捷方式</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">分析查询</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">命令已成功完成</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">命令失败:</target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">请连接到服务器</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">已存在同名的服务器组。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">成功</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">失败</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">正在进行</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">尚未开始</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">已取消</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">正在取消</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">仪表板中使用的小组件</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">无法用给定的数据显示图表</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">仪表板中使用的小组件</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">仪表板中使用的小组件</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">仪表板中使用的小组件</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">打开链接时出错: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">执行命令“{0}”时出错: {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">复制失败，出现错误 {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">显示图表</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">显示表</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;双击以编辑&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;在此处添加内容...&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">刷新节点“{0}”时出错: {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">完成</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">生成脚本</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">下一步</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">上一步</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">选项卡未初始化</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated">是必需的。</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">输入无效。预期值为数值。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">备份文件路径</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">目标数据库</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">还原</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">还原数据库</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">数据库</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">备份文件</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">还原数据库</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">脚本</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">源</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">还原自</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">需要备份文件路径。</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">请输入一个或多个用逗号分隔的文件路径</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">数据库</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">目标</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">还原到</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">还原计划</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">要还原的备份集</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">将数据库文件还原为</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">还原数据库文件详细信息</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">逻辑文件名</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">文件类型</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">原始文件名</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">还原为</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">还原选项</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">结尾日志备份</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">服务器连接</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">常规</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">文件</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">选项</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">复制单元格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">完成</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">复制并打开</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">用户代码</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">网站</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">索引 {0} 无效。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">服务器说明(可选)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">高级属性</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">放弃</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">无法识别 nbformat v{0}.{1}</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">此文件没有有效的笔记本格式</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">单元格类型 {0} 未知</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">无法识别输出类型 {0}</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">{0} 的数据应为字符串或字符串数组</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">无法识别输出类型 {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">欢迎</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 管理包</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 管理包</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">SQL Server 管理包是热门数据库管理扩展的一个集合，可帮助你管理 SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">使用 Azure Data Studio 功能丰富的查询编辑器编写和执行 PowerShell 脚本</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">数据虚拟化</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">使用 SQL Server 2019 虚拟化数据，并使用交互式向导创建外部表</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">使用 Azure Data Studio 连接、查询和管理 Postgres 数据库</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">已安装对 {0} 的支持。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">安装对 {0} 的额外支持后，将重载窗口。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">正在安装对 {0} 的额外支持...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">找不到对 {0} (ID: {1}) 的支持。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">新建连接</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">新建查询</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">新建笔记本</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">部署服务器</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">欢迎</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">新建</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">打开…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">打开文件…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">打开文件夹…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">开始教程</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">关闭快速浏览栏</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">是否希望快速浏览 Azure Data Studio?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">欢迎使用!</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">打开路径为 {1} 的文件夹 {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">安装</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">安装 {0} 键映射</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">安装对 {0} 的额外支持</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">已安装</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">已安装 {0} 按键映射</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">已安装 {0} 支持</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">详细信息</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">欢迎页面的背景色。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">用于事件文本的探查器编辑器。只读</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">未能保存结果。</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">选择结果文件</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (以逗号分隔)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Excel 工作簿</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">纯文本</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">正在保存文件...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">已成功将结果保存到 {0}</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">打开文件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">隐藏文本标签</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">显示文本标签</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">用于视图模型的模型视图代码编辑器。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">信息</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">警告</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">错误</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">显示详细信息</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">复制</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">关闭</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">返回</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">隐藏详细信息</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">帐户</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">链接的帐户</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">关闭</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">没有链接的帐户。请添加一个帐户。</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">添加帐户</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">你没有启用云。请转到“设置”-&gt; 搜索 Azure 帐户配置 -&gt; 至少启用一个云</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">你没有选择任何身份验证提供程序。请重试。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">由于意外错误，执行失败: {0}	{1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">执行时间总计: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">开始执行查询的位置: 第 {0} 行</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">已开始执行批处理 {0}</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">批处理执行时间: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">复制失败，出现错误 {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">开始</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">新建连接</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">新建查询</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">新建笔记本</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">打开文件</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">打开文件</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">部署</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">新建部署…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">最近使用</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">更多...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">没有最近使用的文件夹</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">帮助</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">开始使用</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">文档</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">报告问题或功能请求</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">GitHub 存储库</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">发行说明</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">启动时显示欢迎页</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">自定义</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">扩展</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">下载所需的扩展，包括 SQL Server 管理包等</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">键盘快捷方式</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">查找你喜欢的命令并对其进行自定义</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">颜色主题</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">使编辑器和代码呈现你喜欢的外观</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">了解</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">查找并运行所有命令</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">使用命令面板快速访问和搜索命令 ({0})</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">了解最新版本中的新增功能</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">每月推出新的月度博客文章，展示新功能</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">在 Twitter 上关注我们</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">保持了解社区如何使用 Azure Data Studio 并与工程师直接交谈。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">连接</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">断开连接</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">开始</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">新建会话</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">暂停</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">继续</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">清除数据</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">是否确实要清除数据?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">自动滚动: 开</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">自动滚动: 关</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">切换已折叠的面板</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">编辑列</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">查找下一个字符串</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">查找上一个字符串</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">启动探查器</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">筛选器…</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">清除筛选器</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">是否确实要清除筛选器?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">事件(已筛选): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">事件: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">事件计数</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">无可用数据</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">结果</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">消息</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">在对象上调用 select 脚本时没有返回脚本</target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">选择</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">创建</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">插入</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">更新</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">删除</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">在对象 {1} 上执行 {0} 脚本时未返回脚本</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">执行脚本失败</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">执行 {0} 脚本时未返回脚本</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">表头背景色</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">表头前景色</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">当列表/表处于活动状态时所选焦点所在项的列表/表背景色</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">单元格边框颜色。</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">已禁用输入框背景。</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">已禁用输入框前景。</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">聚焦时的按钮轮廓颜色。</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">已禁用复选框前景。</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">SQL 代理表背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">SQL 代理表单元格背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">SQL 代理表悬停背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">SQL 代理标题背景色。</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">SQL 代理表单元格边框颜色。</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">结果消息错误颜色。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">备份名称</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">恢复模式</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">备份类型</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">备份文件</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">算法</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">证书或非对称密钥</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">媒体</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">备份到现有媒体集</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">备份到新的媒体集</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">追加到现有备份集</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">覆盖所有现有备份集</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">新建媒体集名称</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">新建媒体集说明</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">在写入到媒体前执行校验和</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">完成后验证备份</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">出错时继续</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">有效期</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">设置备份保留天数</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">仅限复制的备份</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">高级配置</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">压缩</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">设置备份压缩</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">加密</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">事务日志</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">截断事务日志</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">备份日志的末尾</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">可靠性</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">需要媒体名称</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">没有可用的证书或非对称密钥</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">添加文件</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">删除文件</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">输入无效。值必须大于或等于 0。</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">脚本</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">备份</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">只支持备份到文件</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">需要备份文件路径</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">已禁止此数据提供程序将结果保存为其他格式。</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">无法序列化数据，因为尚未注册任何提供程序</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">出现未知错误，序列化失败</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">没有可提供视图数据的已注册数据提供程序。</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">表头背景色</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">刷新</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">表头前景色</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">全部折叠</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">当列表/表处于活动状态时所选焦点所在项的列表/表背景色</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">运行命令 {1} 错误: {0}。这可能是由提交 {1} 的扩展引起的。</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">单元格边框颜色。</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">已禁用输入框背景。</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">已禁用输入框前景。</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">聚焦时的按钮轮廓颜色。</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">已禁用复选框前景。</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">SQL 代理表背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">SQL 代理表单元格背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">SQL 代理表悬停背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">SQL 代理标题背景色。</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">SQL 代理表单元格边框颜色。</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">结果消息错误颜色。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">请选择活动单元格并重试</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">某些加载的扩展正在使用过时的 API，请在“开发人员工具”窗口的“控制台”选项卡中查找详细信息</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">运行单元格</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">取消执行</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">上次运行时出错。请单击以重新运行</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">不再显示</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">任务取消失败。</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">脚本</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">切换更多</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">正在加载</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">主页</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">“{0}”部分具有无效内容。请与扩展所有者联系。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">作业</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">笔记本</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">警报</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">代理</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">运算符</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">服务器属性</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">数据库属性</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">全选/取消全选</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">显示筛选器</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">确定</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">清除</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的连接</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">服务器</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">服务器</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">备份文件</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">所有文件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">搜索: 键入搜索词，然后按 Enter 键搜索或按 Esc 键取消</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">搜索</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">未能更改数据库</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">上一个匹配项</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">已启用</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">响应之间的延迟(秒)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">类别名称</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">电子邮件地址</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">已启用</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">帐户名称</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">凭据名称</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">说明</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">已启用</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">正在加载对象</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">正在加载数据库</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">对象加载已完成。</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">数据库加载已完成。</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">按类型名称搜索(t:、v:、f: 或 sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">搜索数据库</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">无法加载对象</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">无法加载数据库</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">正在加载属性</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">属性加载已完成</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">无法加载仪表板属性</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">正在加载 {0}</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">{0} 加载已完成</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">自动刷新: 关</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">上次更新时间: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">没有可显示的结果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">步骤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">另存为 CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">另存为 JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">另存为 Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">另存为 XML</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">导出到 JSON 时，将不会保存结果编码，请记得在创建文件后使用所需编码进行保存。</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">备份数据源不支持保存到文件</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">复制</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">带标头复制</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">全选</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">最大化</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">还原</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">图表</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">可视化工具</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">需要选择代码单元格才能使用 F5 快捷键。请选择要运行的代码单元格。</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">需要选择代码单元格才能清除结果。请选择要运行的代码单元格。</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">步骤 ID</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">完成</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">步骤名称</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">消息</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">生成脚本</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">下一步</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">上一步</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">选项卡未初始化</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">查找</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">未注册 ID 为 "{0}" 的树状视图。</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">查找</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">必须向此方法传递具有有效 providerId 的 NotebookProvider</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">上一个匹配项</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">未找到笔记本提供程序</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">下一个匹配项</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">未找到管理器</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">笔记本 {0} 的笔记本管理器没有服务器管理器。无法对其执行操作</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">笔记本 {0} 的笔记本管理器没有内容管理器。无法对其执行操作</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">笔记本 {0} 的笔记本管理器没有会话管理器。无法对其执行操作</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">必须向此方法传递具有有效 providerId 的 NotebookProvider</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">显示详细信息</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">了解更多</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">清除所有保存的帐户</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">预览功能</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">启用未发布的预览功能</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">在启动时显示连接对话框</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">过时的 API 通知</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">启用/禁用过时的 API 使用通知</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">编辑数据会话连接失败</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">探查器</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">未连接</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">XEvent 探查器会话在服务器 {0} 上意外停止。</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">启动新会话时出错</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">{0} 的 XEvent 探查器会话缺失事件。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">显示操作</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">资源查看器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">信息</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">警告</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">错误</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">显示详细信息</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">复制</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">关闭</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">搜索返回了大量结果，将仅突出显示前 999 个匹配项。</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">返回</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0} 个(共 {1} 个)</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">无结果</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">隐藏详细信息</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">水平条</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">条形图</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">折线图</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">饼图</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">散点图</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">时序</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">图像</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">计数</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">表</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">圆环图</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">未能获得数据集的行来绘制图表。</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">不支持图表类型“{0}”。</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">参数</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated">是必需的。</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">输入无效。预期值为数值。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">已连接到</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">索引 {0} 无效。</target>
       </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">空白</target>
+      </trans-unit>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">选中列中的所有复选框: {0}</target>
+      </trans-unit>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">显示操作</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">正在加载</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">加载已完成</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">值无效</target>
+      </trans-unit>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}。{1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">正在加载</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">加载完毕</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">用于视图模型的模型视图代码编辑器。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">找不到类型 {0} 的组件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">不支持更改未保存文件的编辑器类型</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">选择前 1000 项</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">选取 10 个</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">执行 Execute 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">执行 Alter 脚本</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">编辑数据</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">执行 Create 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">执行 Drop 脚本</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">在对象上调用 select 脚本时没有返回脚本</target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">选择</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">创建</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">插入</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">更新</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">删除</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">在对象 {1} 上执行 {0} 脚本时未返回脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">执行脚本失败</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">执行 {0} 脚本时未返回脚本</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
         <target state="translated">已断开连接</target>
       </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">未保存的连接</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">浏览(预览)</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">在此处键入以筛选列表</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">筛选器连接</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">正在应用筛选器</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">正在删除筛选器</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">已应用筛选器</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">已删除筛选器</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存的连接</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">保存的连接</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">连接浏览器树</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Azure Data Studio 建议使用此扩展。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">不再显示</target>
-      </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio 具有扩展建议。</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio 具有针对数据可视化的扩展建议。
-安装后，你可以选择“可视化工具”图标来可视化查询结果。</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">全部安装</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">显示建议</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">必须提供扩展建议的方案类型。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">此功能页面处于预览状态。预览功能引入了新功能，这些功能有望成为产品的永久组成部分。它们是稳定的，但需要改进额外的辅助功能。欢迎在功能开发期间提供早期反馈。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">预览</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">创建连接</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">通过连接对话连接到数据库实例。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">运行查询</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">通过查询编辑器与数据交互。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">创建笔记本</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">使用本机笔记本编辑器生成新笔记本。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">部署服务器</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">在所选平台上创建关系数据服务的新实例。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">资源</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">历史记录</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">位置</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">显示更多</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">启动时显示欢迎页</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">有用链接</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">开始使用</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">发现 Azure Data Studio 所提供的功能，并了解如何充分利用这些功能。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">文档</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">访问文档中心，以获取快速入门、操作指南以及 PowerShell、API 等的参考。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Azure Data Studio 概述</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Azure Data Studio 笔记本简介 | 已公开的数据</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
         <target state="translated">扩展</target>
       </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">全部显示</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">垂直选项卡的活动选项卡背景色</target>
       </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">了解更多</target>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">仪表板中边框的颜色</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">仪表板小组件标题的颜色</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">仪表板小组件子文本的颜色</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">属性容器组件中显示的属性值的颜色</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">属性容器组件中显示的属性名称的颜色</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">工具栏溢出阴影颜色</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">创建日期:</target>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">帐户类型的标识符</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">笔记本错误:</target>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(可选) UI 中用于表示帐户的图标。可以是文件路径或可设置主题的配置</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">作业错误:</target>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">使用浅色主题时的图标路径</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">已固定</target>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">使用深色主题时的图标路径</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">最近运行</target>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">向帐户提供者提供图标。</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">已运行</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">查看适用规则</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">查看 {0} 的适用规则</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">调用评估</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">调用 {0} 的评估</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">导出为脚本</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">查看所有规则并了解有关 GitHub 的详细信息</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">创建 HTML 报表</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">已保存报表。是否要打开它?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">打开</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">数据库 {0} 完全符合最佳做法。非常棒!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">图表</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">操作</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">对象</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">预计成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">预计子树成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">实际行数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">预计行数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">实际执行次数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">预计 CPU 成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">预计 IO 成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">并行</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">实际重新绑定次数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">预计重新绑定次数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">实际后退次数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">预计后退次数</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">分区</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">热门的操作</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">未找到连接。</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">添加连接</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">添加帐户…</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;默认值&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">正在加载…</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">服务器组</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;默认值&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">添加新组…</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;不保存&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} 是必需的。</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">将剪裁 {0}。</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">记住密码</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">帐户</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">刷新帐户凭据</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Azure AD 租户</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">名称(可选)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">高级…</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">必须选择一个帐户</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">数据库</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">文件和文件组</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">完整</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">差异</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">事务日志</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">磁盘</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">使用默认服务器设置</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">压缩备份</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">不压缩备份</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">服务器证书</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">非对称密钥</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">你尚未打开任何包含笔记本/工作簿的文件夹。</target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">打开笔记本</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">结果集仅包含所有匹配项的子集。请使你的搜索更加具体，减少结果。</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">正在搜索... -</target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">在“{0}”中找不到结果(“{1}”除外) - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">“{0}”中未找到任何结果 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">除“{0}”外，未找到任何结果 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">未找到结果。查看您的设置配置排除, 并检查您的 gitignore 文件-</target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">重新搜索</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">取消搜索</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">在所有文件中再次搜索</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">打开设置</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">搜索 {1} 文件中返回的 {0} 个结果</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">切换折叠和展开</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">取消搜索</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">全部展开</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">全部折叠</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">清除搜索结果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">连接</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">通过 SQL Server、Azure 等连接、查询和管理你的连接。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">下一步</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">笔记本</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">开始在一个位置创建你自己的笔记本或笔记本集合。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">扩展</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">通过安装由我们/Microsoft 以及第三方社区(你!)开发的扩展来扩展 Azure Data Studio 的功能。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">设置</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">根据你的偏好自定义 Azure Data Studio。可以配置自动保存和选项卡大小等设置，个性化设置键盘快捷方式，并切换到你喜欢的颜色主题。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">欢迎页面</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">在“欢迎”页面上发现热门功能、最近打开的文件以及建议的扩展。有关如何开始使用 Azure Data Studio 的详细信息，请参阅我们的视频和文档。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">完成</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">用户欢迎教程</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">隐藏欢迎教程</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">了解更多</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">帮助</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">删除行</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">还原当前行</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">消息面板</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">复制</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">全部复制</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">在 Azure 门户中打开</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">正在加载</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">备份名称</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">加载已完成</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">恢复模式</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">备份类型</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">备份文件</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">算法</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">证书或非对称密钥</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">媒体</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">备份到现有媒体集</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">备份到新的媒体集</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">追加到现有备份集</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">覆盖所有现有备份集</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">新建媒体集名称</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">新建媒体集说明</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">在写入到媒体前执行校验和</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">完成后验证备份</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">出错时继续</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">有效期</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">设置备份保留天数</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">仅限复制的备份</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">高级配置</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">压缩</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">设置备份压缩</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">加密</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">事务日志</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">截断事务日志</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">备份日志的末尾</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">可靠性</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">需要媒体名称</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">没有可用的证书或非对称密钥</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">添加文件</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">删除文件</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">输入无效。值必须大于或等于 0。</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">脚本</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">备份</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">只支持备份到文件</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">需要备份文件路径</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">单击</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ 代码</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">或</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ 文本</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">添加代码或文本单元格</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">备份</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">StdIn:</target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">必须启用预览功能才能使用备份</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">数据库上下文外不支持备份命令，请选择数据库并重试。</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL 数据库不支持备份命令。</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">备份</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">展开代码单元格内容</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">数据库</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">折叠代码单元格内容</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">文件和文件组</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">完整</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">差异</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">事务日志</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">磁盘</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">使用默认服务器设置</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">压缩备份</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">不压缩备份</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">服务器证书</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">非对称密钥</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">XML 显示计划</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">结果网格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">添加单元格</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">代码单元格</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">文本单元格</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">下移单元格</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">上移单元格</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">删除</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">添加单元格</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">代码单元格</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">文本单元格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">SQL 内核错误</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">必须选择连接才能运行笔记本单元格</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">显示了前 {0} 行。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">上次运行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">下次运行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">已启用</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">状态</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">类别</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">可运行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">计划</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">上次运行结果</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">之前的运行</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">没有可用于此作业的步骤。</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">错误: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">找不到类型 {0} 的组件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">查找</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">查找</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">上一个匹配项</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">下一个匹配项</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">关闭</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">搜索返回了大量结果，将仅突出显示前 999 个匹配项。</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{1} 个中的 {0} 个</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">无结果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">架构</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">类型</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">运行查询</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">未找到 {0} 呈现器用于输出。它具有以下 MIME 类型: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">安全</target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">未找到选择器 {0} 的组件</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">渲染组件时出错: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">正在加载...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">正在加载...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">编辑</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">退出</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">刷新</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">显示操作</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">删除小组件</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">单击以取消固定</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">单击以固定</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">打开已安装的功能</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">折叠小组件</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">展开小组件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} 是未知容器。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名称</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">目标数据库</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">上次运行</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">下次运行</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">状态</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">上次运行结果</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">之前的运行</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">没有可用于此作业的步骤。</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">错误: </target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">笔记本错误:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">正在加载错误…</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">显示操作</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">未找到匹配项</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">已将搜索列表筛选为 1 个项</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">已将搜索列表筛选为 {0} 个项</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">失败</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">已成功</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">重试</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">已取消</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">正在进行</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">状态未知</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">正在执行</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">正在等待线程</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">重试之间</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">空闲</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">已暂停</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[已过时]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">未计划</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">从未运行</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">加粗</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">倾斜</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">下划线</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">突出显示</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">代码</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">链接</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">列表</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">已排序列表</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">图像</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Markdown 预览切换 - 关闭</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">标题</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">标题 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">标题 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">标题 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">段落</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">插入链接</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">插入图像</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">格式文本视图</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">拆分视图</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Markdown 视图</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">创建创建</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">无法创建见解，因为活动编辑器不是 SQL 编辑器</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">我的小组件</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">配置图表</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">复制为图像</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">未找到要保存的图表</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">另存为图像</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">将图表保存到路径: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">图表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">水平条</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">条形图</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">折线图</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">饼图</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">散点图</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">时序</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">图像</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">计数</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">表</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">圆环图</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">未能获得数据集的行来绘制图表。</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">不支持图表类型“{0}”。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">内置图表</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">要显示的图表的最大行数。警告: 增加行数可能会影响性能。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">关闭</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">已存在同名的服务器组。</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">系列 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">表格中不包含有效的图像</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">已超过内置图表的最大行数，仅使用了前 {0} 行。要配置该值，可以打开用户设置并搜索:"builtinCharts. maxRowCount"。</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">不再显示</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">正在连接: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">正在运行命令: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">正在打开新查询: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">无法连接，因为未提供服务器信息</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">由于错误 {0} 而无法打开 URL</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">这将连接到服务器 {0}</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">确定要连接吗?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">打开(&amp;&amp;O)</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">正在连接查询文件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">{0} 已被替换为用户设置中的 {1}。</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">{0} 已被替换为工作区设置中的 {1}。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">连接列表中保存的最近使用的连接数量上限</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">要使用的默认 SQL 引擎。这将驱动 .sql 文件中的默认语言提供程序，以及创建新连接时使用的默认语言提供程序。</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">在打开连接对话框或执行粘贴时尝试分析剪贴板的内容。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">连接状态</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">提供程序的公用 ID</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">提供程序的显示名称</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">提供程序的笔记本内核别名</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">服务器类型的图标路径</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">连接选项</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">树提供程序的用户可见名称</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">提供程序的 ID，必须与注册树数据提供程序时的 ID 相同，且必须以 "connectionDialog/" 开头</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">此容器的唯一标识符。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">将在选项卡中显示的容器。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">提供一个或多个仪表板容器，让用户添加其仪表板。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">仪表板容器中未指定用于扩展的 ID。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">仪表板容器中未指定用于扩展的容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">必须在每个空间定义恰好 1 个仪表板容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">仪表板容器中为扩展定义了未知的容器类型。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">将在此选项卡中显示的 controlhost。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">“{0}”部分具有无效内容。请与扩展所有者联系。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">将在此选项卡中显示的小组件或 Web 视图的列表。</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">扩展预期小组件容器中存在小组件或 Web 视图。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">将在此选项卡中显示的由模型支持的视图。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">此导航部分的唯一标识符。将传递到任何请求的扩展。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(可选) UI 中用于表示此导航部分的图标。可以是文件路径或可设置主题的配置</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">使用浅色主题时的图标路径</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">使用深色主题时的图标路径</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">要向用户显示的导航部分的标题。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">将在此导航部分显示的容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">将在此导航部分显示的仪表板容器的列表。</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">未在导航部分为扩展指定标题。</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">未在导航部分为扩展指定容器。</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">必须在每个空间定义恰好 1 个仪表板容器。</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION 内的 NAV_SECTION 是一个无效的扩展容器。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">将在此选项卡中显示的 Web 视图。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">将在此选项卡中显示的小组件列表。</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">扩展预期小组件容器中存在控件列表。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">编辑</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">退出</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">刷新</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">显示操作</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">删除小组件</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">单击以取消固定</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">单击以固定</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">打开已安装的功能</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">折叠小组件</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">展开小组件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} 是未知容器。</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">创建创建</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">此选项卡的唯一标识符。将传递到任何请求的扩展。</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">无法创建见解，因为活动编辑器不是 SQL 编辑器</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">将向用户显示的选项卡标题。</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">我的小组件</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">将向用户显示的此选项卡的说明。</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">配置图表</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">此条件必须为 true 才能显示此项</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">复制为图像</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">定义此选项卡兼容的连接类型。如果未设置，则默认为 "MSSQL"</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">未找到要保存的图表</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">将在此选项卡中显示的容器。</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">另存为图像</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">是始终显示此选项卡还是仅当用户添加时显示。</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">此选项卡是否应用作连接类型的“开始”选项卡。</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">将图表保存到路径: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">此选项卡所属组的唯一标识符，主页组的值: 主页。</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(可选) UI 中用于表示此选项卡的图标。可以是文件路径或可设置主题的配置</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">使用浅色主题时的图标路径</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">使用深色主题时的图标路径</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">提供一个或多个选项卡，让用户添加到其仪表板。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">没有为扩展指定标题。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">没有可显示的已指定说明。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">没有为扩展指定容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">必须在每个空间定义恰好 1 个仪表板容器</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">此选项卡组的唯一标识符。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">选项卡组的标题。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">为用户提供一个或多个选项卡组以添加到他们的仪表板。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">没有为选项卡组指定 ID。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">没有为选项卡组指定标题。</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">管理</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">监视</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">性能</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">安全性</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">疑难解答</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">设置</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">数据库选项卡</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">数据库</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">添加代码</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">添加文本</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">仪表板</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">创建文件</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">无法显示内容: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">可以省略属性 "icon"，若不省略则必须是字符串或文字，例如 "{dark, light}"</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">添加单元格</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">定义要在仪表板上显示的属性</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">代码单元格</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">用作属性标签的值</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">文本单元格</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">对象中要针对该值访问的值</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">全部运行</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">指定要忽略的值</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">单元格</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">在忽略或没有值时显示的默认值</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">代码</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">用于定义仪表板属性的风格</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">文本</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">风格的 ID</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">运行单元格</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">使用这种风格的条件</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; 上一步</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">用于比较的字段</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">下一步 &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">用于比较的运算符</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">未在此模型中找到具有 URI {0} 的单元格</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">用于和字段比较的值</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">单元格运行失败 - 有关详细信息，请参阅当前所选单元格输出中的错误。</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">数据库页面要显示的属性</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">服务器页面要显示的属性</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">定义此提供程序支持仪表板</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">提供程序 ID (如 MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">要在仪表板上显示的属性值</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">此条件必须为 true 才能显示此项</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">是否隐藏小组件的标题，默认值为 false</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">容器的标题</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">网格中组件的行</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">网格中组件的行跨度。默认值为 1。使用 "*" 设置为网格中的行数。</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">网格中组件的列</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">网格中组件的列跨度。默认值为 1。使用 "*" 设置为网格中的列数。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">此选项卡的唯一标识符。将传递到任何请求的扩展。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">扩展选项卡未知或未安装。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">数据库属性</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">启用或禁用属性小组件</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">要显示的属性值</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">属性的显示名称</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">数据库信息对象中的值</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">指定要忽略的特定值</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">恢复模式</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">上次数据库备份</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">上次日志备份</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">兼容级别</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">所有者</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">自定义数据库仪表板页面</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜索</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">自定义数据库仪表板选项卡</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">服务器属性</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">启用或禁用属性小组件</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">要显示的属性值</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">属性的显示名称</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">服务器信息对象中的值</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">计算机名</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">OS 版本</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜索</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">自定义服务器仪表板页面</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">自定义服务器仪表板选项卡</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">主页</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">未能更改数据库</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">显示操作</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">未找到匹配项</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">已将搜索列表筛选为 1 个项</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">已将搜索列表筛选为 {0} 个项</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">架构</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">类型</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">正在加载对象</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">正在加载数据库</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">对象加载已完成。</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">数据库加载已完成。</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">按类型名称搜索(t:、v:、f: 或 sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">搜索数据库</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">无法加载对象</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">无法加载数据库</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">运行查询</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">正在加载 {0}</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">{0} 加载已完成</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">自动刷新: 关</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">上次更新时间: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">没有可显示的结果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">添加一个可以查询服务器或数据库并以多种方式(如图表、总数等)显示结果的小组件。</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">用于缓存见解结果的唯一标识符。</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">要运行的 SQL 查询。将返回恰好 1 个结果集。</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[可选] 包含查询的文件的路径。未设置“查询”时使用</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[可选] 自动刷新间隔(分钟数)；如果未设置，则不自动刷新</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">要使用的操作</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">操作的目标数据库；可使用格式 "${ columnName }" 以便由数据确定列名。</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">操作的目标服务器；可使用格式 "${ columnName }" 以便由数据确定列名。</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">操作的目标用户；可使用格式 "${ columnName }" 以便由数据确定列名。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">见解的标识符</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">向仪表板提供见解。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">无法用给定的数据显示图表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">将查询结果显示为仪表板上的图表</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">映射“列名称”-&gt;“颜色”。例如，添加 'column1': red 以确保此列使用红色</target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">表示图表图例的首选位置和可见性。这些是查询中的列名称，并映射到每个图表条目的标签</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">如果 dataDirection 为 horizontal，则将其设置为 true 将使用第一列的值作为图例。</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">如果 dataDirection 为 vertical，则将其设置为 true 将使用列名称作为图例。</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">定义是从列(垂直)还是从行(水平)读取数据。对于时序，将忽略此设置，因为方向必须为垂直。</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">如果设置了 showTopNData，则只在图表中显示前 N 个数据。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">Y 轴的最小值</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">y 轴的最大值</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">y 轴的标签</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">x 轴的最小值</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">x 轴的最大值</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">x 轴的标签</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">指示图表数据集的数据属性。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">对于结果集中的每一列，将行 0 中的值显示为计数后跟列名称。例如支持“1 正常”、“3 不正常”，其中“正常”是列名称，1 表示第 1 行单元格 1 中的值</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">显示图像，例如由 R 查询使用 ggplot2 返回的图像</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">期望的格式 - 是 JPEG、PNG 还是其他格式?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">这是以十六进制、base64 还是其他格式进行编码的?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">在简单表中显示结果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">正在加载属性</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">属性加载已完成</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">无法加载仪表板属性</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">数据库连接</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">数据源连接</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">数据源组</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">保存的连接按添加的日期排序。</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">保存的连接按其显示名称按字母顺序排序。</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">控制已保存连接和连接组的排序顺序。</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">启动配置</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">如果要在 Azure Data Studio 启动时默认显示“服务器”视图，则为 true；如果应显示上次打开的视图，则为 false</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">视图的标识符。使用标识符通过 "vscode.window.registerTreeDataProviderForView" API 注册数据提供程序。同时将 "onView:${id}" 事件注册到 "activationEvents" 以触发激活扩展。</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">用户可读的视图名称。将显示它</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">为真时才显示此视图的条件</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">向编辑器提供视图</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">向“活动”栏中的“数据资源管理器”容器提供视图</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">向“提供的视图”容器提供视图</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">无法在视图容器“{1}”中注册多个具有相同 ID (“{0}”) 的视图</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">视图容器“{1}”中已注册有 ID 为“{0}”的视图</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">视图必须为数组</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">属性“{0}”是必需的，其类型必须是 "string"</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">属性“{0}”可以省略，否则其类型必须是 "string"</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">服务器</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">连接</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">显示连接</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">断开连接</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">刷新</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">启动时显示“编辑数据 SQL”窗格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">运行</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">释放编辑失败，出现错误:</target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">显示 SQL 窗格</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">关闭 SQL 窗格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">最大行数:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">删除行</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">还原当前行</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">另存为 CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">另存为 JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">另存为 Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">另存为 XML</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">复制</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">带标头复制</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">全选</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">仪表板选项卡({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">标题</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">说明</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">仪表板见解({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">ID</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">时间</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">从库中获取扩展信息</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">扩展 ID</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">找不到扩展“{0}”。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">显示建议</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">安装扩展</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">创作扩展...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">不再显示</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio 具有扩展建议。</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio 具有针对数据可视化的扩展建议。
+安装后，你可以选择“可视化工具”图标来可视化查询结果。</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">全部安装</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">显示建议</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">必须提供扩展建议的方案类型。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Azure Data Studio 建议使用此扩展。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">作业</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">笔记本</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">警报</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">代理</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">运算符</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">上一个匹配项</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">已启用</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">响应之间的延迟(秒)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">类别名称</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">查看适用规则</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">步骤 ID</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">查看 {0} 的适用规则</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">步骤名称</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">调用评估</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">调用 {0} 的评估</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">导出为脚本</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">查看所有规则并了解有关 GitHub 的详细信息</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">创建 HTML 报表</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">已保存报表。是否要打开它?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">打开</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">消息</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">数据</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">连接</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">查询编辑器</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">笔记本</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">仪表板</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">探查器</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">步骤</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">仪表板选项卡({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">标题</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">说明</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">仪表板见解({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">ID</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">名称</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">时间</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">上次运行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">下次运行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">已启用</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">状态</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">类别</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">可运行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">计划</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">上次运行结果</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">之前的运行</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">没有可用于此作业的步骤。</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">错误: </target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">表格中不包含有效的图像</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">创建日期:</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">笔记本错误:</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">作业错误:</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">已固定</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">最近运行</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">已运行</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">更多</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">编辑</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">目标数据库</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">关闭</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">上次运行</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">转换单元格</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">下次运行</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">在上方运行单元格</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">状态</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">在下方运行单元格</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">上次运行结果</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">在上方插入代码</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">之前的运行</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">在下方插入代码</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">没有可用于此作业的步骤。</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">在上方插入文本</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">错误: </target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">在下方插入文本</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">折叠单元格</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">展开单元格</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">生成参数单元格</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">删除参数单元格</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">清除结果</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">笔记本错误:</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">启动笔记本会话时出错</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">由于未知原因，服务器未启动</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">电子邮件地址</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">未找到内核 {0}。将改为使用默认内核。</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">已启用</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">系列 {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">帐户名称</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">关闭</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">凭据名称</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="zh-Hans">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated"># 个注入参数
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">说明</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">请选择一个连接来运行此内核的单元格</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">未能删除单元格。</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">未能更改内核。将使用内核 {0}。错误为: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">由于以下错误而未能更改内核: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">更改上下文失败: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">无法启动会话: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">关闭笔记本时发生客户端会话错误: {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">未找到提供程序 {0} 的笔记本管理器</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">已启用</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">更多</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">编辑</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">关闭</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">转换单元格</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">在上方运行单元格</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">在下方运行单元格</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">在上方插入代码</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">在下方插入代码</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">在上方插入文本</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">在下方插入文本</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">折叠单元格</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">展开单元格</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">生成参数单元格</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">删除参数单元格</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">清除结果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">添加单元格</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">代码单元格</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">文本单元格</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">下移单元格</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">上移单元格</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">删除</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">添加单元格</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">代码单元格</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">文本单元格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">参数</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">请选择活动单元格并重试</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">运行单元格</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">取消执行</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">上次运行时出错。请单击以重新运行</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">展开代码单元格内容</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">折叠代码单元格内容</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">加粗</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">倾斜</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">下划线</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">突出显示</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">代码</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">链接</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">列表</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">已排序列表</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">图像</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Markdown 预览切换 - 关闭</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">标题</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">标题 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">标题 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">标题 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">段落</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">插入链接</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">插入图像</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">格式文本视图</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">拆分视图</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Markdown 视图</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">未找到 {0} 呈现器用于输出。它具有以下 MIME 类型: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">安全</target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">未找到选择器 {0} 的组件</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">渲染组件时出错: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">单击</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ 代码</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">或</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ 文本</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">添加代码或文本单元格</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">添加代码单元格</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">添加文本单元格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">StdIn:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;双击以编辑&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;在此处添加内容...&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">查找</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">查找</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">上一个匹配项</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">下一个匹配项</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">关闭</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">搜索返回了大量结果，将仅突出显示前 999 个匹配项。</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0} 个(共 {1} 个)</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">无结果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">添加代码</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">添加文本</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">创建文件</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">无法显示内容: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">添加单元格</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">代码单元格</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">文本单元格</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">全部运行</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">单元格</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">代码</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">文本</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">运行单元格</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; 上一步</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">下一步 &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">未在此模型中找到具有 URI {0} 的单元格</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">单元格运行失败 - 有关详细信息，请参阅当前所选单元格输出中的错误。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新建笔记本</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新建笔记本</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">设置工作区并打开</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">SQL 内核: 在单元格中发生错误时停止笔记本执行。</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(预览)显示当前笔记本提供程序的所有内核。</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">允许笔记本运行 Azure Data Studio 命令。</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">启用双击来编辑笔记本中的文本单元格</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">文本显示为格式文本(也称为 "WSIWYG")。</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">Markdown 显示在左侧，右侧是呈现的文本的预览。</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">文本显示为 Markdown。</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">用于文本单元格的默认编辑模式</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(预览)在笔记本元数据中保存连接名称。</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">控制笔记本 Markdown 预览中使用的行高。此数字与字号相关。</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(预览)在差异编辑器中显示呈现的笔记本。</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">笔记本格式文本编辑器的撤消历史记录中存储的最大更改数。</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">搜索笔记本</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">配置glob模式以在全文本搜索和快速打开中排除文件和文件夹。从“＃files.exclude＃”设置继承所有glob模式。在[此处](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)了解更多关于glob模式的信息</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">匹配文件路径所依据的 glob 模式。设置为 true 或 false 可启用或禁用该模式。</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">对匹配文件的同级文件的其他检查。使用 $(basename) 作为匹配文件名的变量。</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated">此设置已被弃用，将回退到 "search.usePCRE2"。</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">已弃用。请考虑使用 "search.usePCRE2" 获取对高级正则表达式功能的支持。</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">启用后，搜索服务进程将保持活动状态，而不是在一个小时不活动后关闭。这将使文件搜索缓存保留在内存中。</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">控制在搜索文件时是否使用 `.gitignore` 和 `.ignore` 文件。</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">控制在搜索文件时是否使用全局 `.gitignore` 和 `.ignore` 文件。</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">控制 Quick Open 文件结果中是否包括全局符号搜索的结果。</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">是否在 Quick Open 的文件结果中包含最近打开的文件。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">历史记录条目按与筛选值的相关性排序。首先显示更相关的条目。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">历史记录条目按最近时间排序。首先显示最近打开的条目。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">控制在快速打开中筛选时编辑器历史记录的排序顺序。</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">控制是否在搜索中跟踪符号链接。</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">若搜索词全为小写，则不区分大小写进行搜索，否则区分大小写进行搜索。</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">控制“搜索”视图是否读取或修改 macOS 的共享查找剪贴板。</target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">控制搜索功能是显示在侧边栏，还是显示在水平空间更大的面板区域。</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">此设置已弃用。请改用搜索视图的上下文菜单。</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">结果少于10个的文件将被展开。其他的则被折叠。</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">控制是折叠还是展开搜索结果。</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">控制在选择或替换匹配项时是否打开“替换预览”视图。</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">控制是否显示搜索结果所在的行号。</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">是否在文本搜索中使用 pcre2 正则表达式引擎。这允许使用一些高级正则表达式功能, 如前瞻和反向引用。但是, 并非所有 pcre2 功能都受支持-仅支持 javascript 也支持的功能。</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">弃用。当使用仅 PCRE2 支持的正则表达式功能时，将自动使用 PCRE2。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">当搜索视图较窄时将操作栏置于右侧，当搜索视图较宽时，将它紧接在内容之后。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">始终将操作栏放置在右侧。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">在搜索视图中控制操作栏的位置。</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">在键入时搜索所有文件。</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">当活动编辑器没有选定内容时，从离光标最近的字词开始进行种子设定搜索。</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">聚焦搜索视图时，将工作区搜索查询更新为编辑器的所选文本。单击时或触发 `workbench.views.search.focus` 命令时会发生此情况。</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">启用"#search.searchOnType"后，控制键入的字符与开始搜索之间的超时(以毫秒为单位)。禁用"搜索.searchOnType"时无效。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">双击选择光标下的单词。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">双击将在活动编辑器组中打开结果。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">双击将在编辑器组中的结果打开到一边，如果尚不存在，则创建一个结果。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">配置在搜索编辑器中双击结果的效果。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">结果按文件夹和文件名按字母顺序排序。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">结果按文件名排序，忽略文件夹顺序，按字母顺序排列。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">结果按文件扩展名的字母顺序排序。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">结果按文件的最后修改日期按降序排序。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">结果按每个文件的计数降序排序。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">结果按每个文件的计数以升序排序。</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">控制搜索结果的排序顺序。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">正在加载内核…</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">正在更改内核…</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">附加到</target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">内核</target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">正在加载上下文…</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">更改连接</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">选择连接</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">无内核</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">此笔记本无法使用参数运行，因为不支持内核。请使用支持的内核和格式。[了解详细信息](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">在添加参数单元格之前，此笔记本无法使用参数运行。[了解详细信息] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">在将参数添加到参数单元格之前，此笔记本无法使用参数运行。[了解详细信息] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">清除结果</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">受信任</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">不受信任</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">折叠单元格</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">展开单元格</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">使用参数运行</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">无</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新建笔记本</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">查找下一个字符串</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">查找上一个字符串</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">搜索结果</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">找不到搜索路径: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">笔记本</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">你尚未打开任何包含笔记本/工作簿的文件夹。</target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">打开笔记本</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">结果集仅包含所有匹配项的子集。请使你的搜索更加具体，减少结果。</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">正在搜索... -</target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">在“{0}”中找不到结果(“{1}”除外) - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">“{0}”中未找到任何结果 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">除“{0}”外，未找到任何结果 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">未找到结果。查看您的设置配置排除, 并检查您的 gitignore 文件-</target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">重新搜索</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">在所有文件中再次搜索</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">打开设置</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">搜索 {1} 文件中返回的 {0} 个结果</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">切换折叠和展开</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">取消搜索</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">全部展开</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">全部折叠</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">清除搜索结果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">搜索: 键入搜索词，然后按 Enter 键搜索或按 Esc 键取消</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜索</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">未在此模型中找到具有 URI {0} 的单元格</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">单元格运行失败 - 有关详细信息，请参阅当前所选单元格输出中的错误。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">请运行此单元格以查看输出。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">此视图为空。请单击“插入单元格”按钮，将单元格添加到此视图。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">复制失败，出现错误 {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">显示图表</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">显示表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">未找到 {0} 呈现器用于输出。它具有以下 MIME 类型: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(安全)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">显示 Plotly 图形时出错: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">未找到连接。</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">添加连接</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">在对象资源管理器 viewlet 中使用的服务器组面板。</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">在对象资源管理器 viewlet 中自动展开服务器组。</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(预览)使用“服务器”视图和“连接”对话框的新异步服务器树，支持动态节点筛选等新功能。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">数据</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">连接</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">查询编辑器</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">笔记本</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">仪表板</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">探查器</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">内置图表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">指定视图模板</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">指定会话模板</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">探查器筛选器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">连接</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">断开连接</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">开始</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">新建会话</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">暂停</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">继续</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">清除数据</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">是否确实要清除数据?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">自动滚动: 开</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">自动滚动: 关</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">切换已折叠的面板</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">编辑列</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">查找下一个字符串</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">查找上一个字符串</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">启动探查器</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">筛选器…</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">清除筛选器</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">是否确实要清除筛选器?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">选择视图</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">选择会话</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">选择会话:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">选择视图:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">文本</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">标签</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">详细信息</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">查找</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">查找</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">上一个匹配项</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">下一个匹配项</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">关闭</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">搜索返回了大量结果，将仅突出显示前 999 个匹配项。</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{1} 个中的 {0} 个</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">无结果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">用于事件文本的探查器编辑器。只读</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">事件(已筛选): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">事件: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">事件计数</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">另存为 CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">另存为 JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">另存为 Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">另存为 XML</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">导出到 JSON 时，将不会保存结果编码，请记得在创建文件后使用所需编码进行保存。</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">备份数据源不支持保存到文件</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">复制</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">带标头复制</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">全选</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">最大化</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">还原</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">图表</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">可视化工具</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">选择 SQL 语言</target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">更改 SQL 语言提供程序</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">SQL 语言风格</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">更改 SQL 引擎提供程序</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">使用引擎 {0} 的连接已存在。若要更改，请先断开或更改连接</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">当前没有活动的文本编辑器</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">选择语言提供程序</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">XML 显示计划</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">结果网格</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">已超过筛选/排序的最大行计数。若要更新它，可以转到“用户设置”并更改设置: "queryEditor.results.inMemoryDataProcessingThreshold"</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">关注当前查询</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">运行查询</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">运行当前查询</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">复制查询和结果</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">已成功复制查询和结果。</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">使用实际计划运行当前查询</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">取消查询</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">刷新 IntelliSense 缓存</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">切换查询结果</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">在查询和结果之间切换焦点</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">需要编辑器参数才能执行快捷方式</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">分析查询</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">命令已成功完成</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">命令失败:</target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">请连接到服务器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">消息面板</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">复制</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">全部复制</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">查询结果</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新建查询</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">查询编辑器</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">为 true 时，将在将结果保存为 CSV 时包含列标题</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">保存为 CSV 时在值之间使用的自定义分隔符</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">将结果保存为 CSV 时用于分隔行的字符</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">将结果保存为 CSV 时用于封装文本字段的字符</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">将结果保存为 CSV 时使用的文件编码</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">为 true 时，将在将结果保存为 XML 时设置 XML 输出的格式</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">将结果保存为 XML 时使用的文件编码</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">启用结果流式处理；包含极少轻微的可视化问题</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">用于从“结果视图”复制结果的配置选项</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">用于从“结果视图”复制多行结果的配置选项</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(实验性)在出现的结果中使用优化的表。某些功能可能缺失或处于准备阶段。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">控制允许在内存中进行筛选和排序的最大行数。如果超过最大行数，则将禁用排序和筛选。警告: 增加此值可能会影响性能。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">是否在保存结果后打开 Azure Data Studio 中的文件。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">是否应显示每个批处理的执行时间</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">自动换行消息</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">从“查询结果”打开“图表查看器”时要使用的默认图表类型</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">将禁用选项卡着色</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">每个编辑器选项卡的上边框颜色将与相关服务器组匹配</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">每个编辑器选项卡的背景色将与相关服务器组匹配</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">控制如何根据活动连接的服务器组为选项卡着色</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">控制是否显示标题中选项卡的连接信息。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">提示保存生成的 SQL 文件</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">设置键绑定 workbench.action.query.shortcut{0}，将快捷方式文本作为过程调用或查询执行运行。查询编辑器中的选中的文本将在查询结尾处作为参数进行传递，也可以使用 {arg} 加以引用</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新建查询</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">运行</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">解释</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">实际</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">断开连接</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">更改连接</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">连接</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">启用 SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">禁用 SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">选择数据库</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">未能更改数据库</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">未能更改数据库: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">导出为笔记本</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">结果</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">消息</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">已用时间</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">行数</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} 行</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">正在执行查询…</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">执行状态</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">选择摘要</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">平均值: {0} 计数: {1} 总和: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">结果网格和消息</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">控制字体系列。</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">控制字体粗细。</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">控制字体大小(像素)。</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">控制字母间距(像素)。</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">控制行高(像素)</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">控制单元格边距(像素)</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">自动调整初始结果的列宽。如果存在大量的列或大型单元格，可能出现性能问题</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">自动调整大小的列的最大宽度(像素)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">切换查询历史记录</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">删除</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">清除所有历史记录</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">打开查询</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">运行查询</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">切换查询历史记录捕获</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">暂停查询历史记录捕获</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">开始查询历史记录捕获</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">成功</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">失败</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">没有可显示的查询。</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">查询历史记录</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">QueryHistory</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">是否启用查询历史记录捕获。若为 false，则不捕获所执行的查询。</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">清除所有历史记录</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">暂停查询历史记录捕获</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">开始查询历史记录捕获</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">查看</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">查询历史记录(&amp;&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">查询历史记录</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">查询计划</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">操作</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">对象</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">预计成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">预计子树成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">实际行数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">预计行数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">实际执行次数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">预计 CPU 成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">预计 IO 成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">并行</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">实际重新绑定次数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">预计重新绑定次数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">实际后退次数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">预计后退次数</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">分区</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">热门的操作</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">资源查看器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">刷新</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">打开链接时出错: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">执行命令“{0}”时出错: {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">资源查看器树</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">资源的标识符。</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">用户可读的视图名称。将显示它</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">资源图标的路径。</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">将资源分配给资源视图</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">属性“{0}”是必需的，其类型必须是 "string"</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">属性“{0}”可以省略，否则其类型必须是 "string"</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">还原</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">还原</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">必须启用预览功能才能使用还原</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">服务器上下文外不支持还原命令，请选择服务器或数据库并重试。</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL 数据库不支持还原命令。</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">还原</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">执行 Create 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">执行 Drop 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">选择前 1000 项</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">执行 Execute 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">执行 Alter 脚本</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">编辑数据</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">选择前 1000 项</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">选取 10 个</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">执行 Create 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">执行 Execute 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">执行 Alter 脚本</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">执行 Drop 脚本</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">刷新</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">刷新节点“{0}”时出错: {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} 个正在执行的任务</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">查看</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">任务</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">任务(&amp;&amp;T)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">切换任务</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">成功</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">失败</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">正在进行</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">尚未开始</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">已取消</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">正在取消</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">没有可显示的任务历史记录。</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">任务历史记录</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">任务错误</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">任务取消失败。</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">脚本</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">没有可提供视图数据的已注册数据提供程序。</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">刷新</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">全部折叠</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">运行命令 {1} 错误: {0}。这可能是由提交 {1} 的扩展引起的。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">关闭</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">预览功能可让你全面访问新功能和改进功能，从而提升你在 Azure Data Studio 中的体验。有关预览功能的详细信息，请访问[此处]({0})。是否要启用预览功能?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">是(推荐)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">否，不再显示</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">此功能页面处于预览状态。预览功能引入了新功能，这些功能有望成为产品的永久组成部分。它们是稳定的，但需要改进额外的辅助功能。欢迎在功能开发期间提供早期反馈。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">预览</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">创建连接</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">通过连接对话连接到数据库实例。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">运行查询</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">通过查询编辑器与数据交互。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">创建笔记本</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">使用本机笔记本编辑器生成新笔记本。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">部署服务器</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">在所选平台上创建关系数据服务的新实例。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">资源</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">历史记录</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名称</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">位置</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">显示更多</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">启动时显示欢迎页</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">有用链接</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">开始使用</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">发现 Azure Data Studio 所提供的功能，并了解如何充分利用这些功能。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">文档</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">访问文档中心，以获取快速入门、操作指南以及 PowerShell、API 等的参考。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">视频</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Azure Data Studio 概述</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Azure Data Studio 笔记本简介 | 已公开的数据</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">扩展</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">全部显示</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">了解更多</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">连接</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">通过 SQL Server、Azure 等连接、查询和管理你的连接。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">下一步</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">笔记本</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">开始在一个位置创建你自己的笔记本或笔记本集合。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">扩展</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">通过安装由我们/Microsoft 以及第三方社区(你!)开发的扩展来扩展 Azure Data Studio 的功能。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">设置</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">根据你的偏好自定义 Azure Data Studio。可以配置自动保存和选项卡大小等设置，个性化设置键盘快捷方式，并切换到你喜欢的颜色主题。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">欢迎页面</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">在“欢迎”页面上发现热门功能、最近打开的文件以及建议的扩展。有关如何开始使用 Azure Data Studio 的详细信息，请参阅我们的视频和文档。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">完成</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">用户欢迎教程</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">隐藏欢迎教程</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">了解更多</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">帮助</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">欢迎</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 管理包</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 管理包</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">SQL Server 管理包是热门数据库管理扩展的一个集合，可帮助你管理 SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server 代理</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">SQL Server 导入</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server Dacpac</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">使用 Azure Data Studio 功能丰富的查询编辑器编写和执行 PowerShell 脚本</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">数据虚拟化</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">使用 SQL Server 2019 虚拟化数据，并使用交互式向导创建外部表</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">使用 Azure Data Studio 连接、查询和管理 Postgres 数据库</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">已安装对 {0} 的支持。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">安装对 {0} 的额外支持后，将重载窗口。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">正在安装对 {0} 的额外支持...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">找不到对 {0} (ID: {1}) 的支持。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">新建连接</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">新建查询</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">新建笔记本</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">部署服务器</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">欢迎</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">新建</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">打开…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">打开文件…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">打开文件夹…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">开始教程</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">关闭快速浏览栏</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">是否希望快速浏览 Azure Data Studio?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">欢迎使用!</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">打开路径为 {1} 的文件夹 {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">安装</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">安装 {0} 键映射</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">安装对 {0} 的额外支持</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">已安装</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">已安装 {0} 按键映射</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">已安装 {0} 支持</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">详细信息</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">欢迎页面的背景色。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">开始</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">新建连接</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">新建查询</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">新建笔记本</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">打开文件</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">打开文件</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">部署</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">新建部署…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">最近使用</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">更多...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">没有最近使用的文件夹</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">帮助</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">开始使用</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">文档</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">报告问题或功能请求</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">GitHub 存储库</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">发行说明</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">启动时显示欢迎页</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">自定义</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">扩展</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">下载所需的扩展，包括 SQL Server 管理包等</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">键盘快捷方式</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">查找你喜欢的命令并对其进行自定义</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">颜色主题</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">使编辑器和代码呈现你喜欢的外观</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">了解</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">查找并运行所有命令</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">使用命令面板快速访问和搜索命令 ({0})</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">了解最新版本中的新增功能</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">每月推出新的月度博客文章，展示新功能</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">在 Twitter 上关注我们</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">保持了解社区如何使用 Azure Data Studio 并与工程师直接交谈。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">帐户</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">链接的帐户</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">关闭</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">没有链接的帐户。请添加一个帐户。</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">添加帐户</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">你没有启用云。请转到“设置”-&gt; 搜索 Azure 帐户配置 -&gt; 至少启用一个云</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">你没有选择任何身份验证提供程序。请重试。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">添加帐户时出错</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">需要刷新此帐户的凭据。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">关闭</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">正在添加帐户...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">用户已取消刷新帐户</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Azure 帐户</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Azure 租户</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">复制并打开</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">用户代码</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">网站</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">无法启动自动 OAuth。自动 OAuth 已在进行中。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">需要连接才能与 adminservice 交互</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">未注册处理程序</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">需要连接才能与评估服务交互</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">未注册处理程序</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">高级属性</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">放弃</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">服务器说明(可选)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">清空列表</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">已清空最新连接列表</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">确定要删除列表中的所有连接吗?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">删除</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">获取当前连接字符串</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">连接字符串不可用</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">没有可用的活动连接</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">浏览</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">在此处键入以筛选列表</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">筛选器连接</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">正在应用筛选器</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">正在删除筛选器</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">已应用筛选器</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">已删除筛选器</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">保存的连接</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">保存的连接</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">连接浏览器树</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">连接错误</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">由于 Kerberos 错误，连接失败。</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">可在 {0} 处获取有关配置 Kerberos 的帮助</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">如果之前已连接，可能需要重新运行 kinit。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">连接</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">正在连接</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">连接类型</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">最近</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">连接详细信息</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">连接</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">最近的连接</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">没有最近的连接</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">未能获取 Azure 帐户令牌用于连接</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">连接未被接受</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">确定要取消此连接吗?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">添加帐户…</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;默认值&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">正在加载…</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">服务器组</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;默认值&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">添加新组…</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;不保存&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} 是必需的。</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">将剪裁 {0}。</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">记住密码</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">帐户</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">刷新帐户凭据</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Azure AD 租户</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">名称(可选)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">高级…</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">必须选择一个帐户</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">已连接到</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">已断开连接</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">未保存的连接</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">打开仪表板扩展</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">目前尚未安装仪表板扩展。转“到扩展管理器”以浏览推荐的扩展。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">步骤 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">完成</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">初始化编辑数据会话失败:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">关闭</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">操作</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">复制详细信息</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">错误</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">警告</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">信息</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">忽略</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">选定的路径</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">文件类型</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">放弃</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">选择文件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">文件浏览器树</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">加载文件浏览器时出错。</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">文件浏览器错误</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">所有文件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">复制单元格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">未将连接配置文件传递到见解浮出控件</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">见解错误</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">读取以下查询文件时出错:</target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">分析见解配置时出错；找不到查询数组/字符串或查询文件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">项</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">见解详细信息</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">属性</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">见解</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">项</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">项详细信息</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">在下述所有路径中都找不到查询文件:
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">失败</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">已成功</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">重试</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">已取消</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">正在进行</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">状态未知</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">正在执行</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">正在等待线程</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">重试之间</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">空闲</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">已暂停</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[已过时]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">未计划</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">从未运行</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">需要连接才能与 JobManagementService 交互</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">未注册处理程序</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">启动笔记本会话时出错</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">由于未知原因，服务器未启动</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">未找到内核 {0}。将改为使用默认内核。</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="zh-Hans">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="zh-Hans">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">不支持更改未保存文件的编辑器类型</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated"># 个注入参数
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">请选择一个连接来运行此内核的单元格</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">未能删除单元格。</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">未能更改内核。将使用内核 {0}。错误为: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">由于以下错误而未能更改内核: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">更改上下文失败: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">无法启动会话: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">关闭笔记本时发生客户端会话错误: {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">未找到提供程序 {0} 的笔记本管理器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">创建笔记本管理器时未传递 URI</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">笔记本提供程序不存在</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">此笔记本中已存在名为 {0} 的视图。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">SQL 内核错误</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">必须选择连接才能运行笔记本单元格</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">显示了前 {0} 行。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">格式文本</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">拆分视图</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">无法识别 nbformat v{0}.{1}</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">此文件没有有效的笔记本格式</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">单元格类型 {0} 未知</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">无法识别输出类型 {0}</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">{0} 的数据应为字符串或字符串数组</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">无法识别输出类型 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">笔记本提供程序的标识符。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">应向此笔记本提供程序注册哪些文件扩展名</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">此笔记本提供程序应标配哪些内核</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">提供笔记本提供程序。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">单元格魔术方法的名称，如 "%%sql"。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">单元格中包含此单元格魔术方法时要使用的单元格语言</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">此魔术方法指示的可选执行目标，例如 Spark 和 SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">可选内核集，对于 python3、pyspark 和 sql 等有效</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">提供笔记本语言。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">正在加载...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">刷新</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">编辑连接</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">断开连接</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">新建连接</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">新建服务器组</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">编辑服务器组</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">显示活动连接</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">显示所有连接</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">删除连接</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">删除组</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">未能创建对象资源管理器会话</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">多个错误:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">无法展开，因为未找到所需的连接提供程序“{0}”</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">用户已取消</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">防火墙对话已取消</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">正在加载...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">最近的连接</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">服务器</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">服务器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">按事件排序</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">按列排序</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">探查器</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">全部清除</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">应用</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">筛选器</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">删除此子句</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">保存筛选器</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">加载筛选器</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">添加子句</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">字段</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">运算符</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">为 Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">不为 Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">包含</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">不包含</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">开头为</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">开头不为</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">提交行失败:</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">开始执行查询的位置:</target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">已开始执行查询 "{0}"</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">第 {0} 行</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">取消查询失败: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">更新单元格失败:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">由于意外错误，执行失败: {0}	{1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">执行时间总计: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">开始执行查询的位置: 第 {0} 行</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">已开始执行批处理 {0}</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">批处理执行时间: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">复制失败，出现错误 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">未能保存结果。</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">选择结果文件</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (以逗号分隔)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Excel 工作簿</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">纯文本</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">正在保存文件...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">已成功将结果保存到 {0}</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">打开文件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">从</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">到</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">新建防火墙规则</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">你的客户端 IP 地址无权访问此服务器。请登录到 Azure 帐户，然后新建一个防火墙规则以启用访问。</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">详细了解防火墙设置</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">防火墙规则</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">添加我的客户端 IP</target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">添加我的子网 IP 范围</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">添加帐户时出错</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">防火墙规则错误</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">备份文件路径</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">目标数据库</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">还原</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">还原数据库</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">数据库</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">备份文件</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">还原数据库</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">脚本</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">源</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">还原自</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">需要备份文件路径。</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">请输入一个或多个用逗号分隔的文件路径</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">数据库</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">目标</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">还原到</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">还原计划</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">要还原的备份集</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">将数据库文件还原为</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">还原数据库文件详细信息</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">逻辑文件名</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">文件类型</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">原始文件名</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">还原为</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">还原选项</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">结尾日志备份</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">服务器连接</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">常规</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">文件</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">选项</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">备份文件</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">所有文件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">服务器组</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">确定</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">服务器组名称</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">组名称是必需的。</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">组描述</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">组颜色</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">添加服务器组</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">编辑服务器组</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">一个或多个任务正在运行中。确定要退出吗?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="zh-Hans">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">开始</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">显示入门</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">入门(&amp;&amp;S)</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hant/admin-tool-ext-win.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/admin-tool-ext-win.zh-Hant.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/admin-tool-ext-win/out/main" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/admin-tool-ext-win/dist/main" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="adminToolExtWin.noConnectionContextForProp">
         <source xml:lang="en">No ConnectionContext provided for handleLaunchSsmsMinPropertiesDialogCommand</source>

--- a/resources/xlf/zh-hant/agent.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/agent.zh-Hant.xlf
@@ -1,230 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/agent/out/dialogs/scheduleDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="scheduleDialog.newSchedule">
-        <source xml:lang="en">New Schedule</source>
-        <target state="translated">新增排程</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.ok">
+      <trans-unit id="agentDialog.OK">
         <source xml:lang="en">OK</source>
         <target state="translated">確定</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.cancel">
+      <trans-unit id="agentDialog.Cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="scheduleDialog.scheduleName">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">排程名稱</target>
-      </trans-unit>
-      <trans-unit id="scheduleDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">排程</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="createProxy.createProxy">
-        <source xml:lang="en">Create Proxy</source>
-        <target state="translated">建立 Proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.editProxy">
-        <source xml:lang="en">Edit Proxy</source>
-        <target state="translated">編輯 Proxy</target>
-      </trans-unit>
-      <trans-unit id="createProxy.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">一般</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ProxyName">
-        <source xml:lang="en">Proxy name</source>
-        <target state="translated">Proxy 名稱</target>
-      </trans-unit>
-      <trans-unit id="createProxy.CredentialName">
-        <source xml:lang="en">Credential name</source>
-        <target state="translated">認證名稱</target>
-      </trans-unit>
-      <trans-unit id="createProxy.Description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">描述</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SubsystemName">
-        <source xml:lang="en">Subsystem</source>
-        <target state="translated">子系統</target>
-      </trans-unit>
-      <trans-unit id="createProxy.OperatingSystem">
-        <source xml:lang="en">Operating system (CmdExec)</source>
-        <target state="translated">作業系統 (cmdexec)</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationSnapshot">
-        <source xml:lang="en">Replication Snapshot</source>
-        <target state="translated">複寫快照集</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationTransactionLog">
-        <source xml:lang="en">Replication Transaction-Log Reader</source>
-        <target state="translated">複寫交易 - 記錄讀取器</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationDistributor">
-        <source xml:lang="en">Replication Distributor</source>
-        <target state="translated">複寫散發者</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationMerge">
-        <source xml:lang="en">Replication Merge</source>
-        <target state="translated">複寫合併</target>
-      </trans-unit>
-      <trans-unit id="createProxy.ReplicationQueueReader">
-        <source xml:lang="en">Replication Queue Reader</source>
-        <target state="translated">複本佇列讀取器</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASQueryLabel">
-        <source xml:lang="en">SQL Server Analysis Services Query</source>
-        <target state="translated">SQL Server Analysis Services 查詢</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSASCommandLabel">
-        <source xml:lang="en">SQL Server Analysis Services Command</source>
-        <target state="translated">SQL Server Analysis Services 命令</target>
-      </trans-unit>
-      <trans-unit id="createProxy.SSISPackage">
-        <source xml:lang="en">SQL Server Integration Services Package</source>
-        <target state="translated">SQL Server Integration Services 套件</target>
-      </trans-unit>
-      <trans-unit id="createProxy.PowerShell">
-        <source xml:lang="en">PowerShell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="createProxy.subSystemHeading">
-        <source xml:lang="en">Active to the following subsytems</source>
-        <target state="translated">對以下子系統有效</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="pickSchedule.jobSchedules">
-        <source xml:lang="en">Job Schedules</source>
-        <target state="translated">作業排程</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.availableSchedules">
-        <source xml:lang="en">Available Schedules:</source>
-        <target state="translated">可用的排程:</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleName">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.scheduleID">
-        <source xml:lang="en">ID</source>
-        <target state="translated">識別碼</target>
-      </trans-unit>
-      <trans-unit id="pickSchedule.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">描述</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="createOperator.createOperator">
-        <source xml:lang="en">Create Operator</source>
-        <target state="translated">建立運算子</target>
-      </trans-unit>
-      <trans-unit id="createOperator.editOperator">
-        <source xml:lang="en">Edit Operator</source>
-        <target state="translated">編輯運算子</target>
-      </trans-unit>
-      <trans-unit id="createOperator.General">
-        <source xml:lang="en">General</source>
-        <target state="translated">一般</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">通知</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="createOperator.Enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">啟用</target>
-      </trans-unit>
-      <trans-unit id="createOperator.EmailName">
-        <source xml:lang="en">E-mail Name</source>
-        <target state="translated">電子郵件名稱</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerEmailName">
-        <source xml:lang="en">Pager E-mail Name</source>
-        <target state="translated">頁面巡覽區電子郵件名稱</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerMondayCheckBox">
-        <source xml:lang="en">Monday</source>
-        <target state="translated">星期一</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerTuesdayCheckBox">
-        <source xml:lang="en">Tuesday</source>
-        <target state="translated">星期二</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerWednesdayCheckBox">
-        <source xml:lang="en">Wednesday</source>
-        <target state="translated">星期三</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerThursdayCheckBox">
-        <source xml:lang="en">Thursday</source>
-        <target state="translated">星期四</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerFridayCheckBox">
-        <source xml:lang="en">Friday  </source>
-        <target state="translated">星期五</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSaturdayCheckBox">
-        <source xml:lang="en">Saturday</source>
-        <target state="translated">星期六</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerSundayCheckBox">
-        <source xml:lang="en">Sunday</source>
-        <target state="translated">星期日</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayBegin">
-        <source xml:lang="en">Workday begin</source>
-        <target state="translated">工作日開始</target>
-      </trans-unit>
-      <trans-unit id="createOperator.workdayEnd">
-        <source xml:lang="en">Workday end</source>
-        <target state="translated">工作日結束</target>
-      </trans-unit>
-      <trans-unit id="createOperator.PagerDutySchedule">
-        <source xml:lang="en">Pager on duty schedule</source>
-        <target state="translated">呼叫器待命排程</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertListHeading">
-        <source xml:lang="en">Alert list</source>
-        <target state="translated">警示清單</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertNameColumnLabel">
-        <source xml:lang="en">Alert name</source>
-        <target state="translated">警示名稱</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertEmailColumnLabel">
-        <source xml:lang="en">E-mail</source>
-        <target state="translated">電子郵件</target>
-      </trans-unit>
-      <trans-unit id="createOperator.AlertPagerColumnLabel">
-        <source xml:lang="en">Pager</source>
-        <target state="translated">頁面巡覽區</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/dialogs/jobStepDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="jobStepDialog.fileBrowserTitle">
         <source xml:lang="en">Locate Database Files - </source>
@@ -416,159 +204,39 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/dialogs/pickScheduleDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="jobDialog.general">
-        <source xml:lang="en">General</source>
-        <target state="translated">一般</target>
+      <trans-unit id="pickSchedule.jobSchedules">
+        <source xml:lang="en">Job Schedules</source>
+        <target state="translated">作業排程</target>
       </trans-unit>
-      <trans-unit id="jobDialog.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">步驟</target>
+      <trans-unit id="pickSchedule.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
       </trans-unit>
-      <trans-unit id="jobDialog.schedules">
-        <source xml:lang="en">Schedules</source>
-        <target state="translated">排程</target>
+      <trans-unit id="pickSchedule.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="jobDialog.alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">警示</target>
+      <trans-unit id="pickSchedule.availableSchedules">
+        <source xml:lang="en">Available Schedules:</source>
+        <target state="translated">可用的排程:</target>
       </trans-unit>
-      <trans-unit id="jobDialog.notifications">
-        <source xml:lang="en">Notifications</source>
-        <target state="translated">通知</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.blankJobNameError">
-        <source xml:lang="en">The name of the job cannot be blank.</source>
-        <target state="translated">作業名稱不得為空。</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.name">
+      <trans-unit id="pickSchedule.scheduleName">
         <source xml:lang="en">Name</source>
         <target state="translated">名稱</target>
       </trans-unit>
-      <trans-unit id="jobDialog.owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">擁有者</target>
+      <trans-unit id="pickSchedule.scheduleID">
+        <source xml:lang="en">ID</source>
+        <target state="translated">識別碼</target>
       </trans-unit>
-      <trans-unit id="jobDialog.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">分類</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.description">
+      <trans-unit id="pickSchedule.description">
         <source xml:lang="en">Description</source>
         <target state="translated">描述</target>
       </trans-unit>
-      <trans-unit id="jobDialog.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">啟用</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.jobStepList">
-        <source xml:lang="en">Job step list</source>
-        <target state="translated">作業步驟清單</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.step">
-        <source xml:lang="en">Step</source>
-        <target state="translated">步驟</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.type">
-        <source xml:lang="en">Type</source>
-        <target state="translated">類型</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onSuccess">
-        <source xml:lang="en">On Success</source>
-        <target state="translated">成功時</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.onFailure">
-        <source xml:lang="en">On Failure</source>
-        <target state="translated">失敗時</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.new">
-        <source xml:lang="en">New Step</source>
-        <target state="translated">新增步驟</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.edit">
-        <source xml:lang="en">Edit Step</source>
-        <target state="translated">編輯步驟</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.delete">
-        <source xml:lang="en">Delete Step</source>
-        <target state="translated">刪除步驟</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveUp">
-        <source xml:lang="en">Move Step Up</source>
-        <target state="translated">向上移動步驟</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.moveDown">
-        <source xml:lang="en">Move Step Down</source>
-        <target state="translated">向下移動步驟</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.startStepAt">
-        <source xml:lang="en">Start step</source>
-        <target state="translated">開始步驟</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.notificationsTabTop">
-        <source xml:lang="en">Actions to perform when the job completes</source>
-        <target state="translated">作業完成時要執行的操作</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.email">
-        <source xml:lang="en">Email</source>
-        <target state="translated">電子郵件</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.page">
-        <source xml:lang="en">Page</source>
-        <target state="translated">頁面</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
-        <source xml:lang="en">Write to the Windows Application event log</source>
-        <target state="translated">寫入 Windows 應用程式事件記錄檔</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.deleteJobLabel">
-        <source xml:lang="en">Automatically delete job</source>
-        <target state="translated">自動刪除作業</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.schedulesaLabel">
-        <source xml:lang="en">Schedules list</source>
-        <target state="translated">排程清單</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.pickSchedule">
-        <source xml:lang="en">Pick Schedule</source>
-        <target state="translated">挑選排程</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.scheduleNameLabel">
-        <source xml:lang="en">Schedule Name</source>
-        <target state="translated">排程名稱</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertsList">
-        <source xml:lang="en">Alerts list</source>
-        <target state="translated">警示清單</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newAlert">
-        <source xml:lang="en">New Alert</source>
-        <target state="translated">新增警示</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertNameLabel">
-        <source xml:lang="en">Alert Name</source>
-        <target state="translated">警示名稱</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertEnabledLabel">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">啟用</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.alertTypeLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">類型</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.newJob">
-        <source xml:lang="en">New Job</source>
-        <target state="translated">新增作業</target>
-      </trans-unit>
-      <trans-unit id="jobDialog.editJob">
-        <source xml:lang="en">Edit Job</source>
-        <target state="translated">編輯作業</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/dialogs/alertDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="alertDialog.createAlert">
         <source xml:lang="en">Create Alert</source>
@@ -778,10 +446,6 @@
         <source xml:lang="en">Additional notification message to send</source>
         <target state="translated">要傳送的其他通知訊息</target>
       </trans-unit>
-      <trans-unit id="alertDialog.DelayBetweenResponse">
-        <source xml:lang="en">Delay between responses</source>
-        <target state="translated">回應之間的延遲</target>
-      </trans-unit>
       <trans-unit id="alertDialog.DelayMinutes">
         <source xml:lang="en">Delay Minutes</source>
         <target state="translated">延遲分鐘數</target>
@@ -792,51 +456,251 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/dialogs/agentDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/dialogs/operatorDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="agentDialog.OK">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
+      <trans-unit id="createOperator.createOperator">
+        <source xml:lang="en">Create Operator</source>
+        <target state="translated">建立運算子</target>
       </trans-unit>
-      <trans-unit id="agentDialog.Cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
+      <trans-unit id="createOperator.editOperator">
+        <source xml:lang="en">Edit Operator</source>
+        <target state="translated">編輯運算子</target>
+      </trans-unit>
+      <trans-unit id="createOperator.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">一般</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">通知</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
+      </trans-unit>
+      <trans-unit id="createOperator.Enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">啟用</target>
+      </trans-unit>
+      <trans-unit id="createOperator.EmailName">
+        <source xml:lang="en">E-mail Name</source>
+        <target state="translated">電子郵件名稱</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerEmailName">
+        <source xml:lang="en">Pager E-mail Name</source>
+        <target state="translated">頁面巡覽區電子郵件名稱</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerMondayCheckBox">
+        <source xml:lang="en">Monday</source>
+        <target state="translated">星期一</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerTuesdayCheckBox">
+        <source xml:lang="en">Tuesday</source>
+        <target state="translated">星期二</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerWednesdayCheckBox">
+        <source xml:lang="en">Wednesday</source>
+        <target state="translated">星期三</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerThursdayCheckBox">
+        <source xml:lang="en">Thursday</source>
+        <target state="translated">星期四</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerFridayCheckBox">
+        <source xml:lang="en">Friday  </source>
+        <target state="translated">星期五</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSaturdayCheckBox">
+        <source xml:lang="en">Saturday</source>
+        <target state="translated">星期六</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerSundayCheckBox">
+        <source xml:lang="en">Sunday</source>
+        <target state="translated">星期日</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayBegin">
+        <source xml:lang="en">Workday begin</source>
+        <target state="translated">工作日開始</target>
+      </trans-unit>
+      <trans-unit id="createOperator.workdayEnd">
+        <source xml:lang="en">Workday end</source>
+        <target state="translated">工作日結束</target>
+      </trans-unit>
+      <trans-unit id="createOperator.PagerDutySchedule">
+        <source xml:lang="en">Pager on duty schedule</source>
+        <target state="translated">呼叫器待命排程</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertListHeading">
+        <source xml:lang="en">Alert list</source>
+        <target state="translated">警示清單</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertNameColumnLabel">
+        <source xml:lang="en">Alert name</source>
+        <target state="translated">警示名稱</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertEmailColumnLabel">
+        <source xml:lang="en">E-mail</source>
+        <target state="translated">電子郵件</target>
+      </trans-unit>
+      <trans-unit id="createOperator.AlertPagerColumnLabel">
+        <source xml:lang="en">Pager</source>
+        <target state="translated">頁面巡覽區</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/proxyData" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/dialogs/jobDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="proxyData.saveErrorMessage">
-        <source xml:lang="en">Proxy update failed '{0}'</source>
-        <target state="translated">Proxy 更新失敗 '{0}'</target>
+      <trans-unit id="jobDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">一般</target>
       </trans-unit>
-      <trans-unit id="proxyData.saveSucessMessage">
-        <source xml:lang="en">Proxy '{0}' updated successfully</source>
-        <target state="translated">已成功更新 Proxy '{0}'</target>
+      <trans-unit id="jobDialog.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">步驟</target>
       </trans-unit>
-      <trans-unit id="proxyData.newJobSuccessMessage">
-        <source xml:lang="en">Proxy '{0}' created successfully</source>
-        <target state="translated">已成功建立 '{0}'</target>
+      <trans-unit id="jobDialog.schedules">
+        <source xml:lang="en">Schedules</source>
+        <target state="translated">排程</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">警示</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notifications">
+        <source xml:lang="en">Notifications</source>
+        <target state="translated">通知</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.blankJobNameError">
+        <source xml:lang="en">The name of the job cannot be blank.</source>
+        <target state="translated">作業名稱不得為空。</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">擁有者</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">分類</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">描述</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">啟用</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.jobStepList">
+        <source xml:lang="en">Job step list</source>
+        <target state="translated">作業步驟清單</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.step">
+        <source xml:lang="en">Step</source>
+        <target state="translated">步驟</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.type">
+        <source xml:lang="en">Type</source>
+        <target state="translated">類型</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onSuccess">
+        <source xml:lang="en">On Success</source>
+        <target state="translated">成功時</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.onFailure">
+        <source xml:lang="en">On Failure</source>
+        <target state="translated">失敗時</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.new">
+        <source xml:lang="en">New Step</source>
+        <target state="translated">新增步驟</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.edit">
+        <source xml:lang="en">Edit Step</source>
+        <target state="translated">編輯步驟</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.delete">
+        <source xml:lang="en">Delete Step</source>
+        <target state="translated">刪除步驟</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveUp">
+        <source xml:lang="en">Move Step Up</source>
+        <target state="translated">向上移動步驟</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.moveDown">
+        <source xml:lang="en">Move Step Down</source>
+        <target state="translated">向下移動步驟</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.startStepAt">
+        <source xml:lang="en">Start step</source>
+        <target state="translated">開始步驟</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.notificationsTabTop">
+        <source xml:lang="en">Actions to perform when the job completes</source>
+        <target state="translated">作業完成時要執行的操作</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.email">
+        <source xml:lang="en">Email</source>
+        <target state="translated">電子郵件</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.page">
+        <source xml:lang="en">Page</source>
+        <target state="translated">頁面</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.eventLogCheckBoxLabel">
+        <source xml:lang="en">Write to the Windows Application event log</source>
+        <target state="translated">寫入 Windows 應用程式事件記錄檔</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.deleteJobLabel">
+        <source xml:lang="en">Automatically delete job</source>
+        <target state="translated">自動刪除作業</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">排程清單</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">挑選排程</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">移除排程</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertsList">
+        <source xml:lang="en">Alerts list</source>
+        <target state="translated">警示清單</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newAlert">
+        <source xml:lang="en">New Alert</source>
+        <target state="translated">新增警示</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertNameLabel">
+        <source xml:lang="en">Alert Name</source>
+        <target state="translated">警示名稱</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertEnabledLabel">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">啟用</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.alertTypeLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">類型</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.newJob">
+        <source xml:lang="en">New Job</source>
+        <target state="translated">新增作業</target>
+      </trans-unit>
+      <trans-unit id="jobDialog.editJob">
+        <source xml:lang="en">Edit Job</source>
+        <target state="translated">編輯作業</target>
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/jobStepData" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="jobStepData.saveErrorMessage">
-        <source xml:lang="en">Step update failed '{0}'</source>
-        <target state="translated">步驟更新失敗 '{0}'</target>
-      </trans-unit>
-      <trans-unit id="stepData.jobNameRequired">
-        <source xml:lang="en">Job name must be provided</source>
-        <target state="translated">必須提供作業名稱</target>
-      </trans-unit>
-      <trans-unit id="stepData.stepNameRequired">
-        <source xml:lang="en">Step name must be provided</source>
-        <target state="translated">必須提供步驟名稱</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/agent/out/data/jobData" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/data/jobData" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="jobData.whenJobCompletes">
         <source xml:lang="en">When the job completes</source>
@@ -872,7 +736,55 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/data/alertData" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/data/jobStepData" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="jobStepData.saveErrorMessage">
+        <source xml:lang="en">Step update failed '{0}'</source>
+        <target state="translated">步驟更新失敗 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="stepData.jobNameRequired">
+        <source xml:lang="en">Job name must be provided</source>
+        <target state="translated">必須提供作業名稱</target>
+      </trans-unit>
+      <trans-unit id="stepData.stepNameRequired">
+        <source xml:lang="en">Step name must be provided</source>
+        <target state="translated">必須提供步驟名稱</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/mainController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="mainController.notImplemented">
+        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
+        <target state="translated">這項功能尚未開發完成。如果您想嘗試最新的變更，請試試最新的測試人員組建!</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadSuccessful">
+        <source xml:lang="en">Template updated successfully</source>
+        <target state="translated">範本已成功更新</target>
+      </trans-unit>
+      <trans-unit id="agent.templateUploadError">
+        <source xml:lang="en">Template update failure</source>
+        <target state="translated">範本更新失敗</target>
+      </trans-unit>
+      <trans-unit id="agent.unsavedFileSchedulingError">
+        <source xml:lang="en">The notebook must be saved before being scheduled. Please save and then retry scheduling again.</source>
+        <target state="translated">必須先儲存筆記本才能排程。請儲存後重試排程。</target>
+      </trans-unit>
+      <trans-unit id="agent.AddNewConnection">
+        <source xml:lang="en">Add new connection</source>
+        <target state="translated">新增新連線</target>
+      </trans-unit>
+      <trans-unit id="agent.selectConnection">
+        <source xml:lang="en">Select a connection</source>
+        <target state="translated">選取連線</target>
+      </trans-unit>
+      <trans-unit id="agent.selectValidConnection">
+        <source xml:lang="en">Please select a valid connection</source>
+        <target state="translated">請選取有效的連線</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/alertData" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="alertData.saveErrorMessage">
         <source xml:lang="en">Alert update failed '{0}'</source>
@@ -892,11 +804,223 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/agent/out/mainController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/agent/dist/dialogs/proxyDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="mainController.notImplemented">
-        <source xml:lang="en">This feature is under development.  Check-out the latest insiders build if you'd like to try out the most recent changes!</source>
-        <target state="translated">這項功能尚未開發完成。如果您想嘗試最新的變更，請試試最新的測試人員組建!</target>
+      <trans-unit id="createProxy.createProxy">
+        <source xml:lang="en">Create Proxy</source>
+        <target state="translated">建立 Proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.editProxy">
+        <source xml:lang="en">Edit Proxy</source>
+        <target state="translated">編輯 Proxy</target>
+      </trans-unit>
+      <trans-unit id="createProxy.General">
+        <source xml:lang="en">General</source>
+        <target state="translated">一般</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ProxyName">
+        <source xml:lang="en">Proxy name</source>
+        <target state="translated">Proxy 名稱</target>
+      </trans-unit>
+      <trans-unit id="createProxy.CredentialName">
+        <source xml:lang="en">Credential name</source>
+        <target state="translated">認證名稱</target>
+      </trans-unit>
+      <trans-unit id="createProxy.Description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">描述</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SubsystemName">
+        <source xml:lang="en">Subsystem</source>
+        <target state="translated">子系統</target>
+      </trans-unit>
+      <trans-unit id="createProxy.OperatingSystem">
+        <source xml:lang="en">Operating system (CmdExec)</source>
+        <target state="translated">作業系統 (cmdexec)</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationSnapshot">
+        <source xml:lang="en">Replication Snapshot</source>
+        <target state="translated">複寫快照集</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationTransactionLog">
+        <source xml:lang="en">Replication Transaction-Log Reader</source>
+        <target state="translated">複寫交易 - 記錄讀取器</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationDistributor">
+        <source xml:lang="en">Replication Distributor</source>
+        <target state="translated">複寫散發者</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationMerge">
+        <source xml:lang="en">Replication Merge</source>
+        <target state="translated">複寫合併</target>
+      </trans-unit>
+      <trans-unit id="createProxy.ReplicationQueueReader">
+        <source xml:lang="en">Replication Queue Reader</source>
+        <target state="translated">複本佇列讀取器</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASQueryLabel">
+        <source xml:lang="en">SQL Server Analysis Services Query</source>
+        <target state="translated">SQL Server Analysis Services 查詢</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSASCommandLabel">
+        <source xml:lang="en">SQL Server Analysis Services Command</source>
+        <target state="translated">SQL Server Analysis Services 命令</target>
+      </trans-unit>
+      <trans-unit id="createProxy.SSISPackage">
+        <source xml:lang="en">SQL Server Integration Services Package</source>
+        <target state="translated">SQL Server Integration Services 套件</target>
+      </trans-unit>
+      <trans-unit id="createProxy.PowerShell">
+        <source xml:lang="en">PowerShell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/proxyData" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="proxyData.saveErrorMessage">
+        <source xml:lang="en">Proxy update failed '{0}'</source>
+        <target state="translated">Proxy 更新失敗 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="proxyData.saveSucessMessage">
+        <source xml:lang="en">Proxy '{0}' updated successfully</source>
+        <target state="translated">已成功更新 Proxy '{0}'</target>
+      </trans-unit>
+      <trans-unit id="proxyData.newJobSuccessMessage">
+        <source xml:lang="en">Proxy '{0}' created successfully</source>
+        <target state="translated">已成功建立 '{0}'</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/dialogs/notebookDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebookDialog.newJob">
+        <source xml:lang="en">New Notebook Job</source>
+        <target state="translated">新增筆記本作業</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.editJob">
+        <source xml:lang="en">Edit Notebook Job</source>
+        <target state="translated">編輯筆記本作業</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.general">
+        <source xml:lang="en">General</source>
+        <target state="translated">一般</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.notebookSection">
+        <source xml:lang="en">Notebook Details</source>
+        <target state="translated">筆記本詳細資料</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templateNotebook">
+        <source xml:lang="en">Notebook Path</source>
+        <target state="translated">筆記本路徑</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabase">
+        <source xml:lang="en">Storage Database</source>
+        <target state="translated">儲存體資料庫</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executeDatabase">
+        <source xml:lang="en">Execution Database</source>
+        <target state="translated">執行資料庫</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.defaultDropdownString">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">選擇資料庫</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.jobSection">
+        <source xml:lang="en">Job Details</source>
+        <target state="translated">作業詳細資料</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">擁有者</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.schedulesaLabel">
+        <source xml:lang="en">Schedules list</source>
+        <target state="translated">排程清單</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.pickSchedule">
+        <source xml:lang="en">Pick Schedule</source>
+        <target state="translated">挑選排程</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.removeSchedule">
+        <source xml:lang="en">Remove Schedule</source>
+        <target state="translated">移除排程</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">描述</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.templatePath">
+        <source xml:lang="en">Select a notebook to schedule from PC</source>
+        <target state="translated">選取要從電腦排程的筆記本</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.targetDatabaseInfo">
+        <source xml:lang="en">Select a database to store all notebook job metadata and results</source>
+        <target state="translated">選取要儲存所有筆記本作業中繼資料及結果的資料庫</target>
+      </trans-unit>
+      <trans-unit id="notebookDialog.executionDatabaseInfo">
+        <source xml:lang="en">Select a database against which notebook queries will run</source>
+        <target state="translated">選取要執行筆記本查詢的資料庫</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/agent/dist/data/notebookData" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebookData.whenJobCompletes">
+        <source xml:lang="en">When the notebook completes</source>
+        <target state="translated">當筆記本完成時</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobFails">
+        <source xml:lang="en">When the notebook fails</source>
+        <target state="translated">當筆記本失敗時</target>
+      </trans-unit>
+      <trans-unit id="notebookData.whenJobSucceeds">
+        <source xml:lang="en">When the notebook succeeds</source>
+        <target state="translated">當筆記本成功時</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobNameRequired">
+        <source xml:lang="en">Notebook name must be provided</source>
+        <target state="translated">必須提供筆記本名稱</target>
+      </trans-unit>
+      <trans-unit id="notebookData.templatePathRequired">
+        <source xml:lang="en">Template path must be provided</source>
+        <target state="translated">必須提供範本路徑</target>
+      </trans-unit>
+      <trans-unit id="notebookData.invalidNotebookPath">
+        <source xml:lang="en">Invalid notebook path</source>
+        <target state="translated">無效的筆記本路徑</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectStorageDatabase">
+        <source xml:lang="en">Select storage database</source>
+        <target state="translated">選取儲存體資料庫</target>
+      </trans-unit>
+      <trans-unit id="notebookData.selectExecutionDatabase">
+        <source xml:lang="en">Select execution database</source>
+        <target state="translated">選取執行資料庫</target>
+      </trans-unit>
+      <trans-unit id="notebookData.jobExists">
+        <source xml:lang="en">Job with similar name already exists</source>
+        <target state="translated">已有類似名稱的作業存在</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveErrorMessage">
+        <source xml:lang="en">Notebook update failed '{0}'</source>
+        <target state="translated">筆記本更新失敗 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobErrorMessage">
+        <source xml:lang="en">Notebook creation failed '{0}'</source>
+        <target state="translated">筆記本建立失敗 '{0}'</target>
+      </trans-unit>
+      <trans-unit id="notebookData.saveSucessMessage">
+        <source xml:lang="en">Notebook '{0}' updated successfully</source>
+        <target state="translated">筆記本 '{0}' 已成功更新</target>
+      </trans-unit>
+      <trans-unit id="notebookData.newJobSuccessMessage">
+        <source xml:lang="en">Notebook '{0}' created successfully</source>
+        <target state="translated">已成功建立筆記本 '{0}' </target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hant/azurecore.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/azurecore.zh-Hant.xlf
@@ -126,6 +126,10 @@
         <source xml:lang="en">Error fetching resource groups for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
         <target state="translated">擷取帳戶 {0} ({1}) 訂閱 {2} ({3}) 租用戶 {4} 的資源群組時發生錯誤: {5}</target>
       </trans-unit>
+      <trans-unit id="azure.accounts.getLocations.queryError">
+        <source xml:lang="en">Error fetching locations for account {0} ({1}) subscription {2} ({3}) tenant {4} : {5}</source>
+        <target state="translated">擷取帳戶 {0} ({1}) 訂閱 {2} ({3}) 租用戶 {4} 的位置時發生錯誤: {5}</target>
+      </trans-unit>
       <trans-unit id="azure.accounts.runResourceQuery.errors.invalidQuery">
         <source xml:lang="en">Invalid query</source>
         <target state="translated">查詢無效</target>
@@ -379,7 +383,7 @@
         <target state="translated">SQL Server - Azure Arc</target>
       </trans-unit>
       <trans-unit id="azurecore.azureArcPostgres">
-        <source xml:lang="en">Azure Arc enabled PostgreSQL Hyperscale</source>
+        <source xml:lang="en">Azure Arc-enabled PostgreSQL Hyperscale</source>
         <target state="translated">已啟用 Azure Arc 的 PostgreSQL 超大規模資料庫</target>
       </trans-unit>
       <trans-unit id="azure.unableToOpenAzureLink">
@@ -411,7 +415,7 @@
         <target state="translated">Azure 驗證發生無法辨識的錯誤</target>
       </trans-unit>
       <trans-unit id="azure.tenantNotFound">
-        <source xml:lang="en">Specifed tenant with ID '{0}' not found.</source>
+        <source xml:lang="en">Specified tenant with ID '{0}' not found.</source>
         <target state="translated">找不到識別碼為 '{0}' 的指定租用戶。</target>
       </trans-unit>
       <trans-unit id="azure.noBaseToken">
@@ -419,7 +423,7 @@
         <target state="translated">驗證失敗，或您的權杖已從系統中刪除。請嘗試再次將帳戶新增至 Azure Data Studio。</target>
       </trans-unit>
       <trans-unit id="azure.responseError">
-        <source xml:lang="en">Token retrival failed with an error. Open developer tools to view the error</source>
+        <source xml:lang="en">Token retrieval failed with an error. Open developer tools to view the error</source>
         <target state="translated">權杖擷取失敗，發生錯誤。請開啟開發人員工具以檢視錯誤</target>
       </trans-unit>
       <trans-unit id="azure.accessTokenEmpty">
@@ -512,6 +516,14 @@
       <trans-unit id="azure.resource.tree.accountTreeNode.credentialError">
         <source xml:lang="en">Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.</source>
         <target state="translated">無法取得帳戶 {0} 的認證。請前往 [帳戶] 對話方塊並重新整理帳戶。</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.throttleerror">
+        <source xml:lang="en">Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.</source>
+        <target state="translated">已節流來自此帳戶的要求。若要重試，請選取較少的訂閱數目。</target>
+      </trans-unit>
+      <trans-unit id="azure.resource.tree.loadresourceerror">
+        <source xml:lang="en">An error occured while loading Azure resources: {0}</source>
+        <target state="translated">載入 Azure 資源時發生錯誤: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -700,6 +712,14 @@
       <trans-unit id="azure.resource.providers.KustoContainerLabel">
         <source xml:lang="en">Azure Data Explorer Cluster</source>
         <target state="translated">Azure 資料總管叢集</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/azurecore/dist/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="azure.resource.providers.AzureMonitorContainerLabel">
+        <source xml:lang="en">Azure Monitor Workspace</source>
+        <target state="new">Azure Monitor Workspace</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hant/big-data-cluster.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/big-data-cluster.zh-Hant.xlf
@@ -60,6 +60,126 @@
         <source xml:lang="en">Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true</source>
         <target state="translated">若為 True，則忽略對 SQL Server 巨量資料叢集端點 (例如 HDFS、Spark 及控制器) 所產生的 SSL 驗證錯誤</target>
       </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-display-name">
+        <source xml:lang="en">SQL Server Big Data Cluster</source>
+        <target state="translated">SQL Server 巨量資料叢集</target>
+      </trans-unit>
+      <trans-unit id="resource-type-sql-bdc-description">
+        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
+        <target state="translated">SQL Server 巨量資料叢集，可讓您部署於 Kubernetes 上執行且可調整的 SQL Server、Spark 和 HDFS 容器叢集</target>
+      </trans-unit>
+      <trans-unit id="version-display-name">
+        <source xml:lang="en">Version</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="bdc-2019-display-name">
+        <source xml:lang="en">SQL Server 2019</source>
+        <target state="translated">SQL Server 2019</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target">
+        <source xml:lang="en">Deployment target</source>
+        <target state="translated">部署目標</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-new-aks">
+        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
+        <target state="translated">新增 Azure Kubernetes Service 叢集</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aks">
+        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
+        <target state="translated">現有的 Azure Kubernetes 服務叢集</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-kubeadm">
+        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
+        <target state="translated">現有的 Kubernetes 叢集 (kubeadm)</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-aro">
+        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
+        <target state="translated">現有的 Azure Red Hat OpenShift 叢集</target>
+      </trans-unit>
+      <trans-unit id="bdc-deployment-target-existing-openshift">
+        <source xml:lang="en">Existing OpenShift cluster</source>
+        <target state="translated">現有的 OpenShift 叢集</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-settings-section-title">
+        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
+        <target state="translated">SQL Server 巨量資料叢集設定</target>
+      </trans-unit>
+      <trans-unit id="bdc-cluster-name-field">
+        <source xml:lang="en">Cluster name</source>
+        <target state="translated">叢集名稱</target>
+      </trans-unit>
+      <trans-unit id="bdc-controller-username-field">
+        <source xml:lang="en">Controller username</source>
+        <target state="translated">控制器使用者名稱</target>
+      </trans-unit>
+      <trans-unit id="bdc-password-field">
+        <source xml:lang="en">Password</source>
+        <target state="translated">密碼</target>
+      </trans-unit>
+      <trans-unit id="bdc-confirm-password-field">
+        <source xml:lang="en">Confirm password</source>
+        <target state="translated">確認密碼</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-settings-section-title">
+        <source xml:lang="en">Azure settings</source>
+        <target state="translated">Azure 設定</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-field">
+        <source xml:lang="en">Subscription id</source>
+        <target state="translated">訂用帳戶識別碼</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-subscription-id-placeholder">
+        <source xml:lang="en">Use my default Azure subscription</source>
+        <target state="translated">使用我的預設 Azure 訂用帳戶</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-resource-group-field">
+        <source xml:lang="en">Resource group name</source>
+        <target state="translated">資源群組名稱</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-region-field">
+        <source xml:lang="en">Region</source>
+        <target state="translated">區域</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-aks-name-field">
+        <source xml:lang="en">AKS cluster name</source>
+        <target state="translated">AKS 叢集名稱</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-size-field">
+        <source xml:lang="en">VM size</source>
+        <target state="translated">VM 大小</target>
+      </trans-unit>
+      <trans-unit id="bdc-azure-vm-count-field">
+        <source xml:lang="en">VM count</source>
+        <target state="translated">VM 計數</target>
+      </trans-unit>
+      <trans-unit id="bdc-storage-class-field">
+        <source xml:lang="en">Storage class name</source>
+        <target state="translated">儲存類別名稱</target>
+      </trans-unit>
+      <trans-unit id="bdc-data-size-field">
+        <source xml:lang="en">Capacity for data (GB)</source>
+        <target state="translated">資料的容量 (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-log-size-field">
+        <source xml:lang="en">Capacity for logs (GB)</source>
+        <target state="translated">記錄的容量 (GB)</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement">
+        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
+        <target state="translated">我接受 {0}、{1} 和 {2}。</target>
+      </trans-unit>
+      <trans-unit id="microsoft-privacy-statement">
+        <source xml:lang="en">Microsoft Privacy Statement</source>
+        <target state="translated">Microsoft 隱私權聲明</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-azdata-eula">
+        <source xml:lang="en">azdata License Terms</source>
+        <target state="translated">azdata 授權條款</target>
+      </trans-unit>
+      <trans-unit id="bdc-agreement-bdc-eula">
+        <source xml:lang="en">SQL Server License Terms</source>
+        <target state="translated">SQL Server 授權條款</target>
+      </trans-unit>
     </body>
   </file>
   <file original="extensions/big-data-cluster/dist/bigDataCluster/utils" source-language="en" datatype="plaintext" target-language="zh-Hant">

--- a/resources/xlf/zh-hant/cms.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/cms.zh-Hant.xlf
@@ -424,15 +424,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
-        <source xml:lang="en">Loading ...</source>
-        <target state="translated">正在載入...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="cms.resource.cmsResourceTreeNode.noResourcesLabel">
         <source xml:lang="en">No resources found</source>
@@ -440,7 +432,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/cms/dist/cmsResource/tree/cmsResourceEmptyTreeNode" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="cms.resource.tree.CmsTreeNode.addCmsServerLabel">
         <source xml:lang="en">Add Central Management Server...</source>
@@ -448,15 +440,27 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/cms/dist/cmsResource/tree/treeProvider" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="cms.resource.tree.treeProvider.loadError">
+        <source xml:lang="en">Unexpected error occurred while loading saved servers {0}</source>
+        <target state="translated">載入儲存的伺服器時發生未預期的錯誤 {0}</target>
+      </trans-unit>
+      <trans-unit id="cms.resource.tree.treeProvider.loadingLabel">
+        <source xml:lang="en">Loading ...</source>
+        <target state="translated">正在載入...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/cms/dist/cmsResource/cmsResourceCommands" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="cms.errors.sameCmsServerName">
         <source xml:lang="en">Central Management Server Group already has a Registered Server with the name {0}</source>
         <target state="translated">中央管理伺服器群組已經有名稱為 {0} 的已註冊伺服器</target>
       </trans-unit>
       <trans-unit id="cms.errors.azureNotAllowed">
-        <source xml:lang="en">Azure SQL Database Servers cannot be used as Central Management Servers</source>
-        <target state="translated">Azure SQL Database 伺服器無法作為中央管理伺服器使用</target>
+        <source xml:lang="en">Azure SQL Servers cannot be used as Central Management Servers</source>
+        <target state="translated">Azure SQL Servers 無法作為中央管理伺服器使用</target>
       </trans-unit>
       <trans-unit id="cms.confirmDeleteServer">
         <source xml:lang="en">Are you sure you want to delete</source>
@@ -500,7 +504,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/cms/out/cmsUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/cms/dist/cmsUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="cms.errors.sameServerUnderCms">
         <source xml:lang="en">You cannot add a shared registered server with the same name as the Configuration Server</source>

--- a/resources/xlf/zh-hant/dacpac.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/dacpac.zh-Hant.xlf
@@ -1,16 +1,84 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/dacpac/out/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/dacpac/package" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
+      <trans-unit id="dacFx.settings">
+        <source xml:lang="en">Dacpac</source>
+        <target state="translated">Dacpac</target>
+      </trans-unit>
+      <trans-unit id="dacFx.defaultSaveLocation">
+        <source xml:lang="en">Full path to folder where .DACPAC and .BACPAC files are saved by default</source>
+        <target state="translated">資料夾的完整路徑，DACPAC 和 .BACPAC 檔案預設會儲存</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/dacpac/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dacFx.targetServer">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">目標伺服器</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceServer">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">來源伺服器</target>
+      </trans-unit>
+      <trans-unit id="dacFx.sourceDatabase">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">來源資料庫</target>
+      </trans-unit>
+      <trans-unit id="dacFx.targetDatabase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">目標資料庫</target>
+      </trans-unit>
+      <trans-unit id="dacfx.fileLocation">
+        <source xml:lang="en">File Location</source>
+        <target state="translated">檔案位置</target>
+      </trans-unit>
+      <trans-unit id="dacfx.selectFile">
+        <source xml:lang="en">Select file</source>
+        <target state="translated">選取檔案</target>
+      </trans-unit>
+      <trans-unit id="dacfx.summaryTableTitle">
+        <source xml:lang="en">Summary of settings</source>
+        <target state="translated">設定值摘要</target>
+      </trans-unit>
+      <trans-unit id="dacfx.version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="dacfx.setting">
+        <source xml:lang="en">Setting</source>
+        <target state="translated">設定</target>
+      </trans-unit>
+      <trans-unit id="dacfx.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="dacFx.databaseName">
+        <source xml:lang="en">Database Name</source>
+        <target state="translated">資料庫名稱</target>
+      </trans-unit>
+      <trans-unit id="dacFxDeploy.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開啟</target>
+      </trans-unit>
+      <trans-unit id="dacFx.upgradeExistingDatabase">
+        <source xml:lang="en">Upgrade Existing Database</source>
+        <target state="translated">升級現有的資料庫</target>
+      </trans-unit>
+      <trans-unit id="dacFx.newDatabase">
+        <source xml:lang="en">New Database</source>
+        <target state="translated">新增資料庫</target>
+      </trans-unit>
       <trans-unit id="dacfx.dataLossTextWithCount">
         <source xml:lang="en">{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.</source>
         <target state="translated">所列出的 {0} 部署動作可能會導致資料遺失。請確認當部署發生問題時，您有備份或快照集可使用。</target>
       </trans-unit>
-      <trans-unit id="dacFx.dataLossCheckbox">
+      <trans-unit id="dacFx.proceedDataLoss">
         <source xml:lang="en">Proceed despite possible data loss</source>
         <target state="translated">儘管可能遺失資料，仍要繼續</target>
       </trans-unit>
-      <trans-unit id="dacfx.noDataLossText">
+      <trans-unit id="dacfx.noDataLoss">
         <source xml:lang="en">No data loss will occur from the listed deploy actions.</source>
         <target state="translated">列出的部署動作不會導致資料遺失。</target>
       </trans-unit>
@@ -54,19 +122,11 @@
         <source xml:lang="en">Save</source>
         <target state="translated">儲存</target>
       </trans-unit>
-      <trans-unit id="dacfx.fileLocation">
-        <source xml:lang="en">File Location</source>
-        <target state="translated">檔案位置</target>
-      </trans-unit>
-      <trans-unit id="dacFxExtract.versionText">
+      <trans-unit id="dacFx.versionText">
         <source xml:lang="en">Version (use x.x.x.x where x is a number)</source>
         <target state="translated">版本 (使用 x.x.x.x，其中 x 是號碼)</target>
       </trans-unit>
-      <trans-unit id="dacFxDeploy.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開啟</target>
-      </trans-unit>
-      <trans-unit id="dacFx.deployDescrption">
+      <trans-unit id="dacFx.deployDescription">
         <source xml:lang="en">Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]</source>
         <target state="translated">將資料層應用程式 .dacpac 檔案部署到 SQL Server 的執行個體 [部署 Dacpac]</target>
       </trans-unit>
@@ -82,49 +142,9 @@
         <source xml:lang="en">Export the schema and data from a database to the logical .bacpac file format [Export Bacpac]</source>
         <target state="translated">從資料庫將結構描述和資料匯出為邏輯 .bacpac 檔案格式 [匯出 Bacpac]</target>
       </trans-unit>
-      <trans-unit id="dacFx.databaseName">
-        <source xml:lang="en">Database Name</source>
-        <target state="translated">資料庫名稱</target>
-      </trans-unit>
-      <trans-unit id="dacFx.upgradeExistingDatabase">
-        <source xml:lang="en">Upgrade Existing Database</source>
-        <target state="translated">升級現有的資料庫</target>
-      </trans-unit>
-      <trans-unit id="dacFx.newDatabase">
-        <source xml:lang="en">New Database</source>
-        <target state="translated">新增資料庫</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetDatabase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">目標資料庫</target>
-      </trans-unit>
-      <trans-unit id="dacFx.targetServer">
-        <source xml:lang="en">Target Server</source>
-        <target state="translated">目標伺服器</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceServer">
-        <source xml:lang="en">Source Server</source>
-        <target state="translated">來源伺服器</target>
-      </trans-unit>
-      <trans-unit id="dacFx.sourceDatabase">
-        <source xml:lang="en">Source Database</source>
-        <target state="translated">來源資料庫</target>
-      </trans-unit>
-      <trans-unit id="dacfx.version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">版本</target>
-      </trans-unit>
-      <trans-unit id="dacfx.setting">
-        <source xml:lang="en">Setting</source>
-        <target state="translated">設定</target>
-      </trans-unit>
-      <trans-unit id="dacfx.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="dacfx.default">
-        <source xml:lang="en">default</source>
-        <target state="translated">預設</target>
+      <trans-unit id="dacfx.wizardTitle">
+        <source xml:lang="en">Data-tier Application Wizard</source>
+        <target state="translated">資料層應用程式精靈</target>
       </trans-unit>
       <trans-unit id="dacFx.selectOperationPageName">
         <source xml:lang="en">Select an Operation</source>
@@ -174,17 +194,65 @@
         <source xml:lang="en">Generate Script</source>
         <target state="translated">產生指令碼</target>
       </trans-unit>
+      <trans-unit id="dacfx.scriptGeneratingMessage">
+        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
+        <target state="translated">精靈關閉後，您可於工作檢視中檢視指令碼產生的狀態。產生的指令碼將於完成時開啟。</target>
+      </trans-unit>
+      <trans-unit id="dacfx.default">
+        <source xml:lang="en">default</source>
+        <target state="translated">預設</target>
+      </trans-unit>
+      <trans-unit id="dacfx.deployPlanTableTitle">
+        <source xml:lang="en">Deploy plan operations</source>
+        <target state="translated">部署計畫作業</target>
+      </trans-unit>
+      <trans-unit id="dacfx.databaseNameExistsErrorMessage">
+        <source xml:lang="en">A database with the same name already exists on the instance of SQL Server</source>
+        <target state="translated">SQL Server 執行個體上已經存在相同名稱的資料庫</target>
+      </trans-unit>
+      <trans-unit id="dacfx.undefinedFilenameErrorMessage">
+        <source xml:lang="en">Undefined name</source>
+        <target state="translated">未定義的名稱</target>
+      </trans-unit>
+      <trans-unit id="dacfx.filenameEndingInPeriodErrorMessage">
+        <source xml:lang="en">File name cannot end with a period</source>
+        <target state="translated">檔案名稱的結尾不能是句點</target>
+      </trans-unit>
+      <trans-unit id="dacfx.whitespaceFilenameErrorMessage">
+        <source xml:lang="en">File name cannot be whitespace</source>
+        <target state="translated">檔案名稱不能是空白字元</target>
+      </trans-unit>
+      <trans-unit id="dacfx.invalidFileCharsErrorMessage">
+        <source xml:lang="en">Invalid file characters</source>
+        <target state="translated">無效的檔案字元</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedWindowsFilenameErrorMessage">
+        <source xml:lang="en">This file name is reserved for use by Windows. Choose another name and try again</source>
+        <target state="translated">此檔案名稱保留供 Windows 使用。請選擇其他名稱，然後再試一次</target>
+      </trans-unit>
+      <trans-unit id="dacfx.reservedValueErrorMessage">
+        <source xml:lang="en">Reserved file name. Choose another name and try again</source>
+        <target state="translated">保留的檔案名稱。請選擇其他名稱，然後再試一次</target>
+      </trans-unit>
+      <trans-unit id="dacfx.trailingWhitespaceErrorMessage">
+        <source xml:lang="en">File name cannot end with a whitespace</source>
+        <target state="translated">檔案名稱的結尾不能是空白字元</target>
+      </trans-unit>
+      <trans-unit id="dacfx.tooLongFilenameErrorMessage">
+        <source xml:lang="en">File name is over 255 characters</source>
+        <target state="translated">檔案名稱超過 255 個字元</target>
+      </trans-unit>
       <trans-unit id="dacfx.deployPlanErrorMessage">
         <source xml:lang="en">Generating deploy plan failed '{0}'</source>
         <target state="translated">產生部署計劃時 ‘{0}’ 失敗</target>
       </trans-unit>
+      <trans-unit id="dacfx.generateDeployErrorMessage">
+        <source xml:lang="en">Generating deploy script failed '{0}'</source>
+        <target state="translated">產生部署指令碼時 '{0}' 失敗</target>
+      </trans-unit>
       <trans-unit id="dacfx.operationErrorMessage">
         <source xml:lang="en">{0} operation failed '{1}'</source>
         <target state="translated">{0} 作業失敗 '{1}'</target>
-      </trans-unit>
-      <trans-unit id="dacfx.scriptGeneratingMessage">
-        <source xml:lang="en">You can view the status of script generation in the Tasks View once the wizard is closed. The generated script will open when complete.</source>
-        <target state="translated">精靈關閉後，您可於工作檢視中檢視指令碼產生的狀態。產生的指令碼將於完成時開啟。</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hant/import.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/import.zh-Hant.xlf
@@ -1,7 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/import/out/wizard/pages/summaryPage" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/import/package" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
+      <trans-unit id="flatfileimport.configuration.title">
+        <source xml:lang="en">Flat File Import configuration</source>
+        <target state="translated">一般檔案匯入設定</target>
+      </trans-unit>
+      <trans-unit id="flatfileimport.logDebugInfo">
+        <source xml:lang="en">[Optional] Log debug output to the console (View -&gt; Output) and then select appropriate output channel from the dropdown</source>
+        <target state="translated">[選用] 將偵錯記錄輸出至主控台 ([檢視] -&gt; [輸出])，並從下拉式清單選取適當的輸出通道</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="serviceStarted">
+        <source xml:lang="en">{0} Started</source>
+        <target state="translated">已啟動 {0}</target>
+      </trans-unit>
+      <trans-unit id="serviceStarting">
+        <source xml:lang="en">Starting {0}</source>
+        <target state="translated">正在啟動 {0}</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serviceStartFailed">
+        <source xml:lang="en">Failed to start {0}: {1}</source>
+        <target state="translated">無法啟動 {0}: {1}</target>
+      </trans-unit>
+      <trans-unit id="installingServiceDetailed">
+        <source xml:lang="en">Installing {0} to {1}</source>
+        <target state="translated">正在將 {0} 安裝到 {1}</target>
+      </trans-unit>
+      <trans-unit id="installingService">
+        <source xml:lang="en">Installing {0} Service</source>
+        <target state="translated">正在安裝 {0} 服務</target>
+      </trans-unit>
+      <trans-unit id="serviceInstalled">
+        <source xml:lang="en">Installed {0}</source>
+        <target state="translated">已安裝 {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingService">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">正在下載 {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceSize">
+        <source xml:lang="en">({0} KB)</source>
+        <target state="translated">({0} KB)</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceStatus">
+        <source xml:lang="en">Downloading {0}</source>
+        <target state="translated">正在下載 {0}</target>
+      </trans-unit>
+      <trans-unit id="downloadingServiceComplete">
+        <source xml:lang="en">Done downloading {0}</source>
+        <target state="translated">已完成下載 {0}</target>
+      </trans-unit>
+      <trans-unit id="entryExtractedChannelMsg">
+        <source xml:lang="en">Extracted {0} ({1}/{2})</source>
+        <target state="translated">已擷取 {0} ({1}/{2})</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="extensions/import/out/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="import.serviceCrashButton">
+        <source xml:lang="en">Give Feedback</source>
+        <target state="translated">提供意見反應</target>
+      </trans-unit>
+      <trans-unit id="serviceCrashMessage">
+        <source xml:lang="en">service component could not start</source>
+        <target state="translated">服務元件無法啟動</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.serverDropdownTitle">
+        <source xml:lang="en">Server the database is in</source>
+        <target state="translated">資料庫所在的伺服器</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.databaseDropdownTitle">
+        <source xml:lang="en">Database the table is created in</source>
+        <target state="translated">資料表建立所在的資料庫</target>
+      </trans-unit>
+      <trans-unit id="flatFile.InvalidFileLocation">
+        <source xml:lang="en">Invalid file location. Please try a different input file</source>
+        <target state="translated">無效的檔案位置。請嘗試其他輸入檔</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.browseFiles">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">瀏覽</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開啟</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.fileTextboxTitle">
+        <source xml:lang="en">Location of the file to be imported</source>
+        <target state="translated">要匯入檔案的位置</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.tableTextboxTitle">
+        <source xml:lang="en">New table name</source>
+        <target state="translated">新增資料表名稱</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.schemaTextboxTitle">
+        <source xml:lang="en">Table schema</source>
+        <target state="translated">資料表結構描述</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.importData">
+        <source xml:lang="en">Import Data</source>
+        <target state="translated">匯入資料</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">下一個</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.columnName">
+        <source xml:lang="en">Column Name</source>
+        <target state="translated">資料行名稱</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.dataType">
+        <source xml:lang="en">Data Type</source>
+        <target state="translated">資料類型</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.primaryKey">
+        <source xml:lang="en">Primary Key</source>
+        <target state="translated">主索引鍵</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.allowNulls">
+        <source xml:lang="en">Allow Nulls</source>
+        <target state="translated">允許 Null 值</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessage">
+        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
+        <target state="translated">這項作業分析了輸出檔案結構，並產生了以下最多包含前 50 列的預覽。</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.prosePreviewMessageFail">
+        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
+        <target state="translated">這項作業不成功。請嘗試其他輸入檔案。</target>
+      </trans-unit>
+      <trans-unit id="flatFileImport.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">重新整理</target>
+      </trans-unit>
       <trans-unit id="flatFileImport.importInformation">
         <source xml:lang="en">Import information</source>
         <target state="translated">匯入資訊</target>
@@ -34,89 +170,13 @@
         <source xml:lang="en">✔ You have successfully inserted the data into a table.</source>
         <target state="translated">✔ 您已成功將資料插入表中。</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/prosePreviewPage" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="flatFileImport.prosePreviewMessage">
-        <source xml:lang="en">This operation analyzed the input file structure to generate the preview below for up to the first 50 rows.</source>
-        <target state="translated">這項作業分析了輸出檔案結構，並產生了以下最多包含前 50 列的預覽。</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.prosePreviewMessageFail">
-        <source xml:lang="en">This operation was unsuccessful. Please try a different input file.</source>
-        <target state="translated">這項作業不成功。請嘗試其他輸入檔案。</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">重新整理</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/modifyColumnsPage" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="flatFileImport.importData">
-        <source xml:lang="en">Import Data</source>
-        <target state="translated">匯入資料</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">下一個</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.columnName">
-        <source xml:lang="en">Column Name</source>
-        <target state="translated">資料行名稱</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.dataType">
-        <source xml:lang="en">Data Type</source>
-        <target state="translated">資料類型</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.primaryKey">
-        <source xml:lang="en">Primary Key</source>
-        <target state="translated">主索引鍵</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.allowNulls">
-        <source xml:lang="en">Allow Nulls</source>
-        <target state="translated">允許 Null 值</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/pages/fileConfigPage" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="flatFileImport.serverDropdownTitle">
-        <source xml:lang="en">Server the database is in</source>
-        <target state="translated">資料庫所在的伺服器</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.databaseDropdownTitle">
-        <source xml:lang="en">Database the table is created in</source>
-        <target state="translated">資料表建立所在的資料庫</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.browseFiles">
-        <source xml:lang="en">Browse</source>
-        <target state="translated">瀏覽</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開啟</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.fileTextboxTitle">
-        <source xml:lang="en">Location of the file to be imported</source>
-        <target state="translated">要匯入檔案的位置</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.tableTextboxTitle">
-        <source xml:lang="en">New table name</source>
-        <target state="translated">新增資料表名稱</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.schemaTextboxTitle">
-        <source xml:lang="en">Table schema</source>
-        <target state="translated">資料表結構描述</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/wizard/flatFileWizard" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
       <trans-unit id="import.needConnection">
         <source xml:lang="en">Please connect to a server before using this wizard.</source>
         <target state="translated">請先連線至伺服器再使用本精靈。</target>
+      </trans-unit>
+      <trans-unit id="import.needSQLConnection">
+        <source xml:lang="en">SQL Server Import extension does not support this type of connection</source>
+        <target state="translated">SQL Server 匯入延伸不支援此類型的連線</target>
       </trans-unit>
       <trans-unit id="flatFileImport.wizardName">
         <source xml:lang="en">Import flat file wizard</source>
@@ -141,62 +201,6 @@
       <trans-unit id="flatFileImport.importNewFile">
         <source xml:lang="en">Import new file</source>
         <target state="translated">匯入新檔案</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/telemetry" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="import.serviceCrashButton">
-        <source xml:lang="en">Give Feedback</source>
-        <target state="translated">提供意見反應</target>
-      </trans-unit>
-      <trans-unit id="serviceCrashMessage">
-        <source xml:lang="en">service component could not start</source>
-        <target state="translated">服務元件無法啟動</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/import/out/services/serviceClient" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="serviceStarted">
-        <source xml:lang="en">Service Started</source>
-        <target state="translated">已啟動服務</target>
-      </trans-unit>
-      <trans-unit id="serviceStarting">
-        <source xml:lang="en">Starting service</source>
-        <target state="translated">正在啟動服務</target>
-      </trans-unit>
-      <trans-unit id="flatFileImport.serviceStartFailed">
-        <source xml:lang="en">Failed to start Import service{0}</source>
-        <target state="translated">無法啟動匯入服務{0}</target>
-      </trans-unit>
-      <trans-unit id="installingServiceDetailed">
-        <source xml:lang="en">Installing {0} service to {1}</source>
-        <target state="translated">正在將 {0} 服務安裝到 {1}</target>
-      </trans-unit>
-      <trans-unit id="installingService">
-        <source xml:lang="en">Installing Service</source>
-        <target state="translated">正在安裝服務</target>
-      </trans-unit>
-      <trans-unit id="serviceInstalled">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">已安裝</target>
-      </trans-unit>
-      <trans-unit id="downloadingService">
-        <source xml:lang="en">Downloading {0}</source>
-        <target state="translated">正在下載 {0}</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceSize">
-        <source xml:lang="en">({0} KB)</source>
-        <target state="translated">({0} KB)</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceStatus">
-        <source xml:lang="en">Downloading Service</source>
-        <target state="translated">正在下載服務</target>
-      </trans-unit>
-      <trans-unit id="downloadingServiceComplete">
-        <source xml:lang="en">Done!</source>
-        <target state="translated">已完成!</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hant/notebook.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/notebook.zh-Hant.xlf
@@ -22,6 +22,14 @@
         <source xml:lang="en">Local path to a preexisting python installation used by Notebooks.</source>
         <target state="translated">Notebooks 所使用之現有 python 安裝的本機路徑。</target>
       </trans-unit>
+      <trans-unit id="notebook.dontPromptPythonUpdate.description">
+        <source xml:lang="en">Do not show prompt to update Python.</source>
+        <target state="translated">不要顯示更新 Python 的提示。</target>
+      </trans-unit>
+      <trans-unit id="notebook.jupyterServerShutdownTimeout.description">
+        <source xml:lang="en">The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)</source>
+        <target state="translated">在所有筆記本關閉後關閉伺服器前須等候的時間 (分鐘)。(若不要關閉，請輸入 0) </target>
+      </trans-unit>
       <trans-unit id="notebook.overrideEditorTheming.description">
         <source xml:lang="en">Override editor default settings in the Notebook editor. Settings include background color, current line color and border</source>
         <target state="translated">覆寫 Notebook 編輯器中的預設設定。設定包含背景色彩、目前的線條色彩和框線</target>
@@ -49,6 +57,10 @@
       <trans-unit id="notebook.pinnedNotebooks.description">
         <source xml:lang="en">Notebooks that are pinned by the user for the current workspace</source>
         <target state="translated">目前工作區之使用者所釘選的筆記本</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowRoot.description">
+        <source xml:lang="en">Allow Jupyter server to run as root user</source>
+        <target state="new">Allow Jupyter server to run as root user</target>
       </trans-unit>
       <trans-unit id="notebook.command.new">
         <source xml:lang="en">New Notebook</source>
@@ -139,24 +151,24 @@
         <target state="translated">Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="title.saveJupyterBook">
-        <source xml:lang="en">Save Book</source>
-        <target state="translated">儲存書籍</target>
+        <source xml:lang="en">Save Jupyter Book</source>
+        <target state="translated">開啟 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="title.trustBook">
-        <source xml:lang="en">Trust Book</source>
-        <target state="translated">信任書籍</target>
+        <source xml:lang="en">Trust Jupyter Book</source>
+        <target state="translated">信任 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="title.searchJupyterBook">
-        <source xml:lang="en">Search Book</source>
-        <target state="translated">搜尋書籍</target>
+        <source xml:lang="en">Search Jupyter Book</source>
+        <target state="translated">搜尋 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="title.SavedBooks">
         <source xml:lang="en">Notebooks</source>
         <target state="translated">Notebooks</target>
       </trans-unit>
       <trans-unit id="title.ProvidedBooks">
-        <source xml:lang="en">Provided Books</source>
-        <target state="translated">提供的書籍</target>
+        <source xml:lang="en">Provided Jupyter Books</source>
+        <target state="translated">提供的 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="title.PinnedBooks">
         <source xml:lang="en">Pinned notebooks</source>
@@ -174,17 +186,29 @@
         <source xml:lang="en">Close Jupyter Book</source>
         <target state="translated">關閉 Jupyter 書籍</target>
       </trans-unit>
-      <trans-unit id="title.closeJupyterNotebook">
-        <source xml:lang="en">Close Jupyter Notebook</source>
-        <target state="translated">關閉 Jupyter Notebook</target>
+      <trans-unit id="title.closeNotebook">
+        <source xml:lang="en">Close Notebook</source>
+        <target state="translated">關閉筆記本</target>
+      </trans-unit>
+      <trans-unit id="title.removeNotebook">
+        <source xml:lang="en">Remove Notebook</source>
+        <target state="translated">移除筆記本</target>
+      </trans-unit>
+      <trans-unit id="title.addNotebook">
+        <source xml:lang="en">Add Notebook</source>
+        <target state="translated">新增筆記本</target>
+      </trans-unit>
+      <trans-unit id="title.addMarkdown">
+        <source xml:lang="en">Add Markdown File</source>
+        <target state="translated">新增 Markdown 檔案</target>
       </trans-unit>
       <trans-unit id="title.revealInBooksViewlet">
         <source xml:lang="en">Reveal in Books</source>
         <target state="translated">在書籍中顯示</target>
       </trans-unit>
       <trans-unit id="title.createJupyterBook">
-        <source xml:lang="en">Create Book (Preview)</source>
-        <target state="translated">建立書籍 (預覽)</target>
+        <source xml:lang="en">Create Jupyter Book</source>
+        <target state="translated">建立 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="title.openNotebookFolder">
         <source xml:lang="en">Open Notebooks in Folder</source>
@@ -263,8 +287,8 @@
         <target state="translated">選取資料夾</target>
       </trans-unit>
       <trans-unit id="labelBookFolder">
-        <source xml:lang="en">Select Book</source>
-        <target state="translated">選取書籍</target>
+        <source xml:lang="en">Select Jupyter Book</source>
+        <target state="translated">選取 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="confirmReplace">
         <source xml:lang="en">Folder already exists. Are you sure you want to delete and replace this folder?</source>
@@ -283,40 +307,40 @@
         <target state="translated">開啟外部連結</target>
       </trans-unit>
       <trans-unit id="msgBookTrusted">
-        <source xml:lang="en">Book is now trusted in the workspace.</source>
-        <target state="translated">書籍在此工作區現已受信任。</target>
+        <source xml:lang="en">Jupyter Book is now trusted in the workspace.</source>
+        <target state="translated">Jupyter 書籍在此工作區現已受信任。</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyTrusted">
-        <source xml:lang="en">Book is already trusted in this workspace.</source>
-        <target state="translated">書籍在此工作區已受信任。</target>
+        <source xml:lang="en">Jupyter Book is already trusted in this workspace.</source>
+        <target state="translated">Jupyter 書籍在此工作區已受信任。</target>
       </trans-unit>
       <trans-unit id="msgBookUntrusted">
-        <source xml:lang="en">Book is no longer trusted in this workspace</source>
-        <target state="translated">書籍在此工作區已不再受信任</target>
+        <source xml:lang="en">Jupyter Book is no longer trusted in this workspace</source>
+        <target state="translated">Jupyter 書籍在此工作區已不再受信任</target>
       </trans-unit>
       <trans-unit id="msgBookAlreadyUntrusted">
-        <source xml:lang="en">Book is already untrusted in this workspace.</source>
-        <target state="translated">書籍在此工作區未受信任。</target>
+        <source xml:lang="en">Jupyter Book is already untrusted in this workspace.</source>
+        <target state="translated">Jupyter 書籍在此工作區未受信任。</target>
       </trans-unit>
       <trans-unit id="msgBookPinned">
-        <source xml:lang="en">Book {0} is now pinned in the workspace.</source>
-        <target state="translated">書籍 {0} 現已釘選在工作區中。</target>
+        <source xml:lang="en">Jupyter Book {0} is now pinned in the workspace.</source>
+        <target state="translated">Jupyter 書籍 {0} 現已釘選在工作區中。</target>
       </trans-unit>
       <trans-unit id="msgBookUnpinned">
-        <source xml:lang="en">Book {0} is no longer pinned in this workspace</source>
-        <target state="translated">書籍 {0} 已不再釘選於此工作區中</target>
+        <source xml:lang="en">Jupyter Book {0} is no longer pinned in this workspace</source>
+        <target state="translated">Jupyter 書籍 {0} 已不再釘選於此工作區中</target>
       </trans-unit>
       <trans-unit id="bookInitializeFailed">
-        <source xml:lang="en">Failed to find a Table of Contents file in the specified book.</source>
-        <target state="translated">找不到指定書籍中的目錄檔案。</target>
+        <source xml:lang="en">Failed to find a Table of Contents file in the specified Jupyter Book.</source>
+        <target state="translated">指定 Jupyter 書籍中找不到的目錄檔案。</target>
       </trans-unit>
       <trans-unit id="noBooksSelected">
-        <source xml:lang="en">No books are currently selected in the viewlet.</source>
-        <target state="translated">目前未在 Viewlet 中選取任何書籍。</target>
+        <source xml:lang="en">No Jupyter Books are currently selected in the viewlet.</source>
+        <target state="translated">目前未在 Viewlet 中選取任何 Jupyter 書籍。</target>
       </trans-unit>
       <trans-unit id="labelBookSection">
-        <source xml:lang="en">Select Book Section</source>
-        <target state="translated">選取書籍區段</target>
+        <source xml:lang="en">Select Jupyter Book Section</source>
+        <target state="translated">選取 Jupyter 書籍章節</target>
       </trans-unit>
       <trans-unit id="labelAddToLevel">
         <source xml:lang="en">Add to this level</source>
@@ -339,12 +363,12 @@
         <target state="translated">缺少組態檔</target>
       </trans-unit>
       <trans-unit id="openBookError">
-        <source xml:lang="en">Open book {0} failed: {1}</source>
-        <target state="translated">無法開啟書籍 {0}: {1}</target>
+        <source xml:lang="en">Open Jupyter Book {0} failed: {1}</source>
+        <target state="translated">開啟 Jupyter 書籍 {0} 失敗: {1}</target>
       </trans-unit>
       <trans-unit id="readBookError">
-        <source xml:lang="en">Failed to read book {0}: {1}</source>
-        <target state="translated">無法讀取書籍 {0}: {1}</target>
+        <source xml:lang="en">Failed to read Jupyter Book {0}: {1}</source>
+        <target state="translated">無法讀取 Jupyter 書籍 {0}: {1}</target>
       </trans-unit>
       <trans-unit id="openNotebookError">
         <source xml:lang="en">Open notebook {0} failed: {1}</source>
@@ -363,8 +387,8 @@
         <target state="translated">開啟連結 {0} 失敗: {1}</target>
       </trans-unit>
       <trans-unit id="closeBookError">
-        <source xml:lang="en">Close book {0} failed: {1}</source>
-        <target state="translated">無法關閉書籍 {0}: {1}</target>
+        <source xml:lang="en">Close Jupyter Book {0} failed: {1}</source>
+        <target state="translated">關閉 Jupyter 書籍 {0} 失敗: {1}</target>
       </trans-unit>
       <trans-unit id="duplicateFileError">
         <source xml:lang="en">File {0} already exists in the destination folder {1} 
@@ -373,12 +397,16 @@
  檔案已重新命名為 {2}，以避免資料遺失。</target>
       </trans-unit>
       <trans-unit id="editBookError">
-        <source xml:lang="en">Error while editing book {0}: {1}</source>
-        <target state="translated">編輯書籍 {0} 時發生錯誤: {1}</target>
+        <source xml:lang="en">Error while editing Jupyter Book {0}: {1}</source>
+        <target state="translated">編輯 Jupyter 書籍 {0} 時發生錯誤: {1}</target>
       </trans-unit>
       <trans-unit id="selectBookError">
-        <source xml:lang="en">Error while selecting a book or a section to edit: {0}</source>
-        <target state="translated">選取要編輯的書籍或區段時發生錯誤: {0}</target>
+        <source xml:lang="en">Error while selecting a Jupyter Book or a section to edit: {0}</source>
+        <target state="translated">選取要編輯的 Jupyter 書籍或章節時發生錯誤: {0}</target>
+      </trans-unit>
+      <trans-unit id="sectionNotFound">
+        <source xml:lang="en">Failed to find section {0} in {1}.</source>
+        <target state="translated">在 {1} 中找不到區段 {0}。</target>
       </trans-unit>
       <trans-unit id="url">
         <source xml:lang="en">URL</source>
@@ -393,8 +421,8 @@
         <target state="translated">位置</target>
       </trans-unit>
       <trans-unit id="addRemoteBook">
-        <source xml:lang="en">Add Remote Book</source>
-        <target state="translated">新增遠端書籍</target>
+        <source xml:lang="en">Add Remote Jupyter Book</source>
+        <target state="translated">新增遠端 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="onGitHub">
         <source xml:lang="en">GitHub</source>
@@ -409,8 +437,8 @@
         <target state="translated">版本</target>
       </trans-unit>
       <trans-unit id="book">
-        <source xml:lang="en">Book</source>
-        <target state="translated">書籍</target>
+        <source xml:lang="en">Jupyter Book</source>
+        <target state="translated">Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="version">
         <source xml:lang="en">Version</source>
@@ -421,8 +449,8 @@
         <target state="translated">語言</target>
       </trans-unit>
       <trans-unit id="booksNotFound">
-        <source xml:lang="en">No books are currently available on the provided link</source>
-        <target state="translated">提供的連結目前沒有任何書籍可供使用</target>
+        <source xml:lang="en">No Jupyter Books are currently available on the provided link</source>
+        <target state="translated">提供的連結目前沒有任何 Jupyter 書籍可供使用</target>
       </trans-unit>
       <trans-unit id="urlGithubError">
         <source xml:lang="en">The url provided is not a Github release url</source>
@@ -445,44 +473,44 @@
         <target state="translated">-</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadProgress">
-        <source xml:lang="en">Remote Book download is in progress</source>
-        <target state="translated">正在下載遠端書籍</target>
+        <source xml:lang="en">Remote Jupyter Book download is in progress</source>
+        <target state="translated">遠端 Jupyter 書籍下載進行中</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadComplete">
-        <source xml:lang="en">Remote Book download is complete</source>
-        <target state="translated">遠端書籍下載已完成</target>
+        <source xml:lang="en">Remote Jupyter Book download is complete</source>
+        <target state="translated">遠端 Jupyter 書籍下載已完成</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDownloadError">
-        <source xml:lang="en">Error while downloading remote Book</source>
-        <target state="translated">下載遠端書籍時發生錯誤</target>
+        <source xml:lang="en">Error while downloading remote Jupyter Book</source>
+        <target state="translated">下載遠端 Jupyter 書籍時發生錯誤</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookUnpackingError">
-        <source xml:lang="en">Error while decompressing remote Book</source>
-        <target state="translated">解壓縮遠端書籍時發生錯誤</target>
+        <source xml:lang="en">Error while decompressing remote Jupyter Book</source>
+        <target state="translated">解壓縮遠端 Jupyter 書籍時發生錯誤</target>
       </trans-unit>
       <trans-unit id="msgRemoteBookDirectoryError">
-        <source xml:lang="en">Error while creating remote Book directory</source>
-        <target state="translated">建立遠端書籍目錄時發生錯誤</target>
+        <source xml:lang="en">Error while creating remote Jupyter Book directory</source>
+        <target state="translated">建立遠端 Jupyter 書籍目錄時發生錯誤</target>
       </trans-unit>
       <trans-unit id="msgTaskName">
-        <source xml:lang="en">Downloading Remote Book</source>
-        <target state="translated">正在下載遠端書籍</target>
+        <source xml:lang="en">Downloading Remote Jupyter Book</source>
+        <target state="translated">正在下載遠端 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="msgResourceNotFound">
         <source xml:lang="en">Resource not Found</source>
         <target state="translated">找不到資源</target>
       </trans-unit>
       <trans-unit id="msgBookNotFound">
-        <source xml:lang="en">Books not Found</source>
-        <target state="translated">找不到書籍</target>
+        <source xml:lang="en">Jupyter Books not Found</source>
+        <target state="translated">找不到 Jupyter 書籍</target>
       </trans-unit>
       <trans-unit id="msgReleaseNotFound">
         <source xml:lang="en">Releases not Found</source>
         <target state="translated">找不到版本</target>
       </trans-unit>
       <trans-unit id="msgUndefinedAssetError">
-        <source xml:lang="en">The selected book is not valid</source>
-        <target state="translated">選取的書籍無效</target>
+        <source xml:lang="en">The selected Jupyter Book is not valid</source>
+        <target state="translated">選取的 Jupyter 書籍無效</target>
       </trans-unit>
       <trans-unit id="httpRequestError">
         <source xml:lang="en">Http Request failed with error: {0} {1}</source>
@@ -492,21 +520,21 @@
         <source xml:lang="en">Downloading to {0}</source>
         <target state="translated">正在下載至 {0}</target>
       </trans-unit>
-      <trans-unit id="newGroup">
-        <source xml:lang="en">New Group</source>
-        <target state="translated">新增群組</target>
+      <trans-unit id="newBook">
+        <source xml:lang="en">New Jupyter Book (Preview)</source>
+        <target state="translated">新 Jupyter Book (預覽)</target>
       </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Groups are used to organize Notebooks.</source>
-        <target state="translated">群組可用於整理 Notebooks。</target>
+      <trans-unit id="bookDescription">
+        <source xml:lang="en">Jupyter Books are used to organize Notebooks.</source>
+        <target state="translated">Jupyter Books 可用來整理筆記本。</target>
       </trans-unit>
-      <trans-unit id="locationBrowser">
-        <source xml:lang="en">Browse locations...</source>
-        <target state="translated">瀏覽位置...</target>
+      <trans-unit id="learnMore">
+        <source xml:lang="en">Learn more.</source>
+        <target state="translated">深入了解。</target>
       </trans-unit>
-      <trans-unit id="selectContentFolder">
-        <source xml:lang="en">Select content folder</source>
-        <target state="translated">選取內容資料夾</target>
+      <trans-unit id="contentFolder">
+        <source xml:lang="en">Content folder</source>
+        <target state="translated">內容資料夾</target>
       </trans-unit>
       <trans-unit id="browse">
         <source xml:lang="en">Browse</source>
@@ -524,7 +552,7 @@
         <source xml:lang="en">Save location</source>
         <target state="translated">儲存位置</target>
       </trans-unit>
-      <trans-unit id="contentFolder">
+      <trans-unit id="contentFolderOptional">
         <source xml:lang="en">Content folder (Optional)</source>
         <target state="translated">內容資料夾 (選擇性)</target>
       </trans-unit>
@@ -533,8 +561,44 @@
         <target state="translated">內容資料夾路徑不存在</target>
       </trans-unit>
       <trans-unit id="msgSaveFolderError">
-        <source xml:lang="en">Save location path does not exist</source>
-        <target state="translated">儲存位置路徑不存在</target>
+        <source xml:lang="en">Save location path does not exist.</source>
+        <target state="translated">儲存位置路徑不存在。</target>
+      </trans-unit>
+      <trans-unit id="msgCreateBookWarningMsg">
+        <source xml:lang="en">Error while trying to access: {0}</source>
+        <target state="translated">嘗試存取時發生錯誤: {0}</target>
+      </trans-unit>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook (Preview)</source>
+        <target state="translated">新筆記本 (預覽)</target>
+      </trans-unit>
+      <trans-unit id="newMarkdown">
+        <source xml:lang="en">New Markdown (Preview)</source>
+        <target state="translated">新增 Markdown (預覽)</target>
+      </trans-unit>
+      <trans-unit id="fileExtension">
+        <source xml:lang="en">File Extension</source>
+        <target state="translated">副檔名</target>
+      </trans-unit>
+      <trans-unit id="confirmOverwrite">
+        <source xml:lang="en">File already exists. Are you sure you want to overwrite this file?</source>
+        <target state="translated">檔案已存在。確定要覆寫此檔案嗎 ?</target>
+      </trans-unit>
+      <trans-unit id="title">
+        <source xml:lang="en">Title</source>
+        <target state="translated">標題</target>
+      </trans-unit>
+      <trans-unit id="fileName">
+        <source xml:lang="en">File Name</source>
+        <target state="translated">檔案名稱</target>
+      </trans-unit>
+      <trans-unit id="msgInvalidSaveFolder">
+        <source xml:lang="en">Save location path is not valid.</source>
+        <target state="translated">儲存位置路徑無效。</target>
+      </trans-unit>
+      <trans-unit id="msgDuplicadFileName">
+        <source xml:lang="en">File {0} already exists in the destination folder</source>
+        <target state="translated">檔案 {0} 已存在於目的地資料夾中</target>
       </trans-unit>
     </body>
   </file>
@@ -588,6 +652,18 @@
         <source xml:lang="en">Another Python installation is currently in progress. Waiting for it to complete.</source>
         <target state="translated">目前在進行另一個 Python 安裝。請等它完成。</target>
       </trans-unit>
+      <trans-unit id="msgShutdownNotebookSessions">
+        <source xml:lang="en">Active Python notebook sessions will be shutdown in order to update. Would you like to proceed now?</source>
+        <target state="translated">為了進行更新，將關閉使用中的 Python 筆記本工作階段。您要立即繼續嗎?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdatePrompt">
+        <source xml:lang="en">Python {0} is now available in Azure Data Studio. The current Python version (3.6.6) will be out of support in December 2021. Would you like to update to Python {0} now?</source>
+        <target state="translated">Azure Data Studio 現已提供 Python {0}。目前的 Python 版本 (3.6.6) 將在 2021 年 12 月時取消支援。您要立即更新為 Python {0} 嗎?</target>
+      </trans-unit>
+      <trans-unit id="msgPythonVersionUpdateWarning">
+        <source xml:lang="en">Python {0} will be installed and will replace Python 3.6.6. Some packages may no longer be compatible with the new version or may need to be reinstalled. A notebook will be created to help you reinstall all pip packages. Would you like to continue with the update now?</source>
+        <target state="translated">將安裝 Python {0} 並取代 Python 3.6.6。某些套件可能不再與新版本相容，或可能需要重新安裝。將建立筆記本以協助您重新安裝所有 pip 套件。您要立即繼續更新嗎?</target>
+      </trans-unit>
       <trans-unit id="msgDependenciesInstallationFailed">
         <source xml:lang="en">Installing Notebook dependencies failed with error: {0}</source>
         <target state="translated">安裝 Notebook 相依性失敗。錯誤: {0}</target>
@@ -603,6 +679,18 @@
       <trans-unit id="msgGetPythonUserDirFailed">
         <source xml:lang="en">Encountered an error when getting Python user path: {0}</source>
         <target state="translated">取得 Python 使用者路徑時發生錯誤: {0}</target>
+      </trans-unit>
+      <trans-unit id="yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="dontAskAgain">
+        <source xml:lang="en">Don't Ask Again</source>
+        <target state="translated">不要再詢問</target>
       </trans-unit>
     </body>
   </file>
@@ -973,8 +1061,8 @@
         <target state="translated">這個處理常式不支援動作 {0}</target>
       </trans-unit>
       <trans-unit id="unsupportedScheme">
-        <source xml:lang="en">Cannot open link {0} as only HTTP and HTTPS links are supported</source>
-        <target state="translated">因為只支援 HTTP 和 HTTPS 連結，所以無法開啟連結 {0}</target>
+        <source xml:lang="en">Cannot open link {0} as only HTTP, HTTPS, and File links are supported</source>
+        <target state="translated">由於僅支援 HTTP、HTTPS 和檔案連結，所以無法開啟連結 {0}</target>
       </trans-unit>
       <trans-unit id="notebook.confirmOpen">
         <source xml:lang="en">Download and open '{0}'?</source>

--- a/resources/xlf/zh-hant/profiler.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/profiler.zh-Hant.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="extensions/profiler/client/out/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/profiler/dist/dialogs/profilerCreateSessionDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="createSessionDialog.cancel">
         <source xml:lang="en">Cancel</source>

--- a/resources/xlf/zh-hant/resource-deployment.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/resource-deployment.zh-Hant.xlf
@@ -26,14 +26,6 @@
         <source xml:lang="en">Run SQL Server container image with docker</source>
         <target state="translated">以 Docker 執行 SQL Server 容器映像</target>
       </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-display-name">
-        <source xml:lang="en">SQL Server Big Data Cluster</source>
-        <target state="translated">SQL Server 巨量資料叢集</target>
-      </trans-unit>
-      <trans-unit id="resource-type-sql-bdc-description">
-        <source xml:lang="en">SQL Server Big Data Cluster allows you to deploy scalable clusters of SQL Server, Spark, and HDFS containers running on Kubernetes</source>
-        <target state="translated">SQL Server 巨量資料叢集，可讓您部署於 Kubernetes 上執行且可調整的 SQL Server、Spark 和 HDFS 容器叢集</target>
-      </trans-unit>
       <trans-unit id="version-display-name">
         <source xml:lang="en">Version</source>
         <target state="translated">版本</target>
@@ -45,34 +37,6 @@
       <trans-unit id="sql-2019-display-name">
         <source xml:lang="en">SQL Server 2019</source>
         <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-2019-display-name">
-        <source xml:lang="en">SQL Server 2019</source>
-        <target state="translated">SQL Server 2019</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target">
-        <source xml:lang="en">Deployment target</source>
-        <target state="translated">部署目標</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-new-aks">
-        <source xml:lang="en">New Azure Kubernetes Service Cluster</source>
-        <target state="translated">新增 Azure Kubernetes Service 叢集</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aks">
-        <source xml:lang="en">Existing Azure Kubernetes Service Cluster</source>
-        <target state="translated">現有的 Azure Kubernetes 服務叢集</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-kubeadm">
-        <source xml:lang="en">Existing Kubernetes Cluster (kubeadm)</source>
-        <target state="translated">現有的 Kubernetes 叢集 (kubeadm)</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-aro">
-        <source xml:lang="en">Existing Azure Red Hat OpenShift cluster</source>
-        <target state="translated">現有的 Azure Red Hat OpenShift 叢集</target>
-      </trans-unit>
-      <trans-unit id="bdc-deployment-target-existing-openshift">
-        <source xml:lang="en">Existing OpenShift cluster</source>
-        <target state="translated">現有的 OpenShift 叢集</target>
       </trans-unit>
       <trans-unit id="docker-sql-2017-title">
         <source xml:lang="en">Deploy SQL Server 2017 container images</source>
@@ -98,70 +62,6 @@
         <source xml:lang="en">Port</source>
         <target state="translated">連接埠</target>
       </trans-unit>
-      <trans-unit id="bdc-cluster-settings-section-title">
-        <source xml:lang="en">SQL Server Big Data Cluster settings</source>
-        <target state="translated">SQL Server 巨量資料叢集設定</target>
-      </trans-unit>
-      <trans-unit id="bdc-cluster-name-field">
-        <source xml:lang="en">Cluster name</source>
-        <target state="translated">叢集名稱</target>
-      </trans-unit>
-      <trans-unit id="bdc-controller-username-field">
-        <source xml:lang="en">Controller username</source>
-        <target state="translated">控制器使用者名稱</target>
-      </trans-unit>
-      <trans-unit id="bdc-password-field">
-        <source xml:lang="en">Password</source>
-        <target state="translated">密碼</target>
-      </trans-unit>
-      <trans-unit id="bdc-confirm-password-field">
-        <source xml:lang="en">Confirm password</source>
-        <target state="translated">確認密碼</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-settings-section-title">
-        <source xml:lang="en">Azure settings</source>
-        <target state="translated">Azure 設定</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-field">
-        <source xml:lang="en">Subscription id</source>
-        <target state="translated">訂用帳戶識別碼</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-subscription-id-placeholder">
-        <source xml:lang="en">Use my default Azure subscription</source>
-        <target state="translated">使用我的預設 Azure 訂用帳戶</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-resource-group-field">
-        <source xml:lang="en">Resource group name</source>
-        <target state="translated">資源群組名稱</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-region-field">
-        <source xml:lang="en">Region</source>
-        <target state="translated">區域</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-aks-name-field">
-        <source xml:lang="en">AKS cluster name</source>
-        <target state="translated">AKS 叢集名稱</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-size-field">
-        <source xml:lang="en">VM size</source>
-        <target state="translated">VM 大小</target>
-      </trans-unit>
-      <trans-unit id="bdc-azure-vm-count-field">
-        <source xml:lang="en">VM count</source>
-        <target state="translated">VM 計數</target>
-      </trans-unit>
-      <trans-unit id="bdc-storage-class-field">
-        <source xml:lang="en">Storage class name</source>
-        <target state="translated">儲存類別名稱</target>
-      </trans-unit>
-      <trans-unit id="bdc-data-size-field">
-        <source xml:lang="en">Capacity for data (GB)</source>
-        <target state="translated">資料的容量 (GB)</target>
-      </trans-unit>
-      <trans-unit id="bdc-log-size-field">
-        <source xml:lang="en">Capacity for logs (GB)</source>
-        <target state="translated">記錄的容量 (GB)</target>
-      </trans-unit>
       <trans-unit id="resource-type-sql-windows-setup-display-name">
         <source xml:lang="en">SQL Server on Windows</source>
         <target state="translated">Windows 上的 SQL Server</target>
@@ -170,21 +70,9 @@
         <source xml:lang="en">Run SQL Server on Windows, select a version to get started.</source>
         <target state="translated">在 Windows 上執行 SQL Server，選取要開始使用的版本。</target>
       </trans-unit>
-      <trans-unit id="bdc-agreement">
-        <source xml:lang="en">I accept {0}, {1} and {2}.</source>
-        <target state="translated">我接受 {0}、{1} 和 {2}。</target>
-      </trans-unit>
       <trans-unit id="microsoft-privacy-statement">
         <source xml:lang="en">Microsoft Privacy Statement</source>
         <target state="translated">Microsoft 隱私權聲明</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-azdata-eula">
-        <source xml:lang="en">azdata License Terms</source>
-        <target state="translated">azdata 授權條款</target>
-      </trans-unit>
-      <trans-unit id="bdc-agreement-bdc-eula">
-        <source xml:lang="en">SQL Server License Terms</source>
-        <target state="translated">SQL Server 授權條款</target>
       </trans-unit>
       <trans-unit id="deployment.configuration.title">
         <source xml:lang="en">Deployment configuration</source>
@@ -485,6 +373,22 @@
       <trans-unit id="deploymentDialog.RecheckEulaButton">
         <source xml:lang="en">Accept EULA &amp; Select</source>
         <target state="translated">接受 EULA 並選取</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.extensionRequiredPrompt">
+        <source xml:lang="en">The '{0}' extension is required to deploy this resource, do you want to install it now?</source>
+        <target state="translated">需要 ' {0} ' 延伸模組才可部署此資源，要立即安裝嗎?</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">安裝</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.installingExtension">
+        <source xml:lang="en">Installing extension '{0}'...</source>
+        <target state="translated">正在安裝延伸模組 '{0}'...</target>
+      </trans-unit>
+      <trans-unit id="resourceDeployment.unknownExtension">
+        <source xml:lang="en">Unknown extension '{0}'</source>
+        <target state="translated">未知的延伸模組 '{0}'</target>
       </trans-unit>
       <trans-unit id="resourceTypePickerDialog.title">
         <source xml:lang="en">Select the deployment options</source>
@@ -1096,10 +1000,6 @@
   </file>
   <file original="extensions/resource-deployment/dist/main" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="resourceDeployment.FailedToLoadExtension">
-        <source xml:lang="en">Failed to load extension: {0}, Error detected in the resource type definition in package.json, check debug console for details.</source>
-        <target state="translated">無法載入延伸模組: {0}，在 package.json 的資源類型定義中偵測到錯誤，請查看偵錯主控台以取得詳細資料。</target>
-      </trans-unit>
       <trans-unit id="resourceDeployment.UnknownResourceType">
         <source xml:lang="en">The resource type: {0} is not defined</source>
         <target state="translated">資源類型: 未定義 {0}</target>
@@ -2222,13 +2122,13 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Deployment pre-requisites</source>
         <target state="translated">部署必要條件</target>
       </trans-unit>
-      <trans-unit id="deploymentDialog.FailedEulaValidation">
-        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
-        <target state="translated">若要繼續，您必須接受授權條款</target>
-      </trans-unit>
       <trans-unit id="deploymentDialog.FailedToolsInstallation">
         <source xml:lang="en">Some tools were still not discovered. Please make sure that they are installed, running and discoverable</source>
         <target state="translated">仍未探索到某些工具。請確認這些工具已安裝、正在執行並可供探索</target>
+      </trans-unit>
+      <trans-unit id="deploymentDialog.FailedEulaValidation">
+        <source xml:lang="en">To proceed, you must accept the terms of the End User License Agreement(EULA)</source>
+        <target state="translated">若要繼續，您必須接受授權條款</target>
       </trans-unit>
       <trans-unit id="deploymentDialog.loadingRequiredToolsCompleted">
         <source xml:lang="en">Loading required tools information completed</source>
@@ -2378,6 +2278,10 @@ Select a different subscription containing at least one server</source>
         <source xml:lang="en">Azure Data CLI</source>
         <target state="translated">Azure Data CLI</target>
       </trans-unit>
+      <trans-unit id="deploy.azdataExtMissing">
+        <source xml:lang="en">The Azure Data CLI extension must be installed to deploy this resource. Please install it through the extension gallery and try again.</source>
+        <target state="translated">必須安裝 Azure Data CLI 延伸模組，以部署此資源。請透過延伸模組庫安裝，然後再試一次。</target>
+      </trans-unit>
       <trans-unit id="deployCluster.GetToolVersionErrorInformation">
         <source xml:lang="en">Error retrieving version information. See output channel '{0}' for more details</source>
         <target state="translated">擷取版本資訊時發生錯誤。如需詳細資料，請參閱輸出通道 '{0}'</target>
@@ -2385,46 +2289,6 @@ Select a different subscription containing at least one server</source>
       <trans-unit id="deployCluster.GetToolVersionError">
         <source xml:lang="en">Error retrieving version information.{0}Invalid output received, get version command output: '{1}' </source>
         <target state="translated">擷取版本資訊時發生錯誤。{0}接收到的輸出無效，請取得版本命令輸出: '{1}'</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DeletingPreviousAzdata.msi">
-        <source xml:lang="en">deleting previously downloaded Azdata.msi if one exists …</source>
-        <target state="translated">正在刪除先前下載的 Azdata.msi (如果有的話)…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadingAndInstallingAzdata">
-        <source xml:lang="en">downloading Azdata.msi and installing azdata-cli …</source>
-        <target state="translated">正在下載 Azdata.msi 並安裝 azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DisplayingInstallationLog">
-        <source xml:lang="en">displaying the installation log …</source>
-        <target state="translated">正在顯示安裝記錄…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.TappingBrewRepository">
-        <source xml:lang="en">tapping into the brew repository for azdata-cli …</source>
-        <target state="translated">點選 Brew 存放庫以取得 azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.UpdatingBrewRepository">
-        <source xml:lang="en">updating the brew repository for azdata-cli installation …</source>
-        <target state="translated">正在更新 Brew 存放庫以安裝 azdata-cli…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.InstallingAzdata">
-        <source xml:lang="en">installing azdata …</source>
-        <target state="translated">正在安裝 azdata…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetUpdate">
-        <source xml:lang="en">updating repository information …</source>
-        <target state="translated">正在更新存放庫資訊…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AptGetPackages">
-        <source xml:lang="en">getting packages needed for azdata installation …</source>
-        <target state="translated">正在取得安裝 azdata 所需的套件…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.DownloadAndInstallingSigningKey">
-        <source xml:lang="en">downloading and installing the signing key for azdata …</source>
-        <target state="translated">正在下載並安裝 azdata 的簽署金鑰…</target>
-      </trans-unit>
-      <trans-unit id="resourceDeployment.Azdata.AddingAzdataRepositoryInformation">
-        <source xml:lang="en">adding the azdata repository information …</source>
-        <target state="translated">正在新增 azdata 存放庫資訊…</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hant/schema-compare.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/schema-compare.zh-Hant.xlf
@@ -16,27 +16,115 @@
       </trans-unit>
     </body>
   </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareOptionsDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="extensions/schema-compare/dist/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="SchemaCompareOptionsDialog.Ok">
-        <source xml:lang="en">Ok</source>
+      <trans-unit id="schemaCompareDialog.ok">
+        <source xml:lang="en">OK</source>
         <target state="translated">確定</target>
       </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Cancel">
+      <trans-unit id="schemaCompareDialog.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.SourceTitle">
+        <source xml:lang="en">Source</source>
+        <target state="translated">來源</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.TargetTitle">
+        <source xml:lang="en">Target</source>
+        <target state="translated">目標</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
+        <source xml:lang="en">File</source>
+        <target state="translated">FILE</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
+        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
+        <target state="translated">資料層應用程式檔案 (.dacpac)</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.databaseButtonLabel">
+        <source xml:lang="en">Database</source>
+        <target state="translated">資料庫</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.radioButtonsLabel">
+        <source xml:lang="en">Type</source>
+        <target state="translated">類型</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
+        <source xml:lang="en">Server</source>
+        <target state="translated">伺服器</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
+        <source xml:lang="en">Database</source>
+        <target state="translated">資料庫</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.dialogTitle">
+        <source xml:lang="en">Schema Compare</source>
+        <target state="translated">結構描述比較</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceMessage">
+        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">已選取其他來源結構描述。要比較以查看比較結果嗎?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentTargetMessage">
+        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
+        <target state="translated">已選取其他目標結構描述。要比較以查看比較結果嗎?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
+        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
+        <target state="translated">已選取不同的來源和結構描述。要比較以查看比較結果嗎?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.Yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.No">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceTextBox">
+        <source xml:lang="en">Source file</source>
+        <target state="translated">原始程式檔</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetTextBox">
+        <source xml:lang="en">Target file</source>
+        <target state="translated">目標檔案</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceDatabaseDropdown">
+        <source xml:lang="en">Source Database</source>
+        <target state="translated">來源資料庫</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetDatabaseDropdown">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">目標資料庫</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.sourceServerDropdown">
+        <source xml:lang="en">Source Server</source>
+        <target state="translated">來源伺服器</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.targetServerDropdown">
+        <source xml:lang="en">Target Server</source>
+        <target state="translated">目標伺服器</target>
+      </trans-unit>
+      <trans-unit id="schemaCompareDialog.defaultUser">
+        <source xml:lang="en">default</source>
+        <target state="translated">預設</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openFile">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開啟</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectSourceFile">
+        <source xml:lang="en">Select source file</source>
+        <target state="translated">選取來源檔案</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectTargetFile">
+        <source xml:lang="en">Select target file</source>
+        <target state="translated">選取目標檔案</target>
       </trans-unit>
       <trans-unit id="SchemaCompareOptionsDialog.Reset">
         <source xml:lang="en">Reset</source>
         <target state="translated">重設</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="SchemaCompareOptionsDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
       </trans-unit>
       <trans-unit id="schemaCompareOptions.RecompareMessage">
         <source xml:lang="en">Options have changed. Recompare to see the comparison?</source>
@@ -53,6 +141,174 @@
       <trans-unit id="SchemaCompare.ObjectTypesOptionsLabel">
         <source xml:lang="en">Include Object Types</source>
         <target state="translated">包含物件類型</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.CompareDetailsTitle">
+        <source xml:lang="en">Compare Details</source>
+        <target state="translated">比較詳細資料</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.ApplyConfirmation">
+        <source xml:lang="en">Are you sure you want to update the target?</source>
+        <target state="translated">確定要更新目標嗎?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.RecompareToRefresh">
+        <source xml:lang="en">Press Compare to refresh the comparison.</source>
+        <target state="translated">按下 [比較] 即可重新整理比較結果。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptEnabledButton">
+        <source xml:lang="en">Generate script to deploy changes to target</source>
+        <target state="translated">產生指令碼以將變更部署至目標</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptNoChanges">
+        <source xml:lang="en">No changes to script</source>
+        <target state="translated">指令碼沒有任何變更</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
+        <source xml:lang="en">Apply changes to target</source>
+        <target state="translated">將變更套用至目標</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyNoChanges">
+        <source xml:lang="en">No changes to apply</source>
+        <target state="translated">沒有任何要套用的變更</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeExcludeInfoMessage">
+        <source xml:lang="en">Please note that include/exclude operations can take a moment to calculate affected dependencies</source>
+        <target state="translated">請注意，包含/排除作業可能需要一些時間來計算受影響的相依性</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.deleteAction">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">刪除</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.changeAction">
+        <source xml:lang="en">Change</source>
+        <target state="translated">變更</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.addAction">
+        <source xml:lang="en">Add</source>
+        <target state="translated">新增</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.differencesTableTitle">
+        <source xml:lang="en">Comparison between Source and Target</source>
+        <target state="translated">來源和目標之間的比較</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.waitText">
+        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
+        <target state="translated">正在將比較結果初始化。這可能需要一些時間。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.startText">
+        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
+        <target state="translated">若要比較兩個結構描述，請先選取來源結構描述，然後按下 [比較]。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.noDifferences">
+        <source xml:lang="en">No schema differences were found.</source>
+        <target state="translated">找不到任何結構描述差異。</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.typeColumn">
+        <source xml:lang="en">Type</source>
+        <target state="translated">類型</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceNameColumn">
+        <source xml:lang="en">Source Name</source>
+        <target state="translated">來源名稱</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.includeColumnName">
+        <source xml:lang="en">Include</source>
+        <target state="translated">包含</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.actionColumn">
+        <source xml:lang="en">Action</source>
+        <target state="translated">動作</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetNameColumn">
+        <source xml:lang="en">Target Name</source>
+        <target state="translated">目標名稱</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
+        <source xml:lang="en">Generate script is enabled when the target is a database</source>
+        <target state="translated">當目標為資料庫時，會啟用產生指令碼</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
+        <source xml:lang="en">Apply is enabled when the target is a database</source>
+        <target state="translated">當目標為資料庫時會啟用套用</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessageWithDependent">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist, such as {1}</source>
+        <target state="translated">無法排除 {0}。包含的相依性已存在，例如 {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessageWithDependent">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist, such as {1}</source>
+        <target state="translated">不無法包含 {0}。排除的相依性已存在，例如 {1}</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotExcludeMessage">
+        <source xml:lang="en">Cannot exclude {0}. Included dependents exist</source>
+        <target state="translated">無法排除 {0}。包含的相依性已存在</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cannotIncludeMessage">
+        <source xml:lang="en">Cannot include {0}. Excluded dependents exist</source>
+        <target state="translated">無法包含 {0}。排除的相依性已存在</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.compareButton">
+        <source xml:lang="en">Compare</source>
+        <target state="translated">比較</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.cancelCompareButton">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.generateScriptButton">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">產生指令碼</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.optionsButton">
+        <source xml:lang="en">Options</source>
+        <target state="translated">選項</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.updateButton">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">套用</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchDirectionButton">
+        <source xml:lang="en">Switch direction</source>
+        <target state="translated">切換方向</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.switchButtonTitle">
+        <source xml:lang="en">Switch source and target</source>
+        <target state="translated">切換來源和目標</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.sourceButtonTitle">
+        <source xml:lang="en">Select Source</source>
+        <target state="translated">選取來源</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.targetButtonTitle">
+        <source xml:lang="en">Select Target</source>
+        <target state="translated">選取目標</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButton">
+        <source xml:lang="en">Open .scmp file</source>
+        <target state="translated">開啟 .scmp 檔案</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.openScmpButtonTitle">
+        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
+        <target state="translated">載入儲存在 .scmp 檔案中的來源、目標和選項</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButton">
+        <source xml:lang="en">Save .scmp file</source>
+        <target state="translated">儲存 .scmp 檔案</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveScmpButtonTitle">
+        <source xml:lang="en">Save source and target, options, and excluded elements</source>
+        <target state="translated">儲存來源和目標、選項及排除的元素</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.saveFile">
+        <source xml:lang="en">Save</source>
+        <target state="translated">儲存</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.GetConnectionString">
+        <source xml:lang="en">Do you want to connect to {0}?</source>
+        <target state="translated">是否要連接到 {0}?</target>
+      </trans-unit>
+      <trans-unit id="schemaCompare.selectConnection">
+        <source xml:lang="en">Select connection</source>
+        <target state="translated">選取連線</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.IgnoreTableOptions">
         <source xml:lang="en">Ignore Table Options</source>
@@ -407,8 +663,8 @@
         <target state="translated">資料庫角色</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.DatabaseTriggers">
-        <source xml:lang="en">DatabaseTriggers</source>
-        <target state="translated">DatabaseTriggers</target>
+        <source xml:lang="en">Database Triggers</source>
+        <target state="translated">資料庫觸發程序</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Defaults">
         <source xml:lang="en">Defaults</source>
@@ -426,6 +682,14 @@
         <source xml:lang="en">External File Formats</source>
         <target state="translated">外部檔案格式</target>
       </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreams">
+        <source xml:lang="en">External Streams</source>
+        <target state="translated">外部資料流</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.ExternalStreamingJobs">
+        <source xml:lang="en">External Streaming Jobs</source>
+        <target state="translated">外部串流作業</target>
+      </trans-unit>
       <trans-unit id="SchemaCompare.ExternalTables">
         <source xml:lang="en">External Tables</source>
         <target state="translated">外部資料表</target>
@@ -433,6 +697,10 @@
       <trans-unit id="SchemaCompare.Filegroups">
         <source xml:lang="en">Filegroups</source>
         <target state="translated">檔案群組</target>
+      </trans-unit>
+      <trans-unit id="SchemaCompare.Files">
+        <source xml:lang="en">Files</source>
+        <target state="translated">檔案</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.FileTables">
         <source xml:lang="en">File Tables</source>
@@ -503,12 +771,12 @@
         <target state="translated">簽章</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.StoredProcedures">
-        <source xml:lang="en">StoredProcedures</source>
-        <target state="translated">StoredProcedures</target>
+        <source xml:lang="en">Stored Procedures</source>
+        <target state="translated">預存程序</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.SymmetricKeys">
-        <source xml:lang="en">SymmetricKeys</source>
-        <target state="translated">SymmetricKeys</target>
+        <source xml:lang="en">Symmetric Keys</source>
+        <target state="translated">對稱金鑰</target>
       </trans-unit>
       <trans-unit id="SchemaCompare.Synonyms">
         <source xml:lang="en">Synonyms</source>
@@ -926,285 +1194,29 @@
         <source xml:lang="en">Specifies whether differences in table column order should be ignored or updated when you publish to a database.</source>
         <target state="translated">指定當您發佈至資料庫時，要略過或更新資料表資料行順序的差異。</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/dialogs/schemaCompareDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="schemaCompareDialog.ok">
-        <source xml:lang="en">Ok</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.SourceTitle">
-        <source xml:lang="en">Source</source>
-        <target state="translated">來源</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.TargetTitle">
-        <source xml:lang="en">Target</source>
-        <target state="translated">目標</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.fileTextBoxLabel">
-        <source xml:lang="en">File</source>
-        <target state="translated">FILE</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dacpacRadioButtonLabel">
-        <source xml:lang="en">Data-tier Application File (.dacpac)</source>
-        <target state="translated">資料層應用程式檔案 (.dacpac)</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.databaseButtonLabel">
-        <source xml:lang="en">Database</source>
-        <target state="translated">資料庫</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.radioButtonsLabel">
-        <source xml:lang="en">Type</source>
-        <target state="translated">類型</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.serverDropdownTitle">
-        <source xml:lang="en">Server</source>
-        <target state="translated">伺服器</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.databaseDropdownTitle">
-        <source xml:lang="en">Database</source>
-        <target state="translated">資料庫</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noActiveConnectionsText">
-        <source xml:lang="en">No active connections</source>
-        <target state="translated">沒有使用中的連線</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.dialogTitle">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">結構描述比較</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceMessage">
-        <source xml:lang="en">A different source schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">已選取其他來源結構描述。要比較以查看比較結果嗎?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentTargetMessage">
-        <source xml:lang="en">A different target schema has been selected. Compare to see the comparison?</source>
-        <target state="translated">已選取其他目標結構描述。要比較以查看比較結果嗎?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.differentSourceTargetMessage">
-        <source xml:lang="en">Different source and target schemas have been selected. Compare to see the comparison?</source>
-        <target state="translated">已選取不同的來源和結構描述。要比較以查看比較結果嗎?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.Yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.No">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開啟</target>
-      </trans-unit>
-      <trans-unit id="schemaCompareDialog.defaultUser">
-        <source xml:lang="en">default</source>
-        <target state="translated">預設</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="extensions/schema-compare/out/schemaCompareMainWindow" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="schemaCompare.CompareDetailsTitle">
-        <source xml:lang="en">Compare Details</source>
-        <target state="translated">比較詳細資料</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyConfirmation">
-        <source xml:lang="en">Are you sure you want to update the target?</source>
-        <target state="translated">確定要更新目標嗎?</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.RecompareToRefresh">
-        <source xml:lang="en">Press Compare to refresh the comparison.</source>
-        <target state="translated">按下 [比較] 即可重新整理比較結果。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptEnabledButton">
-        <source xml:lang="en">Generate script to deploy changes to target</source>
-        <target state="translated">產生指令碼以將變更部署至目標</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptNoChanges">
-        <source xml:lang="en">No changes to script</source>
-        <target state="translated">指令碼沒有任何變更</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonEnabledTitle">
-        <source xml:lang="en">Apply changes to target</source>
-        <target state="translated">將變更套用至目標</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyNoChanges">
-        <source xml:lang="en">No changes to apply</source>
-        <target state="translated">沒有任何要套用的變更</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.deleteAction">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">刪除</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.changeAction">
-        <source xml:lang="en">Change</source>
-        <target state="translated">變更</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.addAction">
-        <source xml:lang="en">Add</source>
-        <target state="translated">新增</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.Title">
-        <source xml:lang="en">Schema Compare</source>
-        <target state="translated">結構描述比較</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceLabel">
-        <source xml:lang="en">Source</source>
-        <target state="translated">來源</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetLabel">
-        <source xml:lang="en">Target</source>
-        <target state="translated">目標</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchLabel">
-        <source xml:lang="en">➔</source>
-        <target state="translated">➔</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.waitText">
-        <source xml:lang="en">Initializing Comparison. This might take a moment.</source>
-        <target state="translated">正在將比較結果初始化。這可能需要一些時間。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.startText">
-        <source xml:lang="en">To compare two schemas, first select a source schema and target schema, then press Compare.</source>
-        <target state="translated">若要比較兩個結構描述，請先選取來源結構描述，然後按下 [比較]。</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.noDifferences">
-        <source xml:lang="en">No schema differences were found.</source>
-        <target state="translated">找不到任何結構描述差異。</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.compareErrorMessage">
         <source xml:lang="en">Schema Compare failed: {0}</source>
         <target state="translated">結構描述比較失敗: {0}</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.typeColumn">
-        <source xml:lang="en">Type</source>
-        <target state="translated">類型</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceNameColumn">
-        <source xml:lang="en">Source Name</source>
-        <target state="translated">來源名稱</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.includeColumnName">
-        <source xml:lang="en">Include</source>
-        <target state="translated">包含</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.actionColumn">
-        <source xml:lang="en">Action</source>
-        <target state="translated">動作</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetNameColumn">
-        <source xml:lang="en">Target Name</source>
-        <target state="translated">目標名稱</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButtonDisabledTitle">
-        <source xml:lang="en">Generate script is enabled when the target is a database</source>
-        <target state="translated">當目標為資料庫時，會啟用產生指令碼</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.applyButtonDisabledTitle">
-        <source xml:lang="en">Apply is enabled when the target is a database</source>
-        <target state="translated">當目標為資料庫時會啟用套用</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButton">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">比較</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.compareButtonTitle">
-        <source xml:lang="en">Compare</source>
-        <target state="translated">比較</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButton">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.cancelCompareButtonTitle">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
+      <trans-unit id="schemaCompare.saveScmpErrorMessage">
+        <source xml:lang="en">Save scmp failed: '{0}'</source>
+        <target state="translated">無法儲存 scmp: '{0}'</target>
       </trans-unit>
       <trans-unit id="schemaCompare.cancelErrorMessage">
         <source xml:lang="en">Cancel schema compare failed: '{0}'</source>
         <target state="translated">取消結構描述比較失敗: '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.generateScriptButton">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">產生指令碼</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.generateScriptErrorMessage">
         <source xml:lang="en">Generate script failed: '{0}'</source>
         <target state="translated">無法產生指令碼: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButton">
-        <source xml:lang="en">Options</source>
-        <target state="translated">選項</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.optionsButtonTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">選項</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.updateButton">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">套用</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.ApplyYes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
       </trans-unit>
       <trans-unit id="schemaCompare.updateErrorMessage">
         <source xml:lang="en">Schema Compare Apply failed '{0}'</source>
         <target state="translated">結構描述比較套用失敗 '{0}'</target>
       </trans-unit>
-      <trans-unit id="schemaCompare.switchDirectionButton">
-        <source xml:lang="en">Switch direction</source>
-        <target state="translated">切換方向</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.switchButtonTitle">
-        <source xml:lang="en">Switch source and target</source>
-        <target state="translated">切換來源和目標</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.sourceButtonTitle">
-        <source xml:lang="en">Select Source</source>
-        <target state="translated">選取來源</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.targetButtonTitle">
-        <source xml:lang="en">Select Target</source>
-        <target state="translated">選取目標</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButton">
-        <source xml:lang="en">Open .scmp file</source>
-        <target state="translated">開啟 .scmp 檔案</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openScmpButtonTitle">
-        <source xml:lang="en">Load source, target, and options saved in an .scmp file</source>
-        <target state="translated">載入儲存在 .scmp 檔案中的來源、目標和選項</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.openFile">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開啟</target>
-      </trans-unit>
       <trans-unit id="schemaCompare.openScmpErrorMessage">
         <source xml:lang="en">Open scmp failed: '{0}'</source>
         <target state="translated">無法開啟 scmp: '{0}'</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButton">
-        <source xml:lang="en">Save .scmp file</source>
-        <target state="translated">儲存 .scmp 檔案</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpButtonTitle">
-        <source xml:lang="en">Save source and target, options, and excluded elements</source>
-        <target state="translated">儲存來源和目標、選項及排除的元素</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveFile">
-        <source xml:lang="en">Save</source>
-        <target state="translated">儲存</target>
-      </trans-unit>
-      <trans-unit id="schemaCompare.saveScmpErrorMessage">
-        <source xml:lang="en">Save scmp failed: '{0}'</source>
-        <target state="translated">無法儲存 scmp: '{0}'</target>
       </trans-unit>
     </body>
   </file>

--- a/resources/xlf/zh-hant/sql.zh-Hant.xlf
+++ b/resources/xlf/zh-hant/sql.zh-Hant.xlf
@@ -1,2251 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="imageCopyingNotSupported">
-        <source xml:lang="en">Copying images is not supported</source>
-        <target state="translated">不支援複製映像</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="gettingStarted">
-        <source xml:lang="en">Get Started</source>
-        <target state="translated">開始</target>
-      </trans-unit>
-      <trans-unit id="showReleaseNotes">
-        <source xml:lang="en">Show Getting Started</source>
-        <target state="translated">顯示入門指南</target>
-      </trans-unit>
-      <trans-unit id="miGettingStarted">
-        <source xml:lang="en">Getting &amp;&amp;Started</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">開始使用(&amp;&amp;S)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="queryHistoryConfigurationTitle">
-        <source xml:lang="en">QueryHistory</source>
-        <target state="translated">查詢歷史記錄</target>
-      </trans-unit>
-      <trans-unit id="queryHistoryCaptureEnabled">
-        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
-        <target state="translated">是否啟用了查詢歷史記錄擷取。若未啟用，將不會擷取已經執行的查詢。</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">檢視</target>
-      </trans-unit>
-      <trans-unit id="miViewQueryHistory">
-        <source xml:lang="en">&amp;&amp;Query History</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">查詢歷史記錄(&amp;&amp;Q)</target>
-      </trans-unit>
-      <trans-unit id="queryHistory">
-        <source xml:lang="en">Query History</source>
-        <target state="translated">查詢歷史記錄</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connectingLabel">
-        <source xml:lang="en">Connecting: {0}</source>
-        <target state="translated">正在連線: {0}</target>
-      </trans-unit>
-      <trans-unit id="runningCommandLabel">
-        <source xml:lang="en">Running command: {0}</source>
-        <target state="translated">正在執行命令: {0}</target>
-      </trans-unit>
-      <trans-unit id="openingNewQueryLabel">
-        <source xml:lang="en">Opening new query: {0}</source>
-        <target state="translated">正在開啟新查詢: {0}</target>
-      </trans-unit>
-      <trans-unit id="warnServerRequired">
-        <source xml:lang="en">Cannot connect as no server information was provided</source>
-        <target state="translated">因為未提供伺服器資訊，所以無法連線</target>
-      </trans-unit>
-      <trans-unit id="errConnectUrl">
-        <source xml:lang="en">Could not open URL due to error {0}</source>
-        <target state="translated">因為發生錯誤 {0}，導致無法開啟 URL</target>
-      </trans-unit>
-      <trans-unit id="connectServerDetail">
-        <source xml:lang="en">This will connect to server {0}</source>
-        <target state="translated">這會連線到伺服器 {0}</target>
-      </trans-unit>
-      <trans-unit id="confirmConnect">
-        <source xml:lang="en">Are you sure you want to connect?</source>
-        <target state="translated">確定要連線嗎?</target>
-      </trans-unit>
-      <trans-unit id="open">
-        <source xml:lang="en">&amp;&amp;Open</source>
-        <target state="translated">開啟(&amp;&amp;O)</target>
-      </trans-unit>
-      <trans-unit id="connectingQueryLabel">
-        <source xml:lang="en">Connecting query file</source>
-        <target state="translated">正在連線到查詢檔案</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="InProgressWarning">
-        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
-        <target state="translated">1 個或更多的工作正在進行中。是否確實要退出?</target>
-      </trans-unit>
-      <trans-unit id="taskService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="taskService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="enablePreviewFeatures.notice">
-        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
-        <target state="translated">預覽功能可讓您完整存取新功能及改善的功能，增強您在 Azure Data Studio 的體驗。您可以參閱[這裡]({0})深入了解預覽功能。是否要啟用預覽功能?</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.yes">
-        <source xml:lang="en">Yes (recommended)</source>
-        <target state="translated">是 (建議)</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="enablePreviewFeatures.never">
-        <source xml:lang="en">No, don't show again</source>
-        <target state="translated">不，不要再顯示</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="toggleQueryHistory">
-        <source xml:lang="en">Toggle Query History</source>
-        <target state="translated">切換查詢歷史記錄</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">刪除</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.clearLabel">
-        <source xml:lang="en">Clear All History</source>
-        <target state="translated">清除所有歷史記錄</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.openQuery">
-        <source xml:lang="en">Open Query</source>
-        <target state="translated">開啟查詢</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">執行查詢</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.toggleCaptureLabel">
-        <source xml:lang="en">Toggle Query History capture</source>
-        <target state="translated">切換查詢歷史記錄擷取</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.disableCapture">
-        <source xml:lang="en">Pause Query History Capture</source>
-        <target state="translated">暫停查詢歷史記錄擷取</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.enableCapture">
-        <source xml:lang="en">Start Query History Capture</source>
-        <target state="translated">開始查詢歷史記錄擷取</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="noQueriesMessage">
-        <source xml:lang="en">No queries to display.</source>
-        <target state="translated">沒有查詢可顯示。</target>
-      </trans-unit>
-      <trans-unit id="queryHistory.regTreeAriaLabel">
-        <source xml:lang="en">Query History</source>
-        <note>QueryHistory</note>
-        <target state="translated">查詢歷史記錄</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="error">
-        <source xml:lang="en">Error</source>
-        <target state="translated">錯誤</target>
-      </trans-unit>
-      <trans-unit id="warning">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">警告</target>
-      </trans-unit>
-      <trans-unit id="info">
-        <source xml:lang="en">Info</source>
-        <target state="translated">資訊</target>
-      </trans-unit>
-      <trans-unit id="ignore">
-        <source xml:lang="en">Ignore</source>
-        <target state="translated">忽略</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="saveAsNotSupported">
-        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
-        <target state="translated">正在將結果儲存為其他格式，但此資料提供者已停用該格式。</target>
-      </trans-unit>
-      <trans-unit id="noSerializationProvider">
-        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
-        <target state="translated">因為未註冊任何提供者，所以無法序列化資料</target>
-      </trans-unit>
-      <trans-unit id="unknownSerializationError">
-        <source xml:lang="en">Serialization failed with an unknown error</source>
-        <target state="translated">因為發生未知錯誤，導致序列化失敗</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="adminService.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
-        <target state="translated">必需連線以便與 adminservice 互動</target>
-      </trans-unit>
-      <trans-unit id="adminService.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">未註冊處理常式</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="filebrowser.selectFile">
-        <source xml:lang="en">Select a file</source>
-        <target state="translated">選擇檔案</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="asmt.providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
-        <target state="translated">需要連線才能與評定服務互動</target>
-      </trans-unit>
-      <trans-unit id="asmt.noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">未註冊任何處理常式</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="resultsGridConfigurationTitle">
-        <source xml:lang="en">Results Grid and Messages</source>
-        <target state="translated">結果方格與訊息</target>
-      </trans-unit>
-      <trans-unit id="fontFamily">
-        <source xml:lang="en">Controls the font family.</source>
-        <target state="translated">控制字型家族。</target>
-      </trans-unit>
-      <trans-unit id="fontWeight">
-        <source xml:lang="en">Controls the font weight.</source>
-        <target state="translated">控制字型粗細。</target>
-      </trans-unit>
-      <trans-unit id="fontSize">
-        <source xml:lang="en">Controls the font size in pixels.</source>
-        <target state="translated">控制字型大小 (像素)。</target>
-      </trans-unit>
-      <trans-unit id="letterSpacing">
-        <source xml:lang="en">Controls the letter spacing in pixels.</source>
-        <target state="translated">控制字母間距 (像素)。</target>
-      </trans-unit>
-      <trans-unit id="rowHeight">
-        <source xml:lang="en">Controls the row height in pixels</source>
-        <target state="translated">控制列高 (像素)</target>
-      </trans-unit>
-      <trans-unit id="cellPadding">
-        <source xml:lang="en">Controls the cell padding in pixels</source>
-        <target state="translated">控制資料格填補值 (像素)</target>
-      </trans-unit>
-      <trans-unit id="autoSizeColumns">
-        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
-        <target state="translated">自動調整初始結果的欄寬大小。大量欄位或大型資料格可能會造成效能問題</target>
-      </trans-unit>
-      <trans-unit id="maxColumnWidth">
-        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
-        <target state="translated">自動調整大小之欄位的寬度上限 (像素)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dataExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">檢視</target>
-      </trans-unit>
-      <trans-unit id="databaseConnections">
-        <source xml:lang="en">Database Connections</source>
-        <target state="translated">資料庫連線</target>
-      </trans-unit>
-      <trans-unit id="datasource.connections">
-        <source xml:lang="en">data source connections</source>
-        <target state="translated">資料來源連線</target>
-      </trans-unit>
-      <trans-unit id="datasource.connectionGroups">
-        <source xml:lang="en">data source groups</source>
-        <target state="translated">資料來源群組</target>
-      </trans-unit>
-      <trans-unit id="startupConfig">
-        <source xml:lang="en">Startup Configuration</source>
-        <target state="translated">啟動組態</target>
-      </trans-unit>
-      <trans-unit id="startup.alwaysShowServersView">
-        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
-        <target state="translated">預設為在 Azure Data Studio 啟動時要顯示的伺服器檢視即為 True；如應顯示上次開啟的檢視則為 False</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">中斷連線</target>
-      </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">重新整理</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="previewFeatures.configTitle">
-        <source xml:lang="en">Preview Features</source>
-        <target state="translated">預覽功能</target>
-      </trans-unit>
-      <trans-unit id="previewFeatures.configEnable">
-        <source xml:lang="en">Enable unreleased preview features</source>
-        <target state="translated">啟用未發佈的預覽功能</target>
-      </trans-unit>
-      <trans-unit id="showConnectDialogOnStartup">
-        <source xml:lang="en">Show connect dialog on startup</source>
-        <target state="translated">啟動時顯示連線對話方塊</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
-        <source xml:lang="en">Obsolete API Notification</source>
-        <target state="translated">淘汰 API 通知</target>
-      </trans-unit>
-      <trans-unit id="enableObsoleteApiUsageNotification">
-        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
-        <target state="translated">啟用/停用使用淘汰的 API 通知</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accounts.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="status.problems">
-        <source xml:lang="en">Problems</source>
-        <target state="translated">問題</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="inProgressTasksChangesBadge">
-        <source xml:lang="en">{0} in progress tasks</source>
-        <target state="translated">{0} 正在執行的工作</target>
-      </trans-unit>
-      <trans-unit id="viewCategory">
-        <source xml:lang="en">View</source>
-        <target state="translated">檢視</target>
-      </trans-unit>
-      <trans-unit id="tasks">
-        <source xml:lang="en">Tasks</source>
-        <target state="translated">工作</target>
-      </trans-unit>
-      <trans-unit id="miViewTasks">
-        <source xml:lang="en">&amp;&amp;Tasks</source>
-        <note>&amp;&amp; denotes a mnemonic</note>
-        <target state="translated">工作(&amp;&amp;T)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="sql.maxRecentConnectionsDescription">
-        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
-        <target state="translated">連線列表內最近使用的連線數上限。</target>
-      </trans-unit>
-      <trans-unit id="sql.defaultEngineDescription">
-        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
-        <target state="translated">要使用的預設 SQL 引擎。這會驅動 .sql 檔案中的預設語言提供者，以及建立新連線時要使用的預設。</target>
-      </trans-unit>
-      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
-        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
-        <target state="translated">嘗試在連線對話方塊開啟或已執行貼上時剖析剪貼簿的內容。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="serverGroup.colors">
-        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
-        <target state="translated">在物件總管 Viewlet 中使用的伺服器群組調色盤。</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.autoExpand">
-        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
-        <target state="translated">物件總管 Viewlet 中的自動展開伺服器群組。</target>
-      </trans-unit>
-      <trans-unit id="serverTree.useAsyncServerTree">
-        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
-        <target state="translated">(預覽) 針對伺服器檢視及連線對話方塊使用新的非同步伺服器樹狀結構，並支援動態節點篩選等新功能。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="carbon.extension.contributes.account.id">
-        <source xml:lang="en">Identifier of the account type</source>
-        <target state="translated">帳戶類型的識別碼</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
-        <target state="translated">(選用) 用於 UI 中表示 accpunt 的圖示。任一檔案路徑或主題化的設定。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">使用亮色主題時的圖示路徑</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">使用暗色主題時的圖像路徑</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.account">
-        <source xml:lang="en">Contributes icons to account provider.</source>
-        <target state="translated">將圖示貢獻給帳戶供應者。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="showEditDataSqlPaneOnStartup">
-        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
-        <target state="translated">啟動時顯示 [編輯資料] SQL 窗格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="yAxisMin">
-        <source xml:lang="en">Minimum value of the y axis</source>
-        <target state="translated">y 軸的最小值</target>
-      </trans-unit>
-      <trans-unit id="yAxisMax">
-        <source xml:lang="en">Maximum value of the y axis</source>
-        <target state="translated">y 軸的最大值</target>
-      </trans-unit>
-      <trans-unit id="barchart.yAxisLabel">
-        <source xml:lang="en">Label for the y axis</source>
-        <target state="translated">Y 軸的標籤</target>
-      </trans-unit>
-      <trans-unit id="xAxisMin">
-        <source xml:lang="en">Minimum value of the x axis</source>
-        <target state="translated">X 軸的最小值</target>
-      </trans-unit>
-      <trans-unit id="xAxisMax">
-        <source xml:lang="en">Maximum value of the x axis</source>
-        <target state="translated">X 軸的最大值</target>
-      </trans-unit>
-      <trans-unit id="barchart.xAxisLabel">
-        <source xml:lang="en">Label for the x axis</source>
-        <target state="translated">X 軸標籤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">資源檢視器</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dataTypeDescription">
-        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
-        <target state="translated">指定圖表資料集的資料屬性。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="countInsightDescription">
-        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
-        <target state="translated">為結果集中的每一個資料行，在資料列 0 中先顯示計數值，再顯示資料行名稱。例如，支援 '1 Healthy'，'3 Unhealthy'；其中 'Healthy' 為資料行名稱，1 為資料列 1 中資料格 1 的值</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="tableInsightDescription">
-        <source xml:lang="en">Displays the results in a simple table</source>
-        <target state="translated">在簡單資料表中顯示結果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="imageInsightDescription">
-        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
-        <target state="translated">顯示映像，如使用 ggplot2 R 查詢返回的映像。</target>
-      </trans-unit>
-      <trans-unit id="imageFormatDescription">
-        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
-        <target state="translated">預期格式是什麼 - 是 JPEG、PNG 或其他格式?</target>
-      </trans-unit>
-      <trans-unit id="encodingDescription">
-        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
-        <target state="translated">此編碼為十六進位、base64 或是其他格式?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="dashboard.editor.label">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">儀表板</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.container.webview">
-        <source xml:lang="en">The webview that will be displayed in this tab.</source>
-        <target state="translated">顯示在此索引標籤的 Web 檢視。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.container.controlhost">
-        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
-        <target state="translated">會在此索引標籤中顯示的 controlhost。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.container.widgets">
-        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
-        <target state="translated">顯示在此索引標籤中的小工具清單。</target>
-      </trans-unit>
-      <trans-unit id="widgetContainer.invalidInputs">
-        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
-        <target state="translated">延伸模組的 widgets-container 中應有 widgets 的清單。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.container.gridtab.items">
-        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
-        <target state="translated">顯示在此索引標籤的小工具或 Web 檢視的清單。</target>
-      </trans-unit>
-      <trans-unit id="gridContainer.invalidInputs">
-        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
-        <target state="translated">延伸模組的 widgets-container 中應有 widgets 或 webviews。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
-        <source xml:lang="en">Unique identifier for this container.</source>
-        <target state="translated">此容器的唯一識別碼。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
-        <source xml:lang="en">The container that will be displayed in the tab.</source>
-        <target state="translated">顯示於索引標籤的容器。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.containers">
-        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
-        <target state="translated">提供一個或多個儀表板容器，讓使用者可增加至其儀表板中。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noIdError">
-        <source xml:lang="en">No id in dashboard container specified for extension.</source>
-        <target state="translated">為延伸模組指定的儀表板容器中沒有任何識別碼。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.noContainerError">
-        <source xml:lang="en">No container in dashboard container specified for extension.</source>
-        <target state="translated">為延伸模組指定的儀表板容器中沒有任何容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">至少須為每個空間定義剛好 1 個儀表板容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
-        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
-        <target state="translated">延伸模組的儀表板容器中有不明的容器類型定義。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.container.left-nav-bar.id">
-        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
-        <target state="translated">導覽區的唯一識別碼。將傳遞給任何要求的延伸模組。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(選用) 用於 UI 中表示導覽區的圖示。任一檔案路徑或主題化的設定。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">使用亮色主題時的圖示路徑</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">使用暗色主題時的圖像路徑</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.title">
-        <source xml:lang="en">Title of the nav section to show the user.</source>
-        <target state="translated">顯示給使用者的導覽區標題。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar.container">
-        <source xml:lang="en">The container that will be displayed in this nav section.</source>
-        <target state="translated">顯示在此導覽區的容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboard.container.left-nav-bar">
-        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
-        <target state="translated">在導覽區顯示儀表板容器清單。</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingTitle.error">
-        <source xml:lang="en">No title in nav section specified for extension.</source>
-        <target state="translated">為延伸模組指定的導覽區段中沒有標題。</target>
-      </trans-unit>
-      <trans-unit id="navSection.missingContainer.error">
-        <source xml:lang="en">No container in nav section specified for extension.</source>
-        <target state="translated">為延伸模組指定的導覽區段中沒有任何容器。</target>
-      </trans-unit>
-      <trans-unit id="navSection.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
-        <target state="translated">至少須為每個空間定義剛好 1 個儀表板容器。</target>
-      </trans-unit>
-      <trans-unit id="navSection.invalidContainer.error">
-        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
-        <target state="translated">NAV_SECTION 中的 NAV_SECTION 對延伸模組而言是無效的容器。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.container.modelview">
-        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
-        <target state="translated">將在此索引標籤中顯示的 model-backed 檢視。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">備份</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">還原</target>
-      </trans-unit>
-      <trans-unit id="backup">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">還原</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="azure.openInAzurePortal.title">
-        <source xml:lang="en">Open in Azure Portal</source>
-        <target state="translated">在 Azure 入口網站中開啟</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="disconnected">
-        <source xml:lang="en">disconnected</source>
-        <target state="translated">已中斷連線</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="noProviderFound">
-        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
-        <target state="translated">因為找不到必要的連線提供者 ‘{0}’，所以無法展開</target>
-      </trans-unit>
-      <trans-unit id="loginCanceled">
-        <source xml:lang="en">User canceled</source>
-        <target state="translated">已取消使用者</target>
-      </trans-unit>
-      <trans-unit id="firewallCanceled">
-        <source xml:lang="en">Firewall dialog canceled</source>
-        <target state="translated">已取消防火牆對話方塊</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="providerIdNotValidError">
-        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
-        <target state="translated">需要連線才能與 JobManagementService 互動</target>
-      </trans-unit>
-      <trans-unit id="noHandlerRegistered">
-        <source xml:lang="en">No Handler Registered</source>
-        <target state="translated">未註冊任何處理常式</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="fileBrowserErrorMessage">
-        <source xml:lang="en">An error occured while loading the file browser.</source>
-        <target state="translated">載入檔案瀏覽器時發生錯誤。</target>
-      </trans-unit>
-      <trans-unit id="fileBrowserErrorDialogTitle">
-        <source xml:lang="en">File browser error</source>
-        <target state="translated">檔案瀏覽器錯誤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="schema.providerId">
-        <source xml:lang="en">Common id for the provider</source>
-        <target state="translated">提供者的通用識別碼。</target>
-      </trans-unit>
-      <trans-unit id="schema.displayName">
-        <source xml:lang="en">Display Name for the provider</source>
-        <target state="translated">提供者的顯示名稱</target>
-      </trans-unit>
-      <trans-unit id="schema.notebookKernelAlias">
-        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
-        <target state="translated">提供者的筆記本核心別名</target>
-      </trans-unit>
-      <trans-unit id="schema.iconPath">
-        <source xml:lang="en">Icon path for the server type</source>
-        <target state="translated">伺服器類型的圖示路徑</target>
-      </trans-unit>
-      <trans-unit id="schema.connectionOptions">
-        <source xml:lang="en">Options for connection</source>
-        <target state="translated">連線選項</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">此索引標籤的唯一識別碼。將傳遞給任何要求的延伸模組。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
-        <source xml:lang="en">Title of the tab to show the user.</source>
-        <target state="translated">顯示給使用者的索引標籤的標題。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
-        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
-        <target state="translated">此索引標籤的描述將顯示給使用者。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">必須為 True 以顯示此項目的條件</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tab.provider">
-        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
-        <target state="translated">定義與此索引標籤相容的連線類型。若未設定，則預設值為 'MSSQL'</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
-        <source xml:lang="en">The container that will be displayed in this tab.</source>
-        <target state="translated">將在此索引標籤中顯示的容器。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
-        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
-        <target state="translated">是否應一律顯示此索引標籤或僅當使用者增加時顯示。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
-        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
-        <target state="translated">是否應將此索引標籤用作連線類型的首頁索引標籤。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
-        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
-        <target state="translated">此索引標籤所屬群組的唯一識別碼，常用 (群組) 的值: 常用。</target>
-      </trans-unit>
-      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
-        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
-        <target state="translated">(選用) 用於在 UI 中代表此索引標籤的圖示。這會是檔案路徑或可設定佈景主題的組態</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
-        <source xml:lang="en">Icon path when a light theme is used</source>
-        <target state="translated">使用亮色主題時的圖示路徑</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
-        <source xml:lang="en">Icon path when a dark theme is used</source>
-        <target state="translated">使用暗色主題時的圖像路徑</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabs">
-        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
-        <target state="translated">提供一或多個索引標籤，讓使用者可將其增加至儀表板中。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noTitleError">
-        <source xml:lang="en">No title specified for extension.</source>
-        <target state="translated">未為延伸模組指定標題。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
-        <source xml:lang="en">No description specified to show.</source>
-        <target state="translated">未指定要顯示的描述。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.noContainerError">
-        <source xml:lang="en">No container specified for extension.</source>
-        <target state="translated">未為延伸模組指定任何容器。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
-        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
-        <target state="translated">每個空間必須明確定義 1 個儀表板容器</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
-        <source xml:lang="en">Unique identifier for this tab group.</source>
-        <target state="translated">此索引標籤群組的唯一識別碼。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
-        <source xml:lang="en">Title of the tab group.</source>
-        <target state="translated">索引標籤群組的標題。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.tabGroups">
-        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
-        <target state="translated">提供一或多個索引標籤群組，讓使用者可將其增加至儀表板中。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noIdError">
-        <source xml:lang="en">No id specified for tab group.</source>
-        <target state="translated">沒有為索引標籤群組指定任何識別碼。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
-        <source xml:lang="en">No title specified for tab group.</source>
-        <target state="translated">沒有為索引標籤群組指定任何標題。</target>
-      </trans-unit>
-      <trans-unit id="administrationTabGroup">
-        <source xml:lang="en">Administration</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="monitoringTabGroup">
-        <source xml:lang="en">Monitoring</source>
-        <target state="translated">監視</target>
-      </trans-unit>
-      <trans-unit id="performanceTabGroup">
-        <source xml:lang="en">Performance</source>
-        <target state="translated">效能</target>
-      </trans-unit>
-      <trans-unit id="securityTabGroup">
-        <source xml:lang="en">Security</source>
-        <target state="translated">安全性</target>
-      </trans-unit>
-      <trans-unit id="troubleshootingTabGroup">
-        <source xml:lang="en">Troubleshooting</source>
-        <target state="translated">疑難排解</target>
-      </trans-unit>
-      <trans-unit id="settingsTabGroup">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">設定</target>
-      </trans-unit>
-      <trans-unit id="databasesTabDescription">
-        <source xml:lang="en">databases tab</source>
-        <target state="translated">資料庫索引標籤</target>
-      </trans-unit>
-      <trans-unit id="databasesTabTitle">
-        <source xml:lang="en">Databases</source>
-        <target state="translated">資料庫</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">成功</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">失敗</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connectionError">
-        <source xml:lang="en">Connection error</source>
-        <target state="translated">連線錯誤</target>
-      </trans-unit>
-      <trans-unit id="kerberosErrorStart">
-        <source xml:lang="en">Connection failed due to Kerberos error.</source>
-        <target state="translated">因為 Kerberos 錯誤導致連線失敗。</target>
-      </trans-unit>
-      <trans-unit id="kerberosHelpLink">
-        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
-        <target state="translated">您可於 {0} 取得設定 Kerberos 的說明</target>
-      </trans-unit>
-      <trans-unit id="kerberosKinit">
-        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
-        <target state="translated">如果您之前曾連線，則可能需要重新執行 kinit。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="accountManagementService.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">關閉</target>
-      </trans-unit>
-      <trans-unit id="loggingIn">
-        <source xml:lang="en">Adding account...</source>
-        <target state="translated">正在新增帳戶...</target>
-      </trans-unit>
-      <trans-unit id="refreshFailed">
-        <source xml:lang="en">Refresh account was canceled by the user</source>
-        <target state="translated">使用者已取消重新整理帳戶</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="queryResultsEditor.name">
-        <source xml:lang="en">Query Results</source>
-        <target state="translated">查詢結果</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.name">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">查詢編輯器</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">新增查詢</target>
-      </trans-unit>
-      <trans-unit id="queryEditorConfigurationTitle">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">查詢編輯器</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
-        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
-        <target state="translated">若設定為 true，會在將結果另存為 CSV 時包含資料行標題</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
-        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
-        <target state="translated">另存為 CSV 時，用在值之間的自訂分隔符號</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
-        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
-        <target state="translated">將結果另存為 CSV 時，用於分隔資料列的字元</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
-        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
-        <target state="translated">將結果另存為 CSV 時，用於括住文字欄位的字元</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
-        <source xml:lang="en">File encoding used when saving results as CSV</source>
-        <target state="translated">將結果另存為 CSV 時，要使用的檔案編碼</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.formatted">
-        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
-        <target state="translated">若設定為 true，會在將結果另存為 XML 時將輸出格式化</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.saveAsXml.encoding">
-        <source xml:lang="en">File encoding used when saving results as XML</source>
-        <target state="translated">將結果另存為 XML 時，要使用的檔案編碼</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.streaming">
-        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
-        <target state="translated">啟用結果串流；包含些許輕微視覺效果問題</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyIncludeHeaders">
-        <source xml:lang="en">Configuration options for copying results from the Results View</source>
-        <target state="translated">從結果檢視中複製結果的組態選項</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.copyRemoveNewLine">
-        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
-        <target state="translated">從結果檢視中複製多行結果的組態選項</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.results.optimizedTable">
-        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
-        <target state="translated">(實驗性) 在結果中使用最佳化的資料表。可能會缺少某些功能，這些功能仍在開發中。</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.showBatchTime">
-        <source xml:lang="en">Should execution time be shown for individual batches</source>
-        <target state="translated">是否顯示個別批次的執行時間</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.messages.wordwrap">
-        <source xml:lang="en">Word wrap messages</source>
-        <target state="translated">自動換行訊息</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.chart.defaultChartType">
-        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
-        <target state="translated">從查詢結果開啟圖表檢視器時要使用的預設圖表類型</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.off">
-        <source xml:lang="en">Tab coloring will be disabled</source>
-        <target state="translated">將停用索引標籤著色功能</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.border">
-        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
-        <target state="translated">在每個編輯器索引標籤的上邊框著上符合相關伺服器群組的色彩</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode.fill">
-        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
-        <target state="translated">每個編輯器索引標籤的背景色彩將與相關的伺服器群組相符</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.tabColorMode">
-        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
-        <target state="translated">依據連線的伺服器群組控制索引標籤如何著色</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.showConnectionInfoInTitle">
-        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
-        <target state="translated">控制是否要在標題中顯示索引標籤的連線資訊。</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
-        <source xml:lang="en">Prompt to save generated SQL files</source>
-        <target state="translated">提示儲存產生的 SQL 檔案</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutDescription">
-        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter</source>
-        <target state="translated">設定按鍵繫結關係 workbench.action.query.shortcut{0} 以執行捷徑文字作為程序呼叫。任何選擇的文字在查詢編輯器中將作為參數傳遞</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="profiler.settings.viewTemplates">
-        <source xml:lang="en">Specifies view templates</source>
-        <target state="translated">指定檢視範本</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.sessionTemplates">
-        <source xml:lang="en">Specifies session templates</source>
-        <target state="translated">指定工作階段範本</target>
-      </trans-unit>
-      <trans-unit id="profiler.settings.Filters">
-        <source xml:lang="en">Profiler Filters</source>
-        <target state="translated">分析工具篩選條件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="scriptAsCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">建立指令碼</target>
-      </trans-unit>
-      <trans-unit id="scriptAsDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">將指令碼編寫為 Drop</target>
-      </trans-unit>
-      <trans-unit id="scriptAsSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">選取前 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptAsExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">作為指令碼執行</target>
-      </trans-unit>
-      <trans-unit id="scriptAsAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">修改指令碼</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">編輯資料</target>
-      </trans-unit>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">選取前 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">取用 10 筆</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">建立指令碼</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">作為指令碼執行</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">修改指令碼</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">將指令碼編寫為 Drop</target>
-      </trans-unit>
-      <trans-unit id="refreshNode">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">重新整理</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="commitEditFailed">
-        <source xml:lang="en">Commit row failed: </source>
-        <target state="translated">認可資料列失敗: </target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartMessage">
-        <source xml:lang="en">Started executing query at </source>
-        <target state="translated">已開始執行以下查詢:</target>
-      </trans-unit>
-      <trans-unit id="runQueryStringBatchStartMessage">
-        <source xml:lang="en">Started executing query "{0}"</source>
-        <target state="translated">已開始執行查詢 "{0}"</target>
-      </trans-unit>
-      <trans-unit id="runQueryBatchStartLine">
-        <source xml:lang="en">Line {0}</source>
-        <target state="translated">第 {0} 行</target>
-      </trans-unit>
-      <trans-unit id="msgCancelQueryFailed">
-        <source xml:lang="en">Canceling the query failed: {0}</source>
-        <target state="translated">取消查詢失敗: {0}</target>
-      </trans-unit>
-      <trans-unit id="updateCellFailed">
-        <source xml:lang="en">Update cell failed: </source>
-        <target state="translated">更新資料格失敗: </target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="notebookUriNotDefined">
-        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
-        <target state="translated">建立筆記本管理員時未傳遞任何 URI</target>
-      </trans-unit>
-      <trans-unit id="notebookServiceNoProvider">
-        <source xml:lang="en">Notebook provider does not exist</source>
-        <target state="translated">Notebook 提供者不存在</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="notebookEditor.name">
-        <source xml:lang="en">Notebook Editor</source>
-        <target state="translated">Notebook 編輯器</target>
-      </trans-unit>
-      <trans-unit id="newNotebook">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新增 Notebook</target>
-      </trans-unit>
-      <trans-unit id="newQuery">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新增 Notebook</target>
-      </trans-unit>
-      <trans-unit id="workbench.action.setWorkspaceAndOpen">
-        <source xml:lang="en">Set Workspace And Open</source>
-        <target state="translated">設定工作區並開啟</target>
-      </trans-unit>
-      <trans-unit id="notebook.sqlStopOnError">
-        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
-        <target state="translated">SQL 核心: 當資料格發生錯誤時，停止執行 Notebook。</target>
-      </trans-unit>
-      <trans-unit id="notebook.showAllKernels">
-        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
-        <target state="translated">(預覽) 顯示目前筆記本提供者的所有核心。</target>
-      </trans-unit>
-      <trans-unit id="notebook.allowADSCommands">
-        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
-        <target state="translated">允許筆記本執行 Azure Data Studio 命令。</target>
-      </trans-unit>
-      <trans-unit id="notebook.enableDoubleClickEdit">
-        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
-        <target state="translated">為筆記本中的文字資料格啟用按兩下編輯的功能</target>
-      </trans-unit>
-      <trans-unit id="notebook.setRichTextViewByDefault">
-        <source xml:lang="en">Set Rich Text View mode by default for text cells</source>
-        <target state="translated">預設將文字資料格設定為 RTF 檢視模式</target>
-      </trans-unit>
-      <trans-unit id="notebook.saveConnectionName">
-        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
-        <target state="translated">(預覽) 儲存筆記本中繼資料中的連線名稱。</target>
-      </trans-unit>
-      <trans-unit id="notebook.markdownPreviewLineHeight">
-        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
-        <target state="translated">控制筆記本 Markdown 預覽中使用的行高。此數字相對於字型大小。</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.view">
-        <source xml:lang="en">View</source>
-        <target state="translated">檢視</target>
-      </trans-unit>
-      <trans-unit id="searchConfigurationTitle">
-        <source xml:lang="en">Search Notebooks</source>
-        <target state="translated">搜尋筆記本</target>
-      </trans-unit>
-      <trans-unit id="exclude">
-        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
-        <target state="translated">設定 Glob 模式，在全文檢索搜尋中排除檔案與資料夾，並快速開啟。繼承 `#files.exclude#` 設定的所有 Glob 模式。深入了解 Glob 模式 [這裡](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)。</target>
-      </trans-unit>
-      <trans-unit id="exclude.boolean">
-        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
-        <target state="translated">要符合檔案路徑的 Glob 模式。設為 True 或 False 可啟用或停用模式。</target>
-      </trans-unit>
-      <trans-unit id="exclude.when">
-        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
-        <target state="translated">在相符檔案同層級上額外的檢查。請使用 $(basename) 作為相符檔案名稱的變數。</target>
-      </trans-unit>
-      <trans-unit id="useRipgrep">
-        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
-        <target state="translated"> 此設定已淘汰，現在會回復至 "search.usePCRE2"。</target>
-      </trans-unit>
-      <trans-unit id="useRipgrepDeprecated">
-        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
-        <target state="translated">已淘汰。請考慮使用 "search.usePCRE2" 來取得進階 regex 功能支援。</target>
-      </trans-unit>
-      <trans-unit id="search.maintainFileSearchCache">
-        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
-        <target state="translated">若啟用，searchService 程序在處於非使用狀態一小時後會保持運作，而不是關閉。這會將檔案搜尋快取保留在記憶體中。</target>
-      </trans-unit>
-      <trans-unit id="useIgnoreFiles">
-        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">控制是否在搜尋檔案時使用 `.gitignore` 和 `.ignore` 檔案。</target>
-      </trans-unit>
-      <trans-unit id="useGlobalIgnoreFiles">
-        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
-        <target state="translated">控制是否要在搜尋檔案時使用全域 `.gitignore` 和 `.ignore` 檔案。</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeSymbols">
-        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
-        <target state="translated">是否在 Quick Open 的檔案結果中，包含全域符號搜尋中的結果。</target>
-      </trans-unit>
-      <trans-unit id="search.quickOpen.includeHistory">
-        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
-        <target state="translated">是否要在 Quick Open 中包含檔案結果中，來自最近開啟檔案的結果。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.default">
-        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
-        <target state="translated">歷程記錄項目會依據所使用的篩選值，依相關性排序。相關性愈高的項目排在愈前面。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder.recency">
-        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
-        <target state="translated">依使用時序排序歷程記錄項目。最近開啟的項目顯示在最前面。</target>
-      </trans-unit>
-      <trans-unit id="filterSortOrder">
-        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
-        <target state="translated">控制篩選時，快速開啟的編輯器歷程記錄排列順序。</target>
-      </trans-unit>
-      <trans-unit id="search.followSymlinks">
-        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
-        <target state="translated">控制是否要在搜尋時遵循 symlink。</target>
-      </trans-unit>
-      <trans-unit id="search.smartCase">
-        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
-        <target state="translated">若模式為全小寫，搜尋時不會區分大小寫; 否則會區分大小寫。</target>
-      </trans-unit>
-      <trans-unit id="search.globalFindClipboard">
-        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
-        <target state="translated">控制搜尋檢視應讀取或修改 macOS 上的共用尋找剪貼簿。 </target>
-      </trans-unit>
-      <trans-unit id="search.location">
-        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
-        <target state="translated">控制搜尋要顯示為資訊看板中的檢視，或顯示為面板區域中的面板以增加水平空間。</target>
-      </trans-unit>
-      <trans-unit id="search.location.deprecationMessage">
-        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
-        <target state="translated">這個設定已淘汰。請改用搜尋檢視的操作功能表。</target>
-      </trans-unit>
-      <trans-unit id="search.collapseResults.auto">
-        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
-        <target state="translated">10 個結果以下的檔案將會展開，其他檔案則會摺疊。</target>
-      </trans-unit>
-      <trans-unit id="search.collapseAllResults">
-        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
-        <target state="translated">控制要摺疊或展開搜尋結果。</target>
-      </trans-unit>
-      <trans-unit id="search.useReplacePreview">
-        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
-        <target state="translated">控制是否要在選取或取代相符項目時開啟 [取代預覽]。</target>
-      </trans-unit>
-      <trans-unit id="search.showLineNumbers">
-        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
-        <target state="translated">控制是否要為搜尋結果顯示行號。</target>
-      </trans-unit>
-      <trans-unit id="search.usePCRE2">
-        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
-        <target state="translated">是否要在文字搜尋中使用 PCRE2 規則運算式引擎。這可使用部分進階功能，如 lookahead 和 backreferences。但是，並不支援所有 PCRE2 功能，僅支援 JavaScript 也支援的功能。</target>
-      </trans-unit>
-      <trans-unit id="usePCRE2Deprecated">
-        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
-        <target state="translated">已淘汰。當使用僅有 PCRE2 支援的 regex 功能時，會自動使用 PCRE 2。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionAuto">
-        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
-        <target state="translated">當搜尋檢視較窄時，將動作列放在右邊，當搜尋檢視較寬時，立即放於內容之後。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPositionRight">
-        <source xml:lang="en">Always position the actionbar to the right.</source>
-        <target state="translated">永遠將動作列放在右邊。</target>
-      </trans-unit>
-      <trans-unit id="search.actionsPosition">
-        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
-        <target state="translated">控制動作列在搜尋檢視列上的位置。</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnType">
-        <source xml:lang="en">Search all files as you type.</source>
-        <target state="translated">鍵入的同時搜尋所有檔案。</target>
-      </trans-unit>
-      <trans-unit id="search.seedWithNearestWord">
-        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
-        <target state="translated">允許在使用中的編輯器沒有選取項目時，從最接近游標的文字植入搜尋。</target>
-      </trans-unit>
-      <trans-unit id="search.seedOnFocus">
-        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
-        <target state="translated">聚焦在搜尋檢視時，將工作區搜尋查詢更新為編輯器的選取文字。按一下或觸發 'workbench.views.search.focus' 命令時，即會發生此動作。</target>
-      </trans-unit>
-      <trans-unit id="search.searchOnTypeDebouncePeriod">
-        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
-        <target state="translated">啟用 `#search.searchOnType#` 時，控制字元鍵入和搜尋開始之間的逾時 (毫秒)。當 `search.searchOnType` 停用時無效。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
-        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
-        <target state="translated">點兩下選擇游標下的單字。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
-        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
-        <target state="translated">按兩下將會在正在使用的編輯器群組中開啟結果。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
-        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
-        <target state="translated">按兩下就會在側邊的編輯器群組中開啟結果，如果不存在就會建立一個。</target>
-      </trans-unit>
-      <trans-unit id="search.searchEditor.doubleClickBehaviour">
-        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
-        <target state="translated">設定在搜尋編輯器中按兩下結果的效果。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.default">
-        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
-        <target state="translated">結果會根據資料夾和檔案名稱排序，按字母順序排列。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.filesOnly">
-        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
-        <target state="translated">結果會忽略資料夾順序並根據檔案名稱排序，按字母順序排列。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.type">
-        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
-        <target state="translated">結果會根據副檔名排序，按字母順序排列。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.modified">
-        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
-        <target state="translated">結果會根據最後修改日期降冪排序。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countDescending">
-        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
-        <target state="translated">結果會根據每個檔案的計數降冪排序。</target>
-      </trans-unit>
-      <trans-unit id="searchSortOrder.countAscending">
-        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
-        <target state="translated">結果會根據每個檔案的計數升冪排序。</target>
-      </trans-unit>
-      <trans-unit id="search.sortOrder">
-        <source xml:lang="en">Controls sorting order of search results.</source>
-        <target state="translated">控制搜尋結果的排列順序。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="newQueryTask.newQuery">
-        <source xml:lang="en">New Query</source>
-        <target state="translated">新增查詢</target>
-      </trans-unit>
-      <trans-unit id="runQueryLabel">
-        <source xml:lang="en">Run</source>
-        <target state="translated">執行</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="estimatedQueryPlan">
-        <source xml:lang="en">Explain</source>
-        <target state="translated">說明</target>
-      </trans-unit>
-      <trans-unit id="actualQueryPlan">
-        <source xml:lang="en">Actual</source>
-        <target state="translated">實際</target>
-      </trans-unit>
-      <trans-unit id="disconnectDatabaseLabel">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">中斷連線</target>
-      </trans-unit>
-      <trans-unit id="changeConnectionDatabaseLabel">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">變更連線</target>
-      </trans-unit>
-      <trans-unit id="connectDatabaseLabel">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">連線</target>
-      </trans-unit>
-      <trans-unit id="enablesqlcmdLabel">
-        <source xml:lang="en">Enable SQLCMD</source>
-        <target state="translated">啟用 SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="disablesqlcmdLabel">
-        <source xml:lang="en">Disable SQLCMD</source>
-        <target state="translated">停用 SQLCMD</target>
-      </trans-unit>
-      <trans-unit id="selectDatabase">
-        <source xml:lang="en">Select Database</source>
-        <target state="translated">選擇資料庫</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failed">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">變更資料庫失敗</target>
-      </trans-unit>
-      <trans-unit id="changeDatabase.failedWithError">
-        <source xml:lang="en">Failed to change database {0}</source>
-        <target state="translated">無法變更資料庫 {0}</target>
-      </trans-unit>
-      <trans-unit id="queryEditor.exportSqlAsNotebook">
-        <source xml:lang="en">Export as Notebook</source>
-        <target state="translated">匯出為筆記本</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="errorMessageDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">關閉</target>
-      </trans-unit>
-      <trans-unit id="errorMessageDialog.action">
-        <source xml:lang="en">Action</source>
-        <target state="translated">動作</target>
-      </trans-unit>
-      <trans-unit id="copyDetails">
-        <source xml:lang="en">Copy details</source>
-        <target state="translated">複製詳細資訊</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="serverGroup.addServerGroup">
-        <source xml:lang="en">Add server group</source>
-        <target state="translated">新增伺服器群組</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.editServerGroup">
-        <source xml:lang="en">Edit server group</source>
-        <target state="translated">編輯伺服器群組</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="extensionsInputName">
-        <source xml:lang="en">Extension</source>
-        <target state="translated">延伸模組</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="OeSessionFailedError">
-        <source xml:lang="en">Failed to create Object Explorer session</source>
-        <target state="translated">建立物件總管工作階段失敗</target>
-      </trans-unit>
-      <trans-unit id="nodeExpansionError">
-        <source xml:lang="en">Multiple errors:</source>
-        <target state="translated">多個錯誤:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="firewallDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">新增帳戶時發生錯誤</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleError">
-        <source xml:lang="en">Firewall rule error</source>
-        <target state="translated">防火牆規則錯誤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="workbench.generalObsoleteApiNotification">
-        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
-        <target state="translated">載入的延伸模組中，有一些使用淘汰的 API。請參閱「開發人員工具」視窗 [主控台] 索引標籤中的詳細資訊</target>
-      </trans-unit>
-      <trans-unit id="dontShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">不要再顯示</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="vscode.extension.contributes.view.id">
-        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
-        <target state="translated">檢視的識別碼。請使用此識別碼透過 `vscode.window.registerTreeDataProviderForView` API 登錄資料提供者。並藉由將 `onView:${id}` 事件登錄至 `activationEvents` 以觸發啟用您的延伸模組。</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">使用人性化顯示名稱。會顯示</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.view.when">
-        <source xml:lang="en">Condition which must be true to show this view</source>
-        <target state="translated">必須為 True 以顯示此檢視的條件</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.dataExplorer">
-        <source xml:lang="en">Contributes views to the editor</source>
-        <target state="translated">提供檢視給編輯者</target>
-      </trans-unit>
-      <trans-unit id="extension.dataExplorer">
-        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
-        <target state="translated">將檢視提供到活動列中的資料總管容器</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.contributed">
-        <source xml:lang="en">Contributes views to contributed views container</source>
-        <target state="translated">在參與檢視容器中提供檢視</target>
-      </trans-unit>
-      <trans-unit id="duplicateView1">
-        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
-        <target state="translated">無法在檢視容器 '{1}' 中以同一個識別碼 '{0}' 註冊多個檢視</target>
-      </trans-unit>
-      <trans-unit id="duplicateView2">
-        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
-        <target state="translated">已在檢視容器 '{1}' 中註冊識別碼為 '{0}' 的檢視</target>
-      </trans-unit>
-      <trans-unit id="requirearray">
-        <source xml:lang="en">views must be an array</source>
-        <target state="translated">項目必須為陣列</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">屬性 '{0}' 為強制項目且必須屬於 `string` 類型</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">屬性 `{0}` 可以省略或必須屬於 `string` 類型</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="workbench.configuration.upgradeUser">
-        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
-        <target state="translated">您使用者設定中的 {1} 已取代 {0}。</target>
-      </trans-unit>
-      <trans-unit id="workbench.configuration.upgradeWorkspace">
-        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
-        <target state="translated">您工作區設定中的 {1} 已取代 {0}。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="manage">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-      <trans-unit id="showDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">顯示詳細資訊</target>
-      </trans-unit>
-      <trans-unit id="configureDashboardLearnMore">
-        <source xml:lang="en">Learn More</source>
-        <target state="translated">深入了解</target>
-      </trans-unit>
-      <trans-unit id="clearSavedAccounts">
-        <source xml:lang="en">Clear all saved accounts</source>
-        <target state="translated">清除所有儲存的帳戶</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="toggleTasks">
-        <source xml:lang="en">Toggle Tasks</source>
-        <target state="translated">切換工作</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="status.connection.status">
-        <source xml:lang="en">Connection Status</source>
-        <target state="translated">連線狀態</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connectionTreeProvider.schema.name">
-        <source xml:lang="en">User visible name for the tree provider</source>
-        <target state="translated">樹狀提供者向使用者顯示的名稱</target>
-      </trans-unit>
-      <trans-unit id="connectionTreeProvider.schema.id">
-        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
-        <target state="translated">提供者的識別碼，必須與註冊樹狀資料提供者時的識別碼相同，而且必須以 `connectionDialog/` 開頭</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="chartInsightDescription">
-        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
-        <target state="translated">將查詢結果以圖表方式顯示在儀表板上</target>
-      </trans-unit>
-      <trans-unit id="colorMapDescription">
-        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
-        <target state="translated">對應 'column name' -&gt; 色彩。例如，新增 'column1': red 可確保資料行使用紅色</target>
-      </trans-unit>
-      <trans-unit id="legendDescription">
-        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
-        <target state="translated">指定圖表圖例的優先位置和可見度。這些是您查詢中的欄位名稱，並對應到每個圖表項目的標籤</target>
-      </trans-unit>
-      <trans-unit id="labelFirstColumnDescription">
-        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
-        <target state="translated">若 dataDirection 是水平的，設定為 True 時則使用第一個欄位值為其圖例。</target>
-      </trans-unit>
-      <trans-unit id="columnsAsLabels">
-        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
-        <target state="translated">若 dataDirection 是垂直的，設定為 True 時則使用欄位名稱為其圖例。</target>
-      </trans-unit>
-      <trans-unit id="dataDirectionDescription">
-        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
-        <target state="translated">定義是否從行 (垂直) 或列 (水平) 讀取資料。對於時間序列，當呈現方向為垂直時會被忽略。</target>
-      </trans-unit>
-      <trans-unit id="showTopNData">
-        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
-        <target state="translated">如已設定 showTopNData，則僅顯示圖表中的前 N 個資料。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">儀表板中使用的小工具</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="resourceViewer.showActions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">顯示動作</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerInput.resourceViewer">
-        <source xml:lang="en">Resource Viewer</source>
-        <target state="translated">資源檢視器</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="extension.contributes.resourceView.resource.id">
-        <source xml:lang="en">Identifier of the resource.</source>
-        <target state="translated">資源的識別碼。</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.name">
-        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
-        <target state="translated">使用人性化顯示名稱。會顯示</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceView.resource.icon">
-        <source xml:lang="en">Path to the resource icon.</source>
-        <target state="translated">資源圖示的路徑。</target>
-      </trans-unit>
-      <trans-unit id="extension.contributes.resourceViewResources">
-        <source xml:lang="en">Contributes resource to the resource view</source>
-        <target state="translated">將資源提供給資源檢視</target>
-      </trans-unit>
-      <trans-unit id="requirestring">
-        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
-        <target state="translated">屬性 '{0}' 為強制項目且必須屬於 `string` 類型</target>
-      </trans-unit>
-      <trans-unit id="optstring">
-        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
-        <target state="translated">屬性 `{0}` 可以省略或必須屬於 `string` 類型</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="resourceViewer.ariaLabel">
-        <source xml:lang="en">Resource Viewer Tree</source>
-        <target state="translated">資源檢視器樹狀結構</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="schema.dashboardWidgets.all">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">儀表板中使用的小工具</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.database">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">儀表板中使用的小工具</target>
-      </trans-unit>
-      <trans-unit id="schema.dashboardWidgets.server">
-        <source xml:lang="en">Widget used in the dashboards</source>
-        <target state="translated">儀表板中使用的小工具</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="azdata.extension.contributes.widget.when">
-        <source xml:lang="en">Condition which must be true to show this item</source>
-        <target state="translated">必須為 True 以顯示此項目的條件</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
-        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
-        <target state="translated">是否要隱藏 Widget 的標題，預設值為 false</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.tabName">
-        <source xml:lang="en">The title of the container</source>
-        <target state="translated">容器的標題</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowNumber">
-        <source xml:lang="en">The row of the component in the grid</source>
-        <target state="translated">方格中元件的資料列</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.rowSpan">
-        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
-        <target state="translated">方格中元件的 rowspan。預設值為 1。使用 '*' 即可設定方格中的資料列數。</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colNumber">
-        <source xml:lang="en">The column of the component in the grid</source>
-        <target state="translated">方格中元件的資料行</target>
-      </trans-unit>
-      <trans-unit id="dashboardpage.colspan">
-        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
-        <target state="translated">方格內元件的 colspan。預設值為 1。使用 '*' 即可設定方格中的資料行數。</target>
-      </trans-unit>
-      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
-        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
-        <target state="translated">此索引標籤的唯一識別碼。將傳遞給任何要求的延伸模組。</target>
-      </trans-unit>
-      <trans-unit id="dashboardTabError">
-        <source xml:lang="en">Extension tab is unknown or not installed.</source>
-        <target state="translated">未知的延伸模組索引標籤或未安裝。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboardDatabaseProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">啟用或禁用屬性小工具</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">顯示屬性值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">顯示屬性的名稱</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.value">
-        <source xml:lang="en">Value in the Database Info Object</source>
-        <target state="translated">資料庫資訊物件中的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.databaseproperties.ignore">
-        <source xml:lang="en">Specify specific values to ignore</source>
-        <target state="translated">指定要忽略的特定值</target>
-      </trans-unit>
-      <trans-unit id="recoveryModel">
-        <source xml:lang="en">Recovery Model</source>
-        <target state="translated">復原模式</target>
-      </trans-unit>
-      <trans-unit id="lastDatabaseBackup">
-        <source xml:lang="en">Last Database Backup</source>
-        <target state="translated">上次資料庫備份</target>
-      </trans-unit>
-      <trans-unit id="lastLogBackup">
-        <source xml:lang="en">Last Log Backup</source>
-        <target state="translated">上次記錄備份</target>
-      </trans-unit>
-      <trans-unit id="compatibilityLevel">
-        <source xml:lang="en">Compatibility Level</source>
-        <target state="translated">相容性層級</target>
-      </trans-unit>
-      <trans-unit id="owner">
-        <source xml:lang="en">Owner</source>
-        <target state="translated">擁有者</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabase">
-        <source xml:lang="en">Customizes the database dashboard page</source>
-        <target state="translated">自訂 "資料庫儀表板" 頁</target>
-      </trans-unit>
-      <trans-unit id="objectsWidgetTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">搜尋</target>
-      </trans-unit>
-      <trans-unit id="dashboardDatabaseTabs">
-        <source xml:lang="en">Customizes the database dashboard tabs</source>
-        <target state="translated">自訂資料庫儀表板索引標籤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboardServerProperties">
-        <source xml:lang="en">Enable or disable the properties widget</source>
-        <target state="translated">啟用或禁用屬性小工具</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties">
-        <source xml:lang="en">Property values to show</source>
-        <target state="translated">顯示屬性值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.displayName">
-        <source xml:lang="en">Display name of the property</source>
-        <target state="translated">顯示屬性的名稱</target>
-      </trans-unit>
-      <trans-unit id="dashboard.serverproperties.value">
-        <source xml:lang="en">Value in the Server Info Object</source>
-        <target state="translated">伺服器資訊物件中的值</target>
-      </trans-unit>
-      <trans-unit id="version">
-        <source xml:lang="en">Version</source>
-        <target state="translated">版本</target>
-      </trans-unit>
-      <trans-unit id="edition">
-        <source xml:lang="en">Edition</source>
-        <target state="translated">版本</target>
-      </trans-unit>
-      <trans-unit id="computerName">
-        <source xml:lang="en">Computer Name</source>
-        <target state="translated">電腦名稱</target>
-      </trans-unit>
-      <trans-unit id="osVersion">
-        <source xml:lang="en">OS Version</source>
-        <target state="translated">作業系統版本</target>
-      </trans-unit>
-      <trans-unit id="explorerWidgetsTitle">
-        <source xml:lang="en">Search</source>
-        <target state="translated">搜尋</target>
-      </trans-unit>
-      <trans-unit id="dashboardServer">
-        <source xml:lang="en">Customizes the server dashboard page</source>
-        <target state="translated">自訂伺服器儀表板頁面</target>
-      </trans-unit>
-      <trans-unit id="dashboardServerTabs">
-        <source xml:lang="en">Customizes the Server dashboard tabs</source>
-        <target state="translated">自訂伺服器儀表板索引標籤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="ManageAction">
-        <source xml:lang="en">Manage</source>
-        <target state="translated">管理</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="opticon">
-        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
-        <target state="translated">屬性 `icon` 可以省略，否則必須為字串或類似 `{dark, light}` 的常值</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="insightWidgetDescription">
-        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
-        <target state="translated">新增一個可查詢伺服器或資料庫並以多種方式呈現結果的小工具，如圖表、計數總結等。</target>
-      </trans-unit>
-      <trans-unit id="insightIdDescription">
-        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
-        <target state="translated">用於快取見解結果的唯一識別碼。</target>
-      </trans-unit>
-      <trans-unit id="insightQueryDescription">
-        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
-        <target state="translated">要執行的 SQL 查詢。這僅會回傳 1 個結果集。</target>
-      </trans-unit>
-      <trans-unit id="insightQueryFileDescription">
-        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
-        <target state="translated">[選用] 包含查詢之檔案的路徑。這會在未設定 'query' 時使用</target>
-      </trans-unit>
-      <trans-unit id="insightAutoRefreshIntervalDescription">
-        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
-        <target state="translated">[選用] 自動重新整理間隔 (分鐘)，如未設定，就不會自動重新整理</target>
-      </trans-unit>
-      <trans-unit id="actionTypes">
-        <source xml:lang="en">Which actions to use</source>
-        <target state="translated">要使用的動作</target>
-      </trans-unit>
-      <trans-unit id="actionDatabaseDescription">
-        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">此動作的目標資料庫；可使用格式 '${ columnName }'，以使用資料驅動的資料行名稱。</target>
-      </trans-unit>
-      <trans-unit id="actionServerDescription">
-        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">此動作的目標伺服器；可使用格式 '${ columnName }'，以使用資料驅動的資料列名稱。</target>
-      </trans-unit>
-      <trans-unit id="actionUserDescription">
-        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
-        <target state="translated">請指定執行此動作的使用者；可使用格式 '${ columnName }'，以使用資料驅動的資料行名稱。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insightType.id">
-        <source xml:lang="en">Identifier of the insight</source>
-        <target state="translated">見解識別碼</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.insights">
-        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
-        <target state="translated">在儀表板選擇區提供見解。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="backupAction.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">備份</target>
-      </trans-unit>
-      <trans-unit id="backup.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use backup</source>
-        <target state="translated">您必須啟用預覽功能才能使用備份</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupported">
-        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL 資料庫不支援備份命令。</target>
-      </trans-unit>
-      <trans-unit id="backup.commandNotSupportedForServer">
-        <source xml:lang="en">Backup command is not supported in Server Context. Please select a Database and try again.</source>
-        <target state="translated">伺服器內容中不支援備份命令。請選取資料庫並再試一次。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="restoreAction.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">還原</target>
-      </trans-unit>
-      <trans-unit id="restore.isPreviewFeature">
-        <source xml:lang="en">You must enable preview features in order to use restore</source>
-        <target state="translated">您必須啟用預覽功能才能使用還原</target>
-      </trans-unit>
-      <trans-unit id="restore.commandNotSupported">
-        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
-        <target state="translated">Azure SQL 資料庫不支援還原命令。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">顯示建議</target>
-      </trans-unit>
-      <trans-unit id="Install Extensions">
-        <source xml:lang="en">Install Extensions</source>
-        <target state="translated">安裝延伸模組</target>
-      </trans-unit>
-      <trans-unit id="openExtensionAuthoringDocs">
-        <source xml:lang="en">Author an Extension...</source>
-        <target state="translated">撰寫延伸模組...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connectionFailure">
-        <source xml:lang="en">Edit Data Session Failed To Connect</source>
-        <target state="translated">編輯資料工作階段連線失敗</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="optionsDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="newDashboardTab.openDashboardExtensions">
-        <source xml:lang="en">Open dashboard extensions</source>
-        <target state="translated">開啟儀表板延伸模組</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="newDashboardTab.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
-        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
-        <target state="translated">目前沒有安裝任何儀表板延伸模組。請前往延伸模組能管理員探索建議的延伸模組。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="filebrowser.filepath">
-        <source xml:lang="en">Selected path</source>
-        <target state="translated">選擇的路徑</target>
-      </trans-unit>
-      <trans-unit id="fileFilter">
-        <source xml:lang="en">Files of type</source>
-        <target state="translated">檔案類型</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="fileBrowser.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">捨棄</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="insightsInputError">
-        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
-        <target state="translated">沒有傳遞給見解彈出式視窗的連線設定</target>
-      </trans-unit>
-      <trans-unit id="insightsError">
-        <source xml:lang="en">Insights error</source>
-        <target state="translated">見解錯誤</target>
-      </trans-unit>
-      <trans-unit id="insightsFileError">
-        <source xml:lang="en">There was an error reading the query file: </source>
-        <target state="translated">讀取查詢檔案時發生錯誤:</target>
-      </trans-unit>
-      <trans-unit id="insightsConfigError">
-        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
-        <target state="translated">解析見解設定時發生錯誤。找不到查詢陣列/字串或 queryfile</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="azureAccount">
-        <source xml:lang="en">Azure account</source>
-        <target state="translated">Azure 帳戶</target>
-      </trans-unit>
-      <trans-unit id="azureTenant">
-        <source xml:lang="en">Azure tenant</source>
-        <target state="translated">Azure 租用戶</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="showDataExplorer">
-        <source xml:lang="en">Show Connections</source>
-        <target state="translated">顯示連線</target>
-      </trans-unit>
-      <trans-unit id="dataExplorer.servers">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">伺服器</target>
-      </trans-unit>
-      <trans-unit id="dataexplorer.name">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">連線</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="noTaskMessage">
-        <source xml:lang="en">No task history to display.</source>
-        <target state="translated">沒有工作歷程記錄可顯示。</target>
-      </trans-unit>
-      <trans-unit id="taskHistory.regTreeAriaLabel">
-        <source xml:lang="en">Task history</source>
-        <note>TaskHistory</note>
-        <target state="translated">工作歷程記錄</target>
-      </trans-unit>
-      <trans-unit id="taskError">
-        <source xml:lang="en">Task error</source>
-        <target state="translated">工作錯誤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="ClearRecentlyUsedLabel">
-        <source xml:lang="en">Clear List</source>
-        <target state="translated">清除清單</target>
-      </trans-unit>
-      <trans-unit id="ClearedRecentConnections">
-        <source xml:lang="en">Recent connections list cleared</source>
-        <target state="translated">最近的連線清單已清除</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="clearRecentConnectionMessage">
-        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
-        <target state="translated">您確定要刪除清單中的所有連線嗎?</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="delete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">刪除</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.GetCurrentConnectionString">
-        <source xml:lang="en">Get Current Connection String</source>
-        <target state="translated">取得目前的連接字串</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.connectionString">
-        <source xml:lang="en">Connection string not available</source>
-        <target state="translated">連接字串無法使用</target>
-      </trans-unit>
-      <trans-unit id="connectionAction.noConnection">
-        <source xml:lang="en">No active connection available</source>
-        <target state="translated">沒有可用的有效連線</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connectionTree.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">重新整理</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editConnection">
-        <source xml:lang="en">Edit Connection</source>
-        <target state="translated">編輯連線</target>
-      </trans-unit>
-      <trans-unit id="DisconnectAction">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">中斷連線</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addConnection">
-        <source xml:lang="en">New Connection</source>
-        <target state="translated">新增連線</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.addServerGroup">
-        <source xml:lang="en">New Server Group</source>
-        <target state="translated">新增伺服器群組</target>
-      </trans-unit>
-      <trans-unit id="connectionTree.editServerGroup">
-        <source xml:lang="en">Edit Server Group</source>
-        <target state="translated">編輯伺服器群組</target>
-      </trans-unit>
-      <trans-unit id="activeConnections">
-        <source xml:lang="en">Show Active Connections</source>
-        <target state="translated">顯示使用中的連線</target>
-      </trans-unit>
-      <trans-unit id="showAllConnections">
-        <source xml:lang="en">Show All Connections</source>
-        <target state="translated">顯示所有連線</target>
-      </trans-unit>
-      <trans-unit id="recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的連線</target>
-      </trans-unit>
-      <trans-unit id="deleteConnection">
-        <source xml:lang="en">Delete Connection</source>
-        <target state="translated">刪除連線</target>
-      </trans-unit>
-      <trans-unit id="deleteConnectionGroup">
-        <source xml:lang="en">Delete Group</source>
-        <target state="translated">刪除群組</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="editData.run">
-        <source xml:lang="en">Run</source>
-        <target state="translated">執行</target>
-      </trans-unit>
-      <trans-unit id="disposeEditFailure">
-        <source xml:lang="en">Dispose Edit Failed With Error: </source>
-        <target state="translated">處理編輯失敗，出現錯誤:</target>
-      </trans-unit>
-      <trans-unit id="editData.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="editData.showSql">
-        <source xml:lang="en">Show SQL Pane</source>
-        <target state="translated">顯示 SQL 窗格</target>
-      </trans-unit>
-      <trans-unit id="editData.closeSql">
-        <source xml:lang="en">Close SQL Pane</source>
-        <target state="translated">關閉 SQL 窗格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="profilerInput.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">分析工具</target>
-      </trans-unit>
-      <trans-unit id="profilerInput.notConnected">
-        <source xml:lang="en">Not connected</source>
-        <target state="translated">未連線</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionStopped">
-        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
-        <target state="translated">伺服器 {0} 上的 XEvent 分析工具工作階段意外停止。</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionCreationError">
-        <source xml:lang="en">Error while starting new session</source>
-        <target state="translated">啟動新的工作階段時發生錯誤</target>
-      </trans-unit>
-      <trans-unit id="profiler.eventsLost">
-        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
-        <target state="translated">{0} 的 XEvent 分析工具工作階段遺失事件。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="loadingMessage">
         <source xml:lang="en">Loading</source>
@@ -2257,743 +12,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="ServerGroupsDialogTitle">
-        <source xml:lang="en">Server Groups</source>
-        <target state="translated">伺服器群組</target>
+      <trans-unit id="hideTextLabel">
+        <source xml:lang="en">Hide text labels</source>
+        <target state="translated">隱藏文字標籤</target>
       </trans-unit>
-      <trans-unit id="serverGroup.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="serverGroup.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="connectionGroupName">
-        <source xml:lang="en">Server group name</source>
-        <target state="translated">伺服器群組名稱</target>
-      </trans-unit>
-      <trans-unit id="MissingGroupNameError">
-        <source xml:lang="en">Group name is required.</source>
-        <target state="translated">需要群組名稱。</target>
-      </trans-unit>
-      <trans-unit id="groupDescription">
-        <source xml:lang="en">Group description</source>
-        <target state="translated">群組描述</target>
-      </trans-unit>
-      <trans-unit id="groupColor">
-        <source xml:lang="en">Group color</source>
-        <target state="translated">群組色彩</target>
+      <trans-unit id="showTextLabel">
+        <source xml:lang="en">Show text labels</source>
+        <target state="translated">顯示文字標籤</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="accountDialog.addAccountErrorTitle">
-        <source xml:lang="en">Error adding account</source>
-        <target state="translated">新增帳戶時發生錯誤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="insights.item">
-        <source xml:lang="en">Item</source>
-        <target state="translated">項目</target>
-      </trans-unit>
-      <trans-unit id="insights.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="insightsDetailView.name">
-        <source xml:lang="en">Insight Details</source>
-        <target state="translated">見解詳細資料</target>
-      </trans-unit>
-      <trans-unit id="property">
-        <source xml:lang="en">Property</source>
-        <target state="translated">屬性</target>
-      </trans-unit>
-      <trans-unit id="value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="InsightsDialogTitle">
-        <source xml:lang="en">Insights</source>
-        <target state="translated">見解</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.items">
-        <source xml:lang="en">Items</source>
-        <target state="translated">項目</target>
-      </trans-unit>
-      <trans-unit id="insights.dialog.itemDetails">
-        <source xml:lang="en">Item Details</source>
-        <target state="translated">項目詳細資訊</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="oauthFlyoutIsAlreadyOpen">
-        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
-        <target state="translated">無法啟動自動 OAuth。自動 OAuth 已在進行中。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="eventSort">
-        <source xml:lang="en">Sort by event</source>
-        <target state="translated">依事件排序</target>
-      </trans-unit>
-      <trans-unit id="nameColumn">
-        <source xml:lang="en">Sort by column</source>
-        <target state="translated">依資料行排序</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">分析工具</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="profilerColumnDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="profilerFilterDialog.clear">
-        <source xml:lang="en">Clear all</source>
-        <target state="translated">全部清除</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.apply">
-        <source xml:lang="en">Apply</source>
-        <target state="translated">套用</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.title">
-        <source xml:lang="en">Filters</source>
-        <target state="translated">篩選</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.remove">
-        <source xml:lang="en">Remove this clause</source>
-        <target state="translated">移除此子句</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.saveFilter">
-        <source xml:lang="en">Save Filter</source>
-        <target state="translated">儲存篩選</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.loadFilter">
-        <source xml:lang="en">Load Filter</source>
-        <target state="translated">載入篩選</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.addClauseText">
-        <source xml:lang="en">Add a clause</source>
-        <target state="translated">新增子句</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.fieldColumn">
-        <source xml:lang="en">Field</source>
-        <target state="translated">欄位</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.operatorColumn">
-        <source xml:lang="en">Operator</source>
-        <target state="translated">運算子</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.valueColumn">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNullOperator">
-        <source xml:lang="en">Is Null</source>
-        <target state="translated">為 Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.isNotNullOperator">
-        <source xml:lang="en">Is Not Null</source>
-        <target state="translated">非 Null</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.containsOperator">
-        <source xml:lang="en">Contains</source>
-        <target state="translated">包含</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notContainsOperator">
-        <source xml:lang="en">Not Contains</source>
-        <target state="translated">不包含</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.startsWithOperator">
-        <source xml:lang="en">Starts With</source>
-        <target state="translated">開頭是</target>
-      </trans-unit>
-      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
-        <source xml:lang="en">Not Starts With</source>
-        <target state="translated">開頭不是</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">另存為 CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">另存為 JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">另存為 Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">另存為 XML</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">複製</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">隨標題一併複製</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">全選</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.properties.property">
-        <source xml:lang="en">Defines a property to show on the dashboard</source>
-        <target state="translated">定義顯示於儀表板上的屬性</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.displayName">
-        <source xml:lang="en">What value to use as a label for the property</source>
-        <target state="translated">做為屬性標籤的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.value">
-        <source xml:lang="en">What value in the object to access for the value</source>
-        <target state="translated">要在物件中存取的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.ignore">
-        <source xml:lang="en">Specify values to be ignored</source>
-        <target state="translated">指定要忽略的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.property.default">
-        <source xml:lang="en">Default value to show if ignored or no value</source>
-        <target state="translated">如果忽略或沒有值，則顯示預設值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor">
-        <source xml:lang="en">A flavor for defining dashboard properties</source>
-        <target state="translated">定義儀表板屬性變體</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.id">
-        <source xml:lang="en">Id of the flavor</source>
-        <target state="translated">類別的變體的識別碼</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition">
-        <source xml:lang="en">Condition to use this flavor</source>
-        <target state="translated">使用此變體的條件</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.field">
-        <source xml:lang="en">Field to compare to</source>
-        <target state="translated">要比較的欄位</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.operator">
-        <source xml:lang="en">Which operator to use for comparison</source>
-        <target state="translated">用於比較的運算子</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.flavor.condition.value">
-        <source xml:lang="en">Value to compare the field to</source>
-        <target state="translated">用於比較該欄位的值</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.databaseProperties">
-        <source xml:lang="en">Properties to show for database page</source>
-        <target state="translated">顯示資料庫頁的屬性</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.serverProperties">
-        <source xml:lang="en">Properties to show for server page</source>
-        <target state="translated">顯示伺服器頁的屬性</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.dashboard">
-        <source xml:lang="en">Defines that this provider supports the dashboard</source>
-        <target state="translated">定義此提供者支援儀表板</target>
-      </trans-unit>
-      <trans-unit id="dashboard.id">
-        <source xml:lang="en">Provider id (ex. MSSQL)</source>
-        <target state="translated">提供者識別碼 (例如 MSSQL)</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties">
-        <source xml:lang="en">Property values to show on dashboard</source>
-        <target state="translated">在儀表板上顯示的屬性值</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="invalidValueError">
-        <source xml:lang="en">Invalid value</source>
-        <target state="translated">值無效</target>
-      </trans-unit>
-      <trans-unit id="period">
-        <source xml:lang="en">{0}. {1}</source>
-        <target state="translated">{0}. {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">正在載入</target>
-      </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">已完成載入</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="blankValue">
-        <source xml:lang="en">blank</source>
-        <target state="translated">空白</target>
-      </trans-unit>
-      <trans-unit id="checkAllColumnLabel">
-        <source xml:lang="en">check all checkboxes in column: {0}</source>
-        <target state="translated">選取資料行中的所有核取方塊: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="treeView.notRegistered">
-        <source xml:lang="en">No tree view with id '{0}' registered.</source>
-        <target state="translated">未註冊識別碼為 '{0}' 的樹狀檢視。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="query.initEditExecutionFailed">
-        <source xml:lang="en">Initialize edit data session failed: </source>
-        <target state="translated">初始化編輯資料工作階段失敗:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="carbon.extension.contributes.notebook.provider">
-        <source xml:lang="en">Identifier of the notebook provider.</source>
-        <target state="translated">筆記本提供者的識別碼。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
-        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
-        <target state="translated">應向此筆記本提供者註冊的檔案副檔名</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
-        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
-        <target state="translated">應為此筆記本提供者之標準的核心</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.providers">
-        <source xml:lang="en">Contributes notebook providers.</source>
-        <target state="translated">提供筆記本提供者。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.magic">
-        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
-        <target state="translated">資料格 magic 的名稱，例如 '%%sql'。</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.language">
-        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
-        <target state="translated">資料格中包含此資料格 magic 時，要使用的資料格語言</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
-        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
-        <target state="translated">這個 magic 指示的選擇性執行目標，例如 Spark vs SQL</target>
-      </trans-unit>
-      <trans-unit id="carbon.extension.contributes.notebook.kernels">
-        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
-        <target state="translated">適用於像是 python3、pyspark、sql 等等的選擇性核心集</target>
-      </trans-unit>
-      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
-        <source xml:lang="en">Contributes notebook language.</source>
-        <target state="translated">提供筆記本語言。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="runActiveCell">
-        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">F5 快速鍵需要選取程式碼資料格。請選取要執行的程式碼資料格。</target>
-      </trans-unit>
-      <trans-unit id="clearResultActiveCell">
-        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
-        <target state="translated">清除結果需要選取程式碼資料格。請選取要執行的程式碼資料格。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="sqlKernel">
-        <source xml:lang="en">SQL</source>
-        <target state="translated">SQL</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="maxRowTaskbar">
-        <source xml:lang="en">Max Rows:</source>
-        <target state="translated">最大資料列數:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="profiler.viewSelectAccessibleName">
-        <source xml:lang="en">Select View</source>
-        <target state="translated">選取檢視</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectAccessibleName">
-        <source xml:lang="en">Select Session</source>
-        <target state="translated">選取工作階段</target>
-      </trans-unit>
-      <trans-unit id="profiler.sessionSelectLabel">
-        <source xml:lang="en">Select Session:</source>
-        <target state="translated">選取工作階段:</target>
-      </trans-unit>
-      <trans-unit id="profiler.viewSelectLabel">
-        <source xml:lang="en">Select View:</source>
-        <target state="translated">選取檢視:</target>
-      </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">文字</target>
-      </trans-unit>
-      <trans-unit id="label">
-        <source xml:lang="en">Label</source>
-        <target state="translated">標籤</target>
-      </trans-unit>
-      <trans-unit id="profilerEditor.value">
-        <source xml:lang="en">Value</source>
-        <target state="translated">值</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">詳細資料</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="status.query.timeElapsed">
-        <source xml:lang="en">Time Elapsed</source>
-        <target state="translated">已耗用時間</target>
-      </trans-unit>
-      <trans-unit id="status.query.rowCount">
-        <source xml:lang="en">Row Count</source>
-        <target state="translated">資料列計數</target>
-      </trans-unit>
-      <trans-unit id="rowCount">
-        <source xml:lang="en">{0} rows</source>
-        <target state="translated">{0} 個資料列</target>
-      </trans-unit>
-      <trans-unit id="query.status.executing">
-        <source xml:lang="en">Executing query...</source>
-        <target state="translated">執行查詢中...</target>
-      </trans-unit>
-      <trans-unit id="status.query.status">
-        <source xml:lang="en">Execution Status</source>
-        <target state="translated">執行狀態</target>
-      </trans-unit>
-      <trans-unit id="status.query.selection-summary">
-        <source xml:lang="en">Selection Summary</source>
-        <target state="translated">選取摘要</target>
-      </trans-unit>
-      <trans-unit id="status.query.summaryText">
-        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
-        <target state="translated">平均: {0} 計數: {1} 總和: {2}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="chooseSqlLang">
-        <source xml:lang="en">Choose SQL Language</source>
-        <target state="translated">選擇 SQL 語言 </target>
-      </trans-unit>
-      <trans-unit id="changeProvider">
-        <source xml:lang="en">Change SQL language provider</source>
-        <target state="translated">變更 SQL 語言提供者</target>
-      </trans-unit>
-      <trans-unit id="status.query.flavor">
-        <source xml:lang="en">SQL Language Flavor</source>
-        <target state="translated">SQL 語言的變體</target>
-      </trans-unit>
-      <trans-unit id="changeSqlProvider">
-        <source xml:lang="en">Change SQL Engine Provider</source>
-        <target state="translated">變更 SQL 引擎提供者</target>
-      </trans-unit>
-      <trans-unit id="alreadyConnected">
-        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
-        <target state="translated">使用引擎 {0} 的連線已存在。若要變更，請中斷或變更連線</target>
-      </trans-unit>
-      <trans-unit id="noEditor">
-        <source xml:lang="en">No text editor active at this time</source>
-        <target state="translated">目前無使用中的文字編輯器</target>
-      </trans-unit>
-      <trans-unit id="pickSqlProvider">
-        <source xml:lang="en">Select Language Provider</source>
-        <target state="translated">選擇語言提供者</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="plotlyError">
-        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
-        <target state="translated">顯示 Plotly 圖表時發生錯誤: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="noRendererFound">
-        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">找不到輸出的 {0} 轉譯器。其有下列 MIME 類型: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">(safe) </source>
-        <target state="translated">(安全)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="scriptSelect">
-        <source xml:lang="en">Select Top 1000</source>
-        <target state="translated">選取前 1000</target>
-      </trans-unit>
-      <trans-unit id="scriptKustoSelect">
-        <source xml:lang="en">Take 10</source>
-        <target state="translated">取用 10 筆</target>
-      </trans-unit>
-      <trans-unit id="scriptExecute">
-        <source xml:lang="en">Script as Execute</source>
-        <target state="translated">作為指令碼執行</target>
-      </trans-unit>
-      <trans-unit id="scriptAlter">
-        <source xml:lang="en">Script as Alter</source>
-        <target state="translated">修改指令碼</target>
-      </trans-unit>
-      <trans-unit id="editData">
-        <source xml:lang="en">Edit Data</source>
-        <target state="translated">編輯資料</target>
-      </trans-unit>
-      <trans-unit id="scriptCreate">
-        <source xml:lang="en">Script as Create</source>
-        <target state="translated">建立指令碼</target>
-      </trans-unit>
-      <trans-unit id="scriptDelete">
-        <source xml:lang="en">Script as Drop</source>
-        <target state="translated">將指令碼編寫為 Drop</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">必須將具有有效 providerId 的 NotebookProvider 傳遞給此方法</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="providerRequired">
-        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
-        <target state="translated">必須將具有有效 providerId 的 NotebookProvider 傳遞給此方法</target>
-      </trans-unit>
-      <trans-unit id="errNoProvider">
-        <source xml:lang="en">no notebook provider found</source>
-        <target state="translated">找不到任何筆記本提供者</target>
-      </trans-unit>
-      <trans-unit id="errNoManager">
-        <source xml:lang="en">No Manager found</source>
-        <target state="translated">找不到管理員</target>
-      </trans-unit>
-      <trans-unit id="noServerManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
-        <target state="translated">筆記本 {0} 的 Notebook 管理員沒有伺服器管理員。無法對其執行作業</target>
-      </trans-unit>
-      <trans-unit id="noContentManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
-        <target state="translated">筆記本 {0} 的 Notebook 管理員沒有內容管理員。無法對其執行作業</target>
-      </trans-unit>
-      <trans-unit id="noSessionManager">
-        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
-        <target state="translated">筆記本 {0} 的 Notebook 管理員沒有工作階段管理員。無法對其執行作業</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connection.noAzureAccount">
-        <source xml:lang="en">Failed to get Azure account token for connection</source>
-        <target state="translated">無法取得連線的 Azure 帳戶權杖</target>
-      </trans-unit>
-      <trans-unit id="connectionNotAcceptedError">
-        <source xml:lang="en">Connection Not Accepted</source>
-        <target state="translated">連線未被接受</target>
-      </trans-unit>
-      <trans-unit id="connectionService.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="connectionService.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="cancelConnectionConfirmation">
-        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
-        <target state="translated">您確定要取消此連線嗎?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="webViewDialog.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="webViewDialog.close">
+      <trans-unit id="closeTab">
         <source xml:lang="en">Close</source>
         <target state="translated">關閉</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading kernels...</source>
-        <target state="translated">正在載入核心...</target>
-      </trans-unit>
-      <trans-unit id="changing">
-        <source xml:lang="en">Changing kernel...</source>
-        <target state="translated">正在變更核心...</target>
-      </trans-unit>
-      <trans-unit id="AttachTo">
-        <source xml:lang="en">Attach to </source>
-        <target state="translated">連結至 </target>
-      </trans-unit>
-      <trans-unit id="Kernel">
-        <source xml:lang="en">Kernel </source>
-        <target state="translated">核心 </target>
-      </trans-unit>
-      <trans-unit id="loadingContexts">
-        <source xml:lang="en">Loading contexts...</source>
-        <target state="translated">正在載入內容...</target>
-      </trans-unit>
-      <trans-unit id="changeConnection">
-        <source xml:lang="en">Change Connection</source>
-        <target state="translated">變更連線</target>
-      </trans-unit>
-      <trans-unit id="selectConnection">
-        <source xml:lang="en">Select Connection</source>
-        <target state="translated">選取連線</target>
-      </trans-unit>
-      <trans-unit id="localhost">
-        <source xml:lang="en">localhost</source>
-        <target state="translated">localhost</target>
-      </trans-unit>
-      <trans-unit id="noKernel">
-        <source xml:lang="en">No Kernel</source>
-        <target state="translated">沒有核心</target>
-      </trans-unit>
-      <trans-unit id="clearResults">
-        <source xml:lang="en">Clear Results</source>
-        <target state="translated">清除結果</target>
-      </trans-unit>
-      <trans-unit id="trustLabel">
-        <source xml:lang="en">Trusted</source>
-        <target state="translated">受信任</target>
-      </trans-unit>
-      <trans-unit id="untrustLabel">
-        <source xml:lang="en">Not Trusted</source>
-        <target state="translated">不受信任</target>
-      </trans-unit>
-      <trans-unit id="collapseAllCells">
-        <source xml:lang="en">Collapse Cells</source>
-        <target state="translated">摺疊資料格</target>
-      </trans-unit>
-      <trans-unit id="expandAllCells">
-        <source xml:lang="en">Expand Cells</source>
-        <target state="translated">展開資料格</target>
-      </trans-unit>
-      <trans-unit id="noContextAvailable">
-        <source xml:lang="en">None</source>
-        <target state="translated">無</target>
-      </trans-unit>
-      <trans-unit id="newNotebookAction">
-        <source xml:lang="en">New Notebook</source>
-        <target state="translated">新增 Notebook</target>
-      </trans-unit>
-      <trans-unit id="notebook.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">尋找下一個字串</target>
-      </trans-unit>
-      <trans-unit id="notebook.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">尋找前一個字串</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="queryPlanTitle">
-        <source xml:lang="en">Query Plan</source>
-        <target state="translated">查詢計劃</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="resourceViewer.refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">重新整理</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="wizardPageNumberDisplayText">
-        <source xml:lang="en">Step {0}</source>
-        <target state="translated">步驟 {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="editableDropdown.errorValidate">
-        <source xml:lang="en">Must be an option from the list</source>
-        <target state="translated">必須是清單中的選項</target>
-      </trans-unit>
-      <trans-unit id="selectBox">
-        <source xml:lang="en">Select Box</source>
-        <target state="translated">選取方塊</target>
       </trans-unit>
     </body>
   </file>
@@ -3013,134 +48,260 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">連線</target>
-      </trans-unit>
-      <trans-unit id="connecting">
-        <source xml:lang="en">Connecting</source>
-        <target state="translated">正在連線</target>
-      </trans-unit>
-      <trans-unit id="connectType">
-        <source xml:lang="en">Connection type</source>
-        <target state="translated">連線類型</target>
-      </trans-unit>
-      <trans-unit id="recentConnectionTitle">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的連線</target>
-      </trans-unit>
-      <trans-unit id="savedConnectionTitle">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">已儲存的連線</target>
-      </trans-unit>
-      <trans-unit id="connectionDetailsTitle">
-        <source xml:lang="en">Connection Details</source>
-        <target state="translated">連線詳細資料</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">連線</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.recentConnections">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的連線</target>
-      </trans-unit>
-      <trans-unit id="noRecentConnections">
-        <source xml:lang="en">No recent connection</source>
-        <target state="translated">沒有最近使用的連線</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">已儲存的連線</target>
-      </trans-unit>
-      <trans-unit id="noSavedConnections">
-        <source xml:lang="en">No saved connection</source>
-        <target state="translated">沒有已儲存的連線</target>
+      <trans-unit id="tableCell.NoDataAvailable">
+        <source xml:lang="en">no data available</source>
+        <target state="translated">沒有可用資料</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="fileBrowser.regTreeAriaLabel">
-        <source xml:lang="en">File browser tree</source>
-        <note>FileBrowserTree</note>
-        <target state="translated">樹狀結構檔案瀏覽器</target>
+      <trans-unit id="selectDeselectAll">
+        <source xml:lang="en">Select/Deselect All</source>
+        <target state="translated">選擇/取消全選</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="from">
-        <source xml:lang="en">From</source>
-        <target state="translated">從</target>
+      <trans-unit id="headerFilter.showFilter">
+        <source xml:lang="en">Show Filter</source>
+        <target state="translated">顯示篩選</target>
       </trans-unit>
-      <trans-unit id="to">
-        <source xml:lang="en">To</source>
-        <target state="translated">至</target>
+      <trans-unit id="table.selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">全選</target>
       </trans-unit>
-      <trans-unit id="createNewFirewallRule">
-        <source xml:lang="en">Create new firewall rule</source>
-        <target state="translated">建立新的防火牆規則</target>
+      <trans-unit id="table.searchPlaceHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜尋</target>
       </trans-unit>
-      <trans-unit id="firewall.ok">
+      <trans-unit id="tableFilter.visibleCount">
+        <source xml:lang="en">{0} Results</source>
+        <note>This tells the user how many items are shown in the list. Currently not visible, but read by screen readers.</note>
+        <target state="translated">{0} 個結果</target>
+      </trans-unit>
+      <trans-unit id="tableFilter.selectedCount">
+        <source xml:lang="en">{0} Selected</source>
+        <note>This tells the user how many items are selected in the list</note>
+        <target state="translated">已選取 {0} 個</target>
+      </trans-unit>
+      <trans-unit id="table.sortAscending">
+        <source xml:lang="en">Sort Ascending</source>
+        <target state="translated">遞增排序</target>
+      </trans-unit>
+      <trans-unit id="table.sortDescending">
+        <source xml:lang="en">Sort Descending</source>
+        <target state="translated">遞減排序</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.ok">
         <source xml:lang="en">OK</source>
         <target state="translated">確定</target>
       </trans-unit>
-      <trans-unit id="firewall.cancel">
+      <trans-unit id="headerFilter.clear">
+        <source xml:lang="en">Clear</source>
+        <target state="translated">清除</target>
+      </trans-unit>
+      <trans-unit id="headerFilter.cancel">
         <source xml:lang="en">Cancel</source>
         <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="firewallRuleDialogDescription">
-        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
-        <target state="translated">您的用戶端 IP 位址無法存取伺服器。登錄到 Azure 帳戶並建立新的防火牆規則以啟用存取權限。</target>
-      </trans-unit>
-      <trans-unit id="firewallRuleHelpDescription">
-        <source xml:lang="en">Learn more about firewall settings</source>
-        <target state="translated">深入了解防火牆設定</target>
-      </trans-unit>
-      <trans-unit id="filewallRule">
-        <source xml:lang="en">Firewall rule</source>
-        <target state="translated">防火牆規則</target>
-      </trans-unit>
-      <trans-unit id="addIPAddressLabel">
-        <source xml:lang="en">Add my client IP </source>
-        <target state="translated">新增我的用戶端 IP</target>
-      </trans-unit>
-      <trans-unit id="addIpRangeLabel">
-        <source xml:lang="en">Add my subnet IP range</source>
-        <target state="translated">新增我的子網路 IP 範圍</target>
+      <trans-unit id="table.filterOptions">
+        <source xml:lang="en">Filter Options</source>
+        <target state="translated">篩選選項</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="allFiles">
-        <source xml:lang="en">All files</source>
-        <target state="translated">所有檔案</target>
+      <trans-unit id="loadingSpinner.loading">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">正在載入</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="insightsDidNotFindResolvedFile">
-        <source xml:lang="en">Could not find query file at any of the following paths :
- {0}</source>
-        <target state="translated">無法在以下任一路徑找到查詢檔案 :
- {0}</target>
+      <trans-unit id="rowDetailView.loadError">
+        <source xml:lang="en">Loading Error...</source>
+        <target state="translated">正在載入錯誤...</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="refreshCredentials">
-        <source xml:lang="en">You need to refresh the credentials for this account.</source>
-        <target state="translated">您需要重新整理此帳戶的登入資訊。</target>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Toggle More</source>
+        <target state="translated">切換更多</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/common/locConstants" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="azuredatastudio">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="default">
+        <source xml:lang="en">Enable automatic update checks. Azure Data Studio will check for updates automatically and periodically.</source>
+        <target state="translated">啟用自動更新檢查。Azure Data Studio 會自動並定期檢查更新。</target>
+      </trans-unit>
+      <trans-unit id="enableWindowsBackgroundUpdates">
+        <source xml:lang="en">Enable to download and install new Azure Data Studio Versions in the background on Windows</source>
+        <target state="translated">啟用以在 Windows 背景中下載並安裝新的 Azure Data Studio 版本</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Release Notes after an update. The Release Notes are opened in a new web browser window.</source>
+        <target state="translated">在更新後顯示版本資訊。版本資訊會在新的網頁瀏覽器視窗中開啟。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.toolbar">
+        <source xml:lang="en">The dashboard toolbar action menu</source>
+        <target state="translated">儀表板工具列動作功能表</target>
+      </trans-unit>
+      <trans-unit id="notebook.cellTitle">
+        <source xml:lang="en">The notebook cell title menu</source>
+        <target state="translated">筆記本儲存格標題功能表</target>
+      </trans-unit>
+      <trans-unit id="notebook.title">
+        <source xml:lang="en">The notebook title menu</source>
+        <target state="translated">筆記本標題功能表</target>
+      </trans-unit>
+      <trans-unit id="notebook.toolbar">
+        <source xml:lang="en">The notebook toolbar menu</source>
+        <target state="translated">筆記本工具列功能表</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.action">
+        <source xml:lang="en">The dataexplorer view container title action menu</source>
+        <target state="translated">Dataexplorer 檢視容器標題動作功能表</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.context">
+        <source xml:lang="en">The dataexplorer item context menu</source>
+        <target state="translated">Dataexplorer 項目操作功能表</target>
+      </trans-unit>
+      <trans-unit id="objectExplorer.context">
+        <source xml:lang="en">The object explorer item context menu</source>
+        <target state="translated">物件總管項目操作功能表</target>
+      </trans-unit>
+      <trans-unit id="connectionDialogBrowseTree.context">
+        <source xml:lang="en">The connection dialog's browse tree context menu</source>
+        <target state="translated">連線對話方塊的瀏覽樹狀操作功能表</target>
+      </trans-unit>
+      <trans-unit id="dataGrid.context">
+        <source xml:lang="en">The data grid item context menu</source>
+        <target state="translated">資料格項目操作功能表</target>
+      </trans-unit>
+      <trans-unit id="extensionsPolicy">
+        <source xml:lang="en">Sets the security policy for downloading extensions.</source>
+        <target state="translated">設定下載延伸模組的安全性原則。</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.allowNone">
+        <source xml:lang="en">Your extension policy does not allow installing extensions. Please change your extension policy and try again.</source>
+        <target state="translated">您的延伸模組原則不允許安裝延伸模組。請變更您的延伸模組原則，然後再試一次。</target>
+      </trans-unit>
+      <trans-unit id="InstallVSIXAction.successReload">
+        <source xml:lang="en">Completed installing {0} extension from VSIX. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">延伸模組 {0} 已從 VSIX 安裝完成。請重新載入 Azure Data Studio 以啟用此延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="postUninstallTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of this extension.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以完成此延伸模組的解除安裝。</target>
+      </trans-unit>
+      <trans-unit id="postUpdateTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable the updated extension.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以啟用更新的延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="enable locally">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension locally.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以在本機啟用此延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="postEnableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以啟用此延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="postDisableTooltip">
+        <source xml:lang="en">Please reload Azure Data Studio to disable this extension.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以停用此延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="uninstallExtensionComplete">
+        <source xml:lang="en">Please reload Azure Data Studio to complete the uninstallation of the extension {0}.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以完成延伸模組 {0} 的解除安裝。</target>
+      </trans-unit>
+      <trans-unit id="enable remote">
+        <source xml:lang="en">Please reload Azure Data Studio to enable this extension in {0}.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以在 {0} 中啟用此延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="installExtensionCompletedAndReloadRequired">
+        <source xml:lang="en">Installing extension {0} is completed. Please reload Azure Data Studio to enable it.</source>
+        <target state="translated">延伸模組 {0} 安裝完成。請重新載入 Azure Data Studio 以啟用此延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="ReinstallAction.successReload">
+        <source xml:lang="en">Please reload Azure Data Studio to complete reinstalling the extension {0}.</source>
+        <target state="translated">請重新載入 Azure Data Studio 以完成重新安裝延伸模組 {0}。</target>
+      </trans-unit>
+      <trans-unit id="recommendedExtensions">
+        <source xml:lang="en">Marketplace</source>
+        <target state="translated">Marketplace</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">必須提供延伸模組建議的案例類型。</target>
+      </trans-unit>
+      <trans-unit id="incompatible">
+        <source xml:lang="en">Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.</source>
+        <target state="translated">由於延伸模組 ‘{0}’ 與 Azure Data Studio '{1}' 不相容，所以無法安裝延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新增查詢</target>
+      </trans-unit>
+      <trans-unit id="miNewQuery">
+        <source xml:lang="en">New &amp;&amp;Query</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">新增查詢(&amp;&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="miNewNotebook">
+        <source xml:lang="en">&amp;&amp;New Notebook</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">新增筆記本(&amp;&amp;N)</target>
+      </trans-unit>
+      <trans-unit id="maxMemoryForLargeFilesMB">
+        <source xml:lang="en">Controls the memory available to Azure Data Studio after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.</source>
+        <target state="translated">控制當嘗試開啟大型檔案時，Azure Data Studio 在重新啟動後可用的記憶體。效果與在命令列上指定 `--max-memory=NEWSIZE` 相同。</target>
+      </trans-unit>
+      <trans-unit id="updateLocale">
+        <source xml:lang="en">Would you like to change Azure Data Studio's UI language to {0} and restart?</source>
+        <target state="translated">您想要變更 Azure Data Studio 的 UI 語言為 {0} 並重新啟動嗎?</target>
+      </trans-unit>
+      <trans-unit id="activateLanguagePack">
+        <source xml:lang="en">In order to use Azure Data Studio in {0}, Azure Data Studio needs to restart.</source>
+        <target state="translated">若要在 {0} 中使用 Azure Data Studio，Azure Data Studio 需要重新啟動。</target>
+      </trans-unit>
+      <trans-unit id="watermark.newSqlFile">
+        <source xml:lang="en">New SQL File</source>
+        <target state="translated">新增 SQL 檔案</target>
+      </trans-unit>
+      <trans-unit id="watermark.newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新增筆記本</target>
+      </trans-unit>
+      <trans-unit id="miinstallVsix">
+        <source xml:lang="en">Install Extension from VSIX Package</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">從 VSIX 套件安裝延伸模組</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/base/parts/editableDropdown/browser/dropdown" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="editableDropdown.errorValidate">
+        <source xml:lang="en">Must be an option from the list</source>
+        <target state="translated">必須是清單中的選項</target>
+      </trans-unit>
+      <trans-unit id="selectBox">
+        <source xml:lang="en">Select Box</source>
+        <target state="translated">選取方塊</target>
       </trans-unit>
     </body>
   </file>
@@ -3184,1263 +345,59 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/platform/clipboard/browser/clipboardService" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="showNotebookExplorer">
-        <source xml:lang="en">Show Notebooks</source>
-        <target state="translated">顯示筆記本</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.searchResults">
-        <source xml:lang="en">Search Results</source>
-        <target state="translated">搜尋結果</target>
-      </trans-unit>
-      <trans-unit id="searchPathNotFoundError">
-        <source xml:lang="en">Search path not found: {0}</source>
-        <target state="translated">找不到搜尋路徑: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebookExplorer.name">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">筆記本</target>
+      <trans-unit id="imageCopyingNotSupported">
+        <source xml:lang="en">Copying images is not supported</source>
+        <target state="translated">不支援複製映像</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="focusOnCurrentQueryKeyboardAction">
-        <source xml:lang="en">Focus on Current Query</source>
-        <target state="translated">聚焦於目前的查詢</target>
-      </trans-unit>
-      <trans-unit id="runQueryKeyboardAction">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">執行查詢</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryKeyboardAction">
-        <source xml:lang="en">Run Current Query</source>
-        <target state="translated">執行目前查詢</target>
-      </trans-unit>
-      <trans-unit id="copyQueryWithResultsKeyboardAction">
-        <source xml:lang="en">Copy Query With Results</source>
-        <target state="translated">與結果一併複製查詢</target>
-      </trans-unit>
-      <trans-unit id="queryActions.queryResultsCopySuccess">
-        <source xml:lang="en">Successfully copied query and results.</source>
-        <target state="translated">已成功複製查詢與結果。</target>
-      </trans-unit>
-      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
-        <source xml:lang="en">Run Current Query with Actual Plan</source>
-        <target state="translated">使用實際計畫執行目前的查詢</target>
-      </trans-unit>
-      <trans-unit id="cancelQueryKeyboardAction">
-        <source xml:lang="en">Cancel Query</source>
-        <target state="translated">取消查詢</target>
-      </trans-unit>
-      <trans-unit id="refreshIntellisenseKeyboardAction">
-        <source xml:lang="en">Refresh IntelliSense Cache</source>
-        <target state="translated">重新整理 IntelliSense 快取</target>
-      </trans-unit>
-      <trans-unit id="toggleQueryResultsKeyboardAction">
-        <source xml:lang="en">Toggle Query Results</source>
-        <target state="translated">切換查詢結果</target>
-      </trans-unit>
-      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
-        <source xml:lang="en">Toggle Focus Between Query And Results</source>
-        <target state="translated">在查詢與結果之間切換焦點</target>
-      </trans-unit>
-      <trans-unit id="queryShortcutNoEditor">
-        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
-        <target state="translated">要執行的捷徑需要編輯器參數</target>
-      </trans-unit>
-      <trans-unit id="parseSyntaxLabel">
-        <source xml:lang="en">Parse Query</source>
-        <target state="translated">剖析查詢</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxSuccess">
-        <source xml:lang="en">Commands completed successfully</source>
-        <target state="translated">已成功完成命令</target>
-      </trans-unit>
-      <trans-unit id="queryActions.parseSyntaxFailure">
-        <source xml:lang="en">Command failed: </source>
-        <target state="translated">命令失敗:</target>
-      </trans-unit>
-      <trans-unit id="queryActions.notConnected">
-        <source xml:lang="en">Please connect to a server</source>
-        <target state="translated">請連線至伺服器</target>
+      <trans-unit id="invalidServerName">
+        <source xml:lang="en">A server group with the same name already exists.</source>
+        <target state="translated">伺服器群組名稱已經存在。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/platform/dashboard/browser/insightRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="succeeded">
-        <source xml:lang="en">succeeded</source>
-        <target state="translated">成功</target>
-      </trans-unit>
-      <trans-unit id="failed">
-        <source xml:lang="en">failed</source>
-        <target state="translated">失敗</target>
-      </trans-unit>
-      <trans-unit id="inProgress">
-        <source xml:lang="en">in progress</source>
-        <target state="translated">進行中</target>
-      </trans-unit>
-      <trans-unit id="notStarted">
-        <source xml:lang="en">not started</source>
-        <target state="translated">未啟動</target>
-      </trans-unit>
-      <trans-unit id="canceled">
-        <source xml:lang="en">canceled</source>
-        <target state="translated">已取消</target>
-      </trans-unit>
-      <trans-unit id="canceling">
-        <source xml:lang="en">canceling</source>
-        <target state="translated">取消中</target>
+      <trans-unit id="schema.dashboardWidgets.InsightsRegistry">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">儀表板中使用的小工具</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/platform/dashboard/browser/widgetRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="chartErrorMessage">
-        <source xml:lang="en">Chart cannot be displayed with the given data</source>
-        <target state="translated">無法以指定的資料顯示圖表</target>
+      <trans-unit id="schema.dashboardWidgets.all">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">儀表板中使用的小工具</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.database">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">儀表板中使用的小工具</target>
+      </trans-unit>
+      <trans-unit id="schema.dashboardWidgets.server">
+        <source xml:lang="en">Widget used in the dashboards</source>
+        <target state="translated">儀表板中使用的小工具</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/platform/serialization/common/serializationService" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="resourceViewerTable.openError">
-        <source xml:lang="en">Error opening link : {0}</source>
-        <target state="translated">開啟連結時發生錯誤: {0}</target>
-      </trans-unit>
-      <trans-unit id="resourceViewerTable.commandError">
-        <source xml:lang="en">Error executing command '{0}' : {1}</source>
-        <target state="translated">執行命令 '{0}' 時發生錯誤: {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">複製失敗。錯誤: {0}</target>
-      </trans-unit>
-      <trans-unit id="notebook.showChart">
-        <source xml:lang="en">Show chart</source>
-        <target state="translated">顯示圖表</target>
-      </trans-unit>
-      <trans-unit id="notebook.showTable">
-        <source xml:lang="en">Show table</source>
-        <target state="translated">顯示資料表</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="doubleClickEdit">
-        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;按兩下即可編輯&lt;/i&gt;</target>
-      </trans-unit>
-      <trans-unit id="addContent">
-        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
-        <target state="translated">&lt;i&gt;在這裡新增內容...&lt;/i&gt;</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="refreshError">
-        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
-        <target state="translated">重新整理節點 '{0}' 時發生錯誤: {1}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dialogDoneLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">完成</target>
-      </trans-unit>
-      <trans-unit id="dialogCancelLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="generateScriptLabel">
-        <source xml:lang="en">Generate script</source>
-        <target state="translated">產生指令碼</target>
-      </trans-unit>
-      <trans-unit id="dialogNextLabel">
-        <source xml:lang="en">Next</source>
-        <target state="translated">下一個</target>
-      </trans-unit>
-      <trans-unit id="dialogPreviousLabel">
-        <source xml:lang="en">Previous</source>
-        <target state="translated">上一個</target>
-      </trans-unit>
-      <trans-unit id="dashboardNotInitialized">
-        <source xml:lang="en">Tabs are not initialized</source>
-        <target state="translated">索引標籤未初始化</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="optionsDialog.missingRequireField">
-        <source xml:lang="en"> is required.</source>
-        <target state="translated">是必要的。</target>
-      </trans-unit>
-      <trans-unit id="optionsDialog.invalidInput">
-        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
-        <target state="translated">輸入無效。預期為數字。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="backupFilePath">
-        <source xml:lang="en">Backup file path</source>
-        <target state="translated">備份檔案路徑</target>
-      </trans-unit>
-      <trans-unit id="targetDatabase">
-        <source xml:lang="en">Target database</source>
-        <target state="translated">目標資料庫</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">還原</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.restoreTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">還原資料庫</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">資料庫</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.backupFile">
-        <source xml:lang="en">Backup file</source>
-        <target state="translated">備份檔案</target>
-      </trans-unit>
-      <trans-unit id="RestoreDialogTitle">
-        <source xml:lang="en">Restore database</source>
-        <target state="translated">還原資料庫</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="restoreDialog.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">指令碼</target>
-      </trans-unit>
-      <trans-unit id="source">
-        <source xml:lang="en">Source</source>
-        <target state="translated">來源</target>
-      </trans-unit>
-      <trans-unit id="restoreFrom">
-        <source xml:lang="en">Restore from</source>
-        <target state="translated">還原自</target>
-      </trans-unit>
-      <trans-unit id="missingBackupFilePathError">
-        <source xml:lang="en">Backup file path is required.</source>
-        <target state="translated">需要備份檔案路徑。</target>
-      </trans-unit>
-      <trans-unit id="multipleBackupFilePath">
-        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
-        <target state="translated">請輸入一或多個用逗號分隔的檔案路徑</target>
-      </trans-unit>
-      <trans-unit id="database">
-        <source xml:lang="en">Database</source>
-        <target state="translated">資料庫</target>
-      </trans-unit>
-      <trans-unit id="destination">
-        <source xml:lang="en">Destination</source>
-        <target state="translated">目的地</target>
-      </trans-unit>
-      <trans-unit id="restoreTo">
-        <source xml:lang="en">Restore to</source>
-        <target state="translated">還原到</target>
-      </trans-unit>
-      <trans-unit id="restorePlan">
-        <source xml:lang="en">Restore plan</source>
-        <target state="translated">還原計劃</target>
-      </trans-unit>
-      <trans-unit id="backupSetsToRestore">
-        <source xml:lang="en">Backup sets to restore</source>
-        <target state="translated">要還原的備份組</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileAs">
-        <source xml:lang="en">Restore database files as</source>
-        <target state="translated">將資料庫檔案還原為</target>
-      </trans-unit>
-      <trans-unit id="restoreDatabaseFileDetails">
-        <source xml:lang="en">Restore database file details</source>
-        <target state="translated">還原資料庫檔詳細資訊</target>
-      </trans-unit>
-      <trans-unit id="logicalFileName">
-        <source xml:lang="en">Logical file Name</source>
-        <target state="translated">邏輯檔案名稱</target>
-      </trans-unit>
-      <trans-unit id="fileType">
-        <source xml:lang="en">File type</source>
-        <target state="translated">檔案類型</target>
-      </trans-unit>
-      <trans-unit id="originalFileName">
-        <source xml:lang="en">Original File Name</source>
-        <target state="translated">原始檔案名稱</target>
-      </trans-unit>
-      <trans-unit id="restoreAs">
-        <source xml:lang="en">Restore as</source>
-        <target state="translated">還原為</target>
-      </trans-unit>
-      <trans-unit id="restoreOptions">
-        <source xml:lang="en">Restore options</source>
-        <target state="translated">還原選項</target>
-      </trans-unit>
-      <trans-unit id="taillogBackup">
-        <source xml:lang="en">Tail-Log backup</source>
-        <target state="translated">結尾記錄備份</target>
-      </trans-unit>
-      <trans-unit id="serverConnection">
-        <source xml:lang="en">Server connections</source>
-        <target state="translated">伺服器連線</target>
-      </trans-unit>
-      <trans-unit id="generalTitle">
-        <source xml:lang="en">General</source>
-        <target state="translated">一般</target>
-      </trans-unit>
-      <trans-unit id="filesTitle">
-        <source xml:lang="en">Files</source>
-        <target state="translated">檔案</target>
-      </trans-unit>
-      <trans-unit id="optionsTitle">
-        <source xml:lang="en">Options</source>
-        <target state="translated">選項</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="workbench.action.insights.copySelection">
-        <source xml:lang="en">Copy Cell</source>
-        <target state="translated">複製資料格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dialogModalDoneButtonLabel">
-        <source xml:lang="en">Done</source>
-        <target state="translated">完成</target>
-      </trans-unit>
-      <trans-unit id="dialogModalCancelButtonLabel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="copyAndOpen">
-        <source xml:lang="en">Copy &amp; Open</source>
-        <target state="translated">複製並開啟</target>
-      </trans-unit>
-      <trans-unit id="oauthDialog.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="userCode">
-        <source xml:lang="en">User code</source>
-        <target state="translated">使用者代碼</target>
-      </trans-unit>
-      <trans-unit id="website">
-        <source xml:lang="en">Website</source>
-        <target state="translated">網站</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="invalidIndex">
-        <source xml:lang="en">The index {0} is invalid.</source>
-        <target state="translated">索引 {0} 無效。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="serverDescription">
-        <source xml:lang="en">Server Description (optional)</source>
-        <target state="translated">伺服器描述 (選用)</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connectionAdvancedProperties">
-        <source xml:lang="en">Advanced Properties</source>
-        <target state="translated">進階屬性</target>
-      </trans-unit>
-      <trans-unit id="advancedProperties.discard">
-        <source xml:lang="en">Discard</source>
-        <target state="translated">捨棄</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="nbformatNotRecognized">
-        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
-        <target state="translated">無法識別 nbformat v{0}.{1}</target>
-      </trans-unit>
-      <trans-unit id="nbNotSupported">
-        <source xml:lang="en">This file does not have a valid notebook format</source>
-        <target state="translated">檔案不具備有效的筆記本格式</target>
-      </trans-unit>
-      <trans-unit id="unknownCellType">
-        <source xml:lang="en">Cell type {0} unknown</source>
-        <target state="translated">資料格類型 {0} 不明</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutput">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">無法識別輸出類型 {0}</target>
-      </trans-unit>
-      <trans-unit id="invalidMimeData">
-        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
-        <target state="translated">{0} 的資料應為字串或字串的陣列</target>
-      </trans-unit>
-      <trans-unit id="unrecognizedOutputType">
-        <source xml:lang="en">Output type {0} not recognized</source>
-        <target state="translated">無法識別輸出類型 {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="welcomePage">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">歡迎使用</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 管理員套件</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showAdminPack">
-        <source xml:lang="en">SQL Admin Pack</source>
-        <target state="translated">SQL 管理員套件</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.adminPackDescription">
-        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
-        <target state="translated">SQL Server 的管理員套件是一套熱門的資料庫管理延伸模組，可協助您管理 SQL Server</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershell">
-        <source xml:lang="en">Powershell</source>
-        <target state="translated">PowerShell</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.powershellDescription">
-        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
-        <target state="translated">使用 Azure Data Studio 的豐富查詢編輯器來寫入及執行 PowerShell 指令碼</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualization">
-        <source xml:lang="en">Data Virtualization</source>
-        <target state="translated">資料虛擬化</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.dataVirtualizationDescription">
-        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
-        <target state="translated">使用 SQL Server 2019 將資料虛擬化，並使用互動式精靈建立外部資料表</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQL">
-        <source xml:lang="en">PostgreSQL</source>
-        <target state="translated">PostgreSQL</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.PostgreSQLDescription">
-        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
-        <target state="translated">使用 Azure Data Studio 進行連線、查詢及管理 Postgres 資料庫</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
-        <source xml:lang="en">Support for {0} is already installed.</source>
-        <target state="translated">支援功能{0}已被安裝。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
-        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
-        <target state="translated">{0} 的其他支援安裝完成後，將會重新載入此視窗。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installingExtensionPack">
-        <source xml:lang="en">Installing additional support for {0}...</source>
-        <target state="translated">正在安裝 {0} 的其他支援...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionPackNotFound">
-        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
-        <target state="translated">找不到ID為{1}的{0}支援功能.</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">新增連線</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">新增查詢</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">新增筆記本</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">部署伺服器</target>
-      </trans-unit>
-      <trans-unit id="welcome.title">
-        <source xml:lang="en">Welcome</source>
-        <target state="translated">歡迎使用</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.new">
-        <source xml:lang="en">New</source>
-        <target state="translated">新增</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.open">
-        <source xml:lang="en">Open…</source>
-        <target state="translated">開啟…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFile">
-        <source xml:lang="en">Open file…</source>
-        <target state="translated">開啟檔案…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolder">
-        <source xml:lang="en">Open folder…</source>
-        <target state="translated">開啟資料夾…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.startTour">
-        <source xml:lang="en">Start Tour</source>
-        <target state="translated">開始導覽</target>
-      </trans-unit>
-      <trans-unit id="closeTourBar">
-        <source xml:lang="en">Close quick tour bar</source>
-        <target state="translated">關閉快速導覽列</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.TakeATour">
-        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
-        <target state="translated">要進行 Azure Data Studio 的快速導覽嗎?</target>
-      </trans-unit>
-      <trans-unit id="WelcomePage.welcome">
-        <source xml:lang="en">Welcome!</source>
-        <target state="translated">歡迎使用!</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFolderWithPath">
-        <source xml:lang="en">Open folder {0} with path {1}</source>
-        <target state="translated">透過路徑 {1} 開啟資料夾 {0}</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.install">
-        <source xml:lang="en">Install</source>
-        <target state="translated">安裝</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installKeymap">
-        <source xml:lang="en">Install {0} keymap</source>
-        <target state="translated">安裝 {0} 鍵盤對應</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installExtensionPack">
-        <source xml:lang="en">Install additional support for {0}</source>
-        <target state="translated">安裝 {0} 的其他支援</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installed">
-        <source xml:lang="en">Installed</source>
-        <target state="translated">已安裝</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedKeymap">
-        <source xml:lang="en">{0} keymap is already installed</source>
-        <target state="translated">已安裝 {0} 按鍵對應</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.installedExtensionPack">
-        <source xml:lang="en">{0} support is already installed</source>
-        <target state="translated">已安裝 {0} 支援</target>
-      </trans-unit>
-      <trans-unit id="ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="details">
-        <source xml:lang="en">Details</source>
-        <target state="translated">詳細資料</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.background">
-        <source xml:lang="en">Background color for the Welcome page.</source>
-        <target state="translated">歡迎頁面的背景色彩。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="profilerTextEditorAriaLabel">
-        <source xml:lang="en">Profiler editor for event text. Readonly</source>
-        <target state="translated">事件文字的分析工具編輯器。唯讀</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="msgSaveFailed">
-        <source xml:lang="en">Failed to save results. </source>
-        <target state="translated">無法儲存結果。</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileTitle">
-        <source xml:lang="en">Choose Results File</source>
-        <target state="translated">選擇結果檔案</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
-        <source xml:lang="en">CSV (Comma delimited)</source>
-        <target state="translated">CSV (以逗號分隔)</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
-        <source xml:lang="en">JSON</source>
-        <target state="translated">JSON</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
-        <source xml:lang="en">Excel Workbook</source>
-        <target state="translated">Excel 活頁簿</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
-        <source xml:lang="en">XML</source>
-        <target state="translated">XML</target>
-      </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
-        <source xml:lang="en">Plain Text</source>
-        <target state="translated">純文字</target>
-      </trans-unit>
-      <trans-unit id="savingFile">
-        <source xml:lang="en">Saving file...</source>
-        <target state="translated">正在儲存檔案...</target>
-      </trans-unit>
-      <trans-unit id="msgSaveSucceeded">
-        <source xml:lang="en">Successfully saved results to {0}</source>
-        <target state="translated">已成功將結果儲存至 {0}</target>
-      </trans-unit>
-      <trans-unit id="openFile">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">開啟檔案</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/panel/panel.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="hideTextLabel">
-        <source xml:lang="en">Hide text labels</source>
-        <target state="translated">隱藏文字標籤</target>
-      </trans-unit>
-      <trans-unit id="showTextLabel">
-        <source xml:lang="en">Show text labels</source>
-        <target state="translated">顯示文字標籤</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="queryTextEditorAriaLabel">
-        <source xml:lang="en">modelview code editor for view model.</source>
-        <target state="translated">檢視模型的 modelview 程式碼編輯器。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="infoAltText">
-        <source xml:lang="en">Information</source>
-        <target state="translated">資訊</target>
-      </trans-unit>
-      <trans-unit id="warningAltText">
-        <source xml:lang="en">Warning</source>
-        <target state="translated">警告</target>
-      </trans-unit>
-      <trans-unit id="errorAltText">
-        <source xml:lang="en">Error</source>
-        <target state="translated">錯誤</target>
-      </trans-unit>
-      <trans-unit id="showMessageDetails">
-        <source xml:lang="en">Show Details</source>
-        <target state="translated">顯示詳細資訊</target>
-      </trans-unit>
-      <trans-unit id="copyMessage">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">複製</target>
-      </trans-unit>
-      <trans-unit id="closeMessage">
-        <source xml:lang="en">Close</source>
-        <target state="translated">關閉</target>
-      </trans-unit>
-      <trans-unit id="modal.back">
-        <source xml:lang="en">Back</source>
-        <target state="translated">返回</target>
-      </trans-unit>
-      <trans-unit id="hideMessageDetails">
-        <source xml:lang="en">Hide Details</source>
-        <target state="translated">隱藏詳細資料</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="accountExplorer.name">
-        <source xml:lang="en">Accounts</source>
-        <target state="translated">帳戶</target>
-      </trans-unit>
-      <trans-unit id="linkedAccounts">
-        <source xml:lang="en">Linked accounts</source>
-        <target state="translated">連結的帳戶</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">關閉</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noAccountLabel">
-        <source xml:lang="en">There is no linked account. Please add an account.</source>
-        <target state="translated">沒有任何已連結帳戶。請新增帳戶。</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.addConnection">
-        <source xml:lang="en">Add an account</source>
-        <target state="translated">新增帳戶</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.noCloudsRegistered">
-        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
-        <target state="translated">您未啟用任何雲端。前往 [設定] -&gt; [搜尋 Azure 帳戶組態] -&gt; 啟用至少一個雲端</target>
-      </trans-unit>
-      <trans-unit id="accountDialog.didNotPickAuthProvider">
-        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
-        <target state="translated">您未選取任何驗證提供者。請再試一次。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="query.ExecutionFailedError">
-        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
-        <target state="translated">由於意外錯誤導致執行失敗: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="query.message.executionTime">
-        <source xml:lang="en">Total execution time: {0}</source>
-        <target state="translated">總執行時間: {0}</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQueryWithRange">
-        <source xml:lang="en">Started executing query at Line {0}</source>
-        <target state="translated">已於第 {0} 行開始執行查詢</target>
-      </trans-unit>
-      <trans-unit id="query.message.startQuery">
-        <source xml:lang="en">Started executing batch {0}</source>
-        <target state="translated">已開始執行批次 {0}</target>
-      </trans-unit>
-      <trans-unit id="elapsedBatchTime">
-        <source xml:lang="en">Batch execution time: {0}</source>
-        <target state="translated">批次執行時間: {0}</target>
-      </trans-unit>
-      <trans-unit id="copyFailed">
-        <source xml:lang="en">Copy failed with error {0}</source>
-        <target state="translated">複製失敗。錯誤: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="welcomePage.azdata">
-        <source xml:lang="en">Azure Data Studio</source>
-        <target state="translated">Azure Data Studio</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">開始</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newConnection">
-        <source xml:lang="en">New connection</source>
-        <target state="translated">新增連線</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newQuery">
-        <source xml:lang="en">New query</source>
-        <target state="translated">新增查詢</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newNotebook">
-        <source xml:lang="en">New notebook</source>
-        <target state="translated">新增筆記本</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileMac">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">開啟檔案</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.openFileLinuxPC">
-        <source xml:lang="en">Open file</source>
-        <target state="translated">開啟檔案</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deploy">
-        <source xml:lang="en">Deploy</source>
-        <target state="translated">部署</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.newDeployment">
-        <source xml:lang="en">New Deployment…</source>
-        <target state="translated">新增部署…</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.recent">
-        <source xml:lang="en">Recent</source>
-        <target state="translated">最近使用</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">More...</source>
-        <target state="translated">更多...</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.noRecentFolders">
-        <source xml:lang="en">No recent folders</source>
-        <target state="translated">沒有最近使用的資料夾</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">說明</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting started</source>
-        <target state="translated">使用者入門</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.productDocumentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">文件</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.reportIssue">
-        <source xml:lang="en">Report issue or feature request</source>
-        <target state="translated">回報問題或功能要求</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gitHubRepository">
-        <source xml:lang="en">GitHub repository</source>
-        <target state="translated">GitHub 存放庫</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.releaseNotes">
-        <source xml:lang="en">Release notes</source>
-        <target state="translated">版本資訊</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">啟動時顯示歡迎頁面</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.customize">
-        <source xml:lang="en">Customize</source>
-        <target state="translated">自訂</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">延伸模組</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensionDescription">
-        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
-        <target state="translated">下載所需延伸模組，包括 SQL Server 系統管理員套件等</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcut">
-        <source xml:lang="en">Keyboard Shortcuts</source>
-        <target state="translated">鍵盤快速鍵</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.keyboardShortcutDescription">
-        <source xml:lang="en">Find your favorite commands and customize them</source>
-        <target state="translated">尋找您最愛的命令並予加自訂</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorTheme">
-        <source xml:lang="en">Color theme</source>
-        <target state="translated">色彩佈景主題</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.colorThemeDescription">
-        <source xml:lang="en">Make the editor and your code look the way you love</source>
-        <target state="translated">將編輯器和您的程式碼設定成您喜愛的外觀</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.learn">
-        <source xml:lang="en">Learn</source>
-        <target state="translated">了解</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommands">
-        <source xml:lang="en">Find and run all commands</source>
-        <target state="translated">尋找及執行所有命令</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showCommandsDescription">
-        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
-        <target state="translated">從命令選擇區快速存取及搜尋命令 ({0})</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlog">
-        <source xml:lang="en">Discover what's new in the latest release</source>
-        <target state="translated">探索最新版本中的新功能</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.azdataBlogDescription">
-        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
-        <target state="translated">展示新功能的新每月部落格文章</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitter">
-        <source xml:lang="en">Follow us on Twitter</source>
-        <target state="translated">追蹤我們的 Twitter</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.followTwitterDescription">
-        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
-        <target state="translated">掌握社群如何使用 Azure Data Studio 的最新消息，並可直接與工程師對話。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="profilerAction.connect">
-        <source xml:lang="en">Connect</source>
-        <target state="translated">連線</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.disconnect">
-        <source xml:lang="en">Disconnect</source>
-        <target state="translated">中斷連線</target>
-      </trans-unit>
-      <trans-unit id="start">
-        <source xml:lang="en">Start</source>
-        <target state="translated">開始</target>
-      </trans-unit>
-      <trans-unit id="create">
-        <source xml:lang="en">New Session</source>
-        <target state="translated">新增工作階段</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.pauseCapture">
-        <source xml:lang="en">Pause</source>
-        <target state="translated">暫停</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.resumeCapture">
-        <source xml:lang="en">Resume</source>
-        <target state="translated">繼續</target>
-      </trans-unit>
-      <trans-unit id="profilerStop.stop">
-        <source xml:lang="en">Stop</source>
-        <target state="translated">停止</target>
-      </trans-unit>
-      <trans-unit id="profiler.clear">
-        <source xml:lang="en">Clear Data</source>
-        <target state="translated">清除資料</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearDataPrompt">
-        <source xml:lang="en">Are you sure you want to clear the data?</source>
-        <target state="translated">確定要清除資料嗎?</target>
-      </trans-unit>
-      <trans-unit id="profiler.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="profiler.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOn">
-        <source xml:lang="en">Auto Scroll: On</source>
-        <target state="translated">自動捲動: 開啟</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.autoscrollOff">
-        <source xml:lang="en">Auto Scroll: Off</source>
-        <target state="translated">自動捲動: 關閉</target>
-      </trans-unit>
-      <trans-unit id="profiler.toggleCollapsePanel">
-        <source xml:lang="en">Toggle Collapsed Panel</source>
-        <target state="translated">切換折疊面板</target>
-      </trans-unit>
-      <trans-unit id="profiler.editColumns">
-        <source xml:lang="en">Edit Columns</source>
-        <target state="translated">編輯資料行</target>
-      </trans-unit>
-      <trans-unit id="profiler.findNext">
-        <source xml:lang="en">Find Next String</source>
-        <target state="translated">尋找下一個字串</target>
-      </trans-unit>
-      <trans-unit id="profiler.findPrevious">
-        <source xml:lang="en">Find Previous String</source>
-        <target state="translated">尋找前一個字串</target>
-      </trans-unit>
-      <trans-unit id="profilerAction.newProfiler">
-        <source xml:lang="en">Launch Profiler</source>
-        <target state="translated">啟動分析工具</target>
-      </trans-unit>
-      <trans-unit id="profiler.filter">
-        <source xml:lang="en">Filter…</source>
-        <target state="translated">篩選...</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilter">
-        <source xml:lang="en">Clear Filter</source>
-        <target state="translated">清除篩選</target>
-      </trans-unit>
-      <trans-unit id="profiler.clearFilterPrompt">
-        <source xml:lang="en">Are you sure you want to clear the filters?</source>
-        <target state="translated">確定要清除篩選嗎?</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
-        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
-        <target state="translated">事件 (已篩選): {0}/{1}</target>
-      </trans-unit>
-      <trans-unit id="ProfilerTableEditor.eventCount">
-        <source xml:lang="en">Events: {0}</source>
-        <target state="translated">事件: {0}</target>
-      </trans-unit>
-      <trans-unit id="status.eventCount">
-        <source xml:lang="en">Event Count</source>
-        <target state="translated">事件計數</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/formatters" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="tableCell.NoDataAvailable">
-        <source xml:lang="en">no data available</source>
-        <target state="translated">沒有可用資料</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="resultsTabTitle">
-        <source xml:lang="en">Results</source>
-        <target state="translated">結果</target>
-      </trans-unit>
-      <trans-unit id="messagesTabTitle">
-        <source xml:lang="en">Messages</source>
-        <target state="translated">訊息</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="scriptSelectNotFound">
-        <source xml:lang="en">No script was returned when calling select script on object </source>
-        <target state="translated">在物件上呼叫選取的指令碼時沒有回傳任何指令碼</target>
-      </trans-unit>
-      <trans-unit id="selectOperationName">
-        <source xml:lang="en">Select</source>
-        <target state="translated">選擇</target>
-      </trans-unit>
-      <trans-unit id="createOperationName">
-        <source xml:lang="en">Create</source>
-        <target state="translated">建立</target>
-      </trans-unit>
-      <trans-unit id="insertOperationName">
-        <source xml:lang="en">Insert</source>
-        <target state="translated">插入</target>
-      </trans-unit>
-      <trans-unit id="updateOperationName">
-        <source xml:lang="en">Update</source>
-        <target state="translated">更新</target>
-      </trans-unit>
-      <trans-unit id="deleteOperationName">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">刪除</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFoundForObject">
-        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
-        <target state="translated">在物件 {1} 指令碼為 {0} 時無回傳任何指令碼</target>
-      </trans-unit>
-      <trans-unit id="scriptingFailed">
-        <source xml:lang="en">Scripting Failed</source>
-        <target state="translated">指令碼失敗</target>
-      </trans-unit>
-      <trans-unit id="scriptNotFound">
-        <source xml:lang="en">No script was returned when scripting as {0}</source>
-        <target state="translated">指令碼為 {0} 時無回傳任何指令</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="tableHeaderBackground">
-        <source xml:lang="en">Table header background color</source>
-        <target state="translated">資料表標題背景色彩</target>
-      </trans-unit>
-      <trans-unit id="tableHeaderForeground">
-        <source xml:lang="en">Table header foreground color</source>
-        <target state="translated">資料表標題前景色彩</target>
-      </trans-unit>
-      <trans-unit id="listFocusAndSelectionBackground">
-        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
-        <target state="translated">當清單/資料表處於使用狀態時，所選項目與聚焦項目的清單/資料表背景色彩</target>
-      </trans-unit>
-      <trans-unit id="tableCellOutline">
-        <source xml:lang="en">Color of the outline of a cell.</source>
-        <target state="translated">資料格的外框色彩。</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxBackground">
-        <source xml:lang="en">Disabled Input box background.</source>
-        <target state="translated">已停用輸入方塊背景。</target>
-      </trans-unit>
-      <trans-unit id="disabledInputBoxForeground">
-        <source xml:lang="en">Disabled Input box foreground.</source>
-        <target state="translated">已停用輸入方塊前景。</target>
-      </trans-unit>
-      <trans-unit id="buttonFocusOutline">
-        <source xml:lang="en">Button outline color when focused.</source>
-        <target state="translated">聚焦時按鈕外框色彩。</target>
-      </trans-unit>
-      <trans-unit id="disabledCheckboxforeground">
-        <source xml:lang="en">Disabled checkbox foreground.</source>
-        <target state="translated">已停用核取方塊前景。</target>
-      </trans-unit>
-      <trans-unit id="agentTableBackground">
-        <source xml:lang="en">SQL Agent Table background color.</source>
-        <target state="translated">SQL Agent 資料表背景色彩。</target>
-      </trans-unit>
-      <trans-unit id="agentCellBackground">
-        <source xml:lang="en">SQL Agent table cell background color.</source>
-        <target state="translated">SQL Agent 資料表資料格背景色彩。</target>
-      </trans-unit>
-      <trans-unit id="agentTableHoverBackground">
-        <source xml:lang="en">SQL Agent table hover background color.</source>
-        <target state="translated">SQL Agent 資料表暫留背景色彩。</target>
-      </trans-unit>
-      <trans-unit id="agentJobsHeadingColor">
-        <source xml:lang="en">SQL Agent heading background color.</source>
-        <target state="translated">SQL Agent 標題背景色彩。</target>
-      </trans-unit>
-      <trans-unit id="agentCellBorderColor">
-        <source xml:lang="en">SQL Agent table cell border color.</source>
-        <target state="translated">SQL Agent 資料表資料格邊框色彩。</target>
-      </trans-unit>
-      <trans-unit id="resultsErrorColor">
-        <source xml:lang="en">Results messages error color.</source>
-        <target state="translated">結果訊息錯誤色彩。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="backup.backupName">
-        <source xml:lang="en">Backup name</source>
-        <target state="translated">備份名稱</target>
-      </trans-unit>
-      <trans-unit id="backup.recoveryModel">
-        <source xml:lang="en">Recovery model</source>
-        <target state="translated">復原模式</target>
-      </trans-unit>
-      <trans-unit id="backup.backupType">
-        <source xml:lang="en">Backup type</source>
-        <target state="translated">備份類型</target>
-      </trans-unit>
-      <trans-unit id="backup.backupDevice">
-        <source xml:lang="en">Backup files</source>
-        <target state="translated">備份檔案</target>
-      </trans-unit>
-      <trans-unit id="backup.algorithm">
-        <source xml:lang="en">Algorithm</source>
-        <target state="translated">演算法</target>
-      </trans-unit>
-      <trans-unit id="backup.certificateOrAsymmetricKey">
-        <source xml:lang="en">Certificate or Asymmetric key</source>
-        <target state="translated">憑證或非對稱金鑰</target>
-      </trans-unit>
-      <trans-unit id="backup.media">
-        <source xml:lang="en">Media</source>
-        <target state="translated">媒體</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOption">
-        <source xml:lang="en">Backup to the existing media set</source>
-        <target state="translated">備份到現有的媒體集</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaOptionFormat">
-        <source xml:lang="en">Backup to a new media set</source>
-        <target state="translated">備份到新媒體集</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaAppend">
-        <source xml:lang="en">Append to the existing backup set</source>
-        <target state="translated">附加至現有的備份組</target>
-      </trans-unit>
-      <trans-unit id="backup.existingMediaOverwrite">
-        <source xml:lang="en">Overwrite all existing backup sets</source>
-        <target state="translated">覆寫所有現有的備份集</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetName">
-        <source xml:lang="en">New media set name</source>
-        <target state="translated">新增媒體集名稱</target>
-      </trans-unit>
-      <trans-unit id="backup.newMediaSetDescription">
-        <source xml:lang="en">New media set description</source>
-        <target state="translated">新增媒體集描述</target>
-      </trans-unit>
-      <trans-unit id="backup.checksumContainer">
-        <source xml:lang="en">Perform checksum before writing to media</source>
-        <target state="translated">在寫入媒體前執行檢查碼</target>
-      </trans-unit>
-      <trans-unit id="backup.verifyContainer">
-        <source xml:lang="en">Verify backup when finished</source>
-        <target state="translated">完成後驗證備份</target>
-      </trans-unit>
-      <trans-unit id="backup.continueOnErrorContainer">
-        <source xml:lang="en">Continue on error</source>
-        <target state="translated">錯誤時繼續</target>
-      </trans-unit>
-      <trans-unit id="backup.expiration">
-        <source xml:lang="en">Expiration</source>
-        <target state="translated">逾期</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupRetainDays">
-        <source xml:lang="en">Set backup retain days</source>
-        <target state="translated">設定備份保留天數</target>
-      </trans-unit>
-      <trans-unit id="backup.copyOnly">
-        <source xml:lang="en">Copy-only backup</source>
-        <target state="translated">僅複製備份</target>
-      </trans-unit>
-      <trans-unit id="backup.advancedConfiguration">
-        <source xml:lang="en">Advanced Configuration</source>
-        <target state="translated">進階組態</target>
-      </trans-unit>
-      <trans-unit id="backup.compression">
-        <source xml:lang="en">Compression</source>
-        <target state="translated">壓縮</target>
-      </trans-unit>
-      <trans-unit id="backup.setBackupCompression">
-        <source xml:lang="en">Set backup compression</source>
-        <target state="translated">設定備份壓縮</target>
-      </trans-unit>
-      <trans-unit id="backup.encryption">
-        <source xml:lang="en">Encryption</source>
-        <target state="translated">加密</target>
-      </trans-unit>
-      <trans-unit id="backup.transactionLog">
-        <source xml:lang="en">Transaction log</source>
-        <target state="translated">交易記錄</target>
-      </trans-unit>
-      <trans-unit id="backup.truncateTransactionLog">
-        <source xml:lang="en">Truncate the transaction log</source>
-        <target state="translated">截斷交易記錄</target>
-      </trans-unit>
-      <trans-unit id="backup.backupTail">
-        <source xml:lang="en">Backup the tail of the log</source>
-        <target state="translated">備份最後的記錄</target>
-      </trans-unit>
-      <trans-unit id="backup.reliability">
-        <source xml:lang="en">Reliability</source>
-        <target state="translated">可靠性</target>
-      </trans-unit>
-      <trans-unit id="backup.mediaNameRequired">
-        <source xml:lang="en">Media name is required</source>
-        <target state="translated">需要媒體名稱</target>
-      </trans-unit>
-      <trans-unit id="backup.noEncryptorWarning">
-        <source xml:lang="en">No certificate or asymmetric key is available</source>
-        <target state="translated">沒有憑證或非對稱金鑰可用</target>
-      </trans-unit>
-      <trans-unit id="addFile">
-        <source xml:lang="en">Add a file</source>
-        <target state="translated">增加檔案</target>
-      </trans-unit>
-      <trans-unit id="removeFile">
-        <source xml:lang="en">Remove files</source>
-        <target state="translated">移除檔案</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.invalidInput">
-        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
-        <target state="translated">輸入無效。值必須大於或等於 0。</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">指令碼</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.backup">
-        <source xml:lang="en">Backup</source>
-        <target state="translated">備份</target>
-      </trans-unit>
-      <trans-unit id="backupComponent.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="backup.containsBackupToUrlError">
-        <source xml:lang="en">Only backup to file is supported</source>
-        <target state="translated">僅支援備份到檔案</target>
-      </trans-unit>
-      <trans-unit id="backup.backupFileRequired">
-        <source xml:lang="en">Backup file path is required</source>
-        <target state="translated">需要備份檔案路徑</target>
+      <trans-unit id="saveAsNotSupported">
+        <source xml:lang="en">Saving results into different format disabled for this data provider.</source>
+        <target state="translated">正在將結果儲存為其他格式，但此資料提供者已停用該格式。</target>
+      </trans-unit>
+      <trans-unit id="noSerializationProvider">
+        <source xml:lang="en">Cannot serialize data as no provider has been registered</source>
+        <target state="translated">因為未註冊任何提供者，所以無法序列化資料</target>
+      </trans-unit>
+      <trans-unit id="unknownSerializationError">
+        <source xml:lang="en">Serialization failed with an unknown error</source>
+        <target state="translated">因為發生未知錯誤，導致序列化失敗</target>
       </trans-unit>
     </body>
   </file>
@@ -4632,407 +589,87 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/platform/theme/common/colors" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="no-dataprovider">
-        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
-        <target state="translated">沒有任何已註冊的資料提供者可提供檢視資料。</target>
+      <trans-unit id="tableHeaderBackground">
+        <source xml:lang="en">Table header background color</source>
+        <target state="translated">資料表標題背景色彩</target>
       </trans-unit>
-      <trans-unit id="refresh">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">重新整理</target>
+      <trans-unit id="tableHeaderForeground">
+        <source xml:lang="en">Table header foreground color</source>
+        <target state="translated">資料表標題前景色彩</target>
       </trans-unit>
-      <trans-unit id="collapseAll">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">全部摺疊</target>
+      <trans-unit id="listFocusAndSelectionBackground">
+        <source xml:lang="en">List/Table background color for the selected and focus item when the list/table is active</source>
+        <target state="translated">當清單/資料表處於使用狀態時，所選項目與聚焦項目的清單/資料表背景色彩</target>
       </trans-unit>
-      <trans-unit id="command-error">
-        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
-        <target state="translated">執行命令 {1} 時發生錯誤: {0}。這可能是貢獻 {1} 的延伸模組所引起。</target>
+      <trans-unit id="tableCellOutline">
+        <source xml:lang="en">Color of the outline of a cell.</source>
+        <target state="translated">資料格的外框色彩。</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxBackground">
+        <source xml:lang="en">Disabled Input box background.</source>
+        <target state="translated">已停用輸入方塊背景。</target>
+      </trans-unit>
+      <trans-unit id="disabledInputBoxForeground">
+        <source xml:lang="en">Disabled Input box foreground.</source>
+        <target state="translated">已停用輸入方塊前景。</target>
+      </trans-unit>
+      <trans-unit id="buttonFocusOutline">
+        <source xml:lang="en">Button outline color when focused.</source>
+        <target state="translated">聚焦時按鈕外框色彩。</target>
+      </trans-unit>
+      <trans-unit id="disabledCheckboxforeground">
+        <source xml:lang="en">Disabled checkbox foreground.</source>
+        <target state="translated">已停用核取方塊前景。</target>
+      </trans-unit>
+      <trans-unit id="agentTableBackground">
+        <source xml:lang="en">SQL Agent Table background color.</source>
+        <target state="translated">SQL Agent 資料表背景色彩。</target>
+      </trans-unit>
+      <trans-unit id="agentCellBackground">
+        <source xml:lang="en">SQL Agent table cell background color.</source>
+        <target state="translated">SQL Agent 資料表資料格背景色彩。</target>
+      </trans-unit>
+      <trans-unit id="agentTableHoverBackground">
+        <source xml:lang="en">SQL Agent table hover background color.</source>
+        <target state="translated">SQL Agent 資料表暫留背景色彩。</target>
+      </trans-unit>
+      <trans-unit id="agentJobsHeadingColor">
+        <source xml:lang="en">SQL Agent heading background color.</source>
+        <target state="translated">SQL Agent 標題背景色彩。</target>
+      </trans-unit>
+      <trans-unit id="agentCellBorderColor">
+        <source xml:lang="en">SQL Agent table cell border color.</source>
+        <target state="translated">SQL Agent 資料表資料格邊框色彩。</target>
+      </trans-unit>
+      <trans-unit id="resultsErrorColor">
+        <source xml:lang="en">Results messages error color.</source>
+        <target state="translated">結果訊息錯誤色彩。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/api/browser/mainThreadExtensionManagement" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="notebook.failed">
-        <source xml:lang="en">Please select active cell and try again</source>
-        <target state="translated">請選取作用資料格並再試一次</target>
+      <trans-unit id="workbench.generalObsoleteApiNotification">
+        <source xml:lang="en">Some of the loaded extensions are using obsolete APIs, please find the detailed information in the Console tab of Developer Tools window</source>
+        <target state="translated">載入的延伸模組中，有一些使用淘汰的 API。請參閱「開發人員工具」視窗 [主控台] 索引標籤中的詳細資訊</target>
       </trans-unit>
-      <trans-unit id="runCell">
-        <source xml:lang="en">Run cell</source>
-        <target state="translated">執行資料格</target>
-      </trans-unit>
-      <trans-unit id="stopCell">
-        <source xml:lang="en">Cancel execution</source>
-        <target state="translated">取消執行</target>
-      </trans-unit>
-      <trans-unit id="errorRunCell">
-        <source xml:lang="en">Error on last run. Click to run again</source>
-        <target state="translated">上一個執行發生錯誤。按一下即可重新執行</target>
+      <trans-unit id="dontShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">不要再顯示</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="cancelTask.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-      <trans-unit id="errorMsgFromCancelTask">
-        <source xml:lang="en">The task is failed to cancel.</source>
-        <target state="translated">工作無法取消。</target>
-      </trans-unit>
-      <trans-unit id="taskAction.script">
-        <source xml:lang="en">Script</source>
-        <target state="translated">指令碼</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/taskbar/overflowActionbar" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Toggle More</source>
-        <target state="translated">切換更多</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/loadingSpinner.plugin" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="loadingSpinner.loading">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">正在載入</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="homeCrumb">
-        <source xml:lang="en">Home</source>
-        <target state="translated">首頁</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboardNavSection.loadTabError">
-        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
-        <target state="translated">"{0}" 區段有無效的內容。請連絡延伸模組擁有者。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="jobview.Jobs">
-        <source xml:lang="en">Jobs</source>
-        <target state="translated">作業</target>
-      </trans-unit>
-      <trans-unit id="jobview.Notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">Notebooks</target>
-      </trans-unit>
-      <trans-unit id="jobview.Alerts">
-        <source xml:lang="en">Alerts</source>
-        <target state="translated">警示</target>
-      </trans-unit>
-      <trans-unit id="jobview.Proxies">
-        <source xml:lang="en">Proxies</source>
-        <target state="translated">Proxy</target>
-      </trans-unit>
-      <trans-unit id="jobview.Operators">
-        <source xml:lang="en">Operators</source>
-        <target state="translated">運算子</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="serverPageName">
-        <source xml:lang="en">Server Properties</source>
-        <target state="translated">伺服器屬性</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="databasePageName">
-        <source xml:lang="en">Database Properties</source>
-        <target state="translated">資料庫屬性</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="selectDeselectAll">
-        <source xml:lang="en">Select/Deselect All</source>
-        <target state="translated">選擇/取消全選</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/headerFilter.plugin" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="headerFilter.showFilter">
-        <source xml:lang="en">Show Filter</source>
-        <target state="translated">顯示篩選</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.ok">
-        <source xml:lang="en">OK</source>
-        <target state="translated">確定</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.clear">
-        <source xml:lang="en">Clear</source>
-        <target state="translated">清除</target>
-      </trans-unit>
-      <trans-unit id="headerFilter.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="treeAriaLabel">
-        <source xml:lang="en">Recent Connections</source>
-        <target state="translated">最近的連線</target>
-      </trans-unit>
-      <trans-unit id="serversAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">伺服器</target>
-      </trans-unit>
-      <trans-unit id="treeCreation.regTreeAriaLabel">
-        <source xml:lang="en">Servers</source>
-        <target state="translated">伺服器</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="backup.filterBackupFiles">
-        <source xml:lang="en">Backup Files</source>
-        <target state="translated">備份檔案</target>
-      </trans-unit>
-      <trans-unit id="backup.allFiles">
-        <source xml:lang="en">All Files</source>
-        <target state="translated">所有檔案</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="label.Search">
-        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
-        <target state="translated">搜尋: 輸入搜尋字詞，然後按 Enter 鍵搜尋或按 Esc 鍵取消</target>
-      </trans-unit>
-      <trans-unit id="search.placeHolder">
-        <source xml:lang="en">Search</source>
-        <target state="translated">搜尋</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.changeDatabaseFailure">
-        <source xml:lang="en">Failed to change database</source>
-        <target state="translated">變更資料庫失敗</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="jobAlertColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
-        <source xml:lang="en">Last Occurrence</source>
-        <target state="translated">上次發生</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">啟用</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.delayBetweenResponses">
-        <source xml:lang="en">Delay Between Responses (in secs)</source>
-        <target state="translated">回應之間的延遲 (秒)</target>
-      </trans-unit>
-      <trans-unit id="jobAlertColumns.categoryName">
-        <source xml:lang="en">Category Name</source>
-        <target state="translated">類別名稱</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="jobOperatorsView.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.emailAddress">
-        <source xml:lang="en">Email Address</source>
-        <target state="translated">電子郵件地址</target>
-      </trans-unit>
-      <trans-unit id="jobOperatorsView.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">啟用</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="jobProxiesView.accountName">
-        <source xml:lang="en">Account Name</source>
-        <target state="translated">帳戶名稱</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.credentialName">
-        <source xml:lang="en">Credential Name</source>
-        <target state="translated">認證名稱</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.description">
-        <source xml:lang="en">Description</source>
-        <target state="translated">描述</target>
-      </trans-unit>
-      <trans-unit id="jobProxiesView.isEnabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">啟用</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="loadingObjects">
-        <source xml:lang="en">loading objects</source>
-        <target state="translated">正在載入物件</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabases">
-        <source xml:lang="en">loading databases</source>
-        <target state="translated">正在載入資料庫</target>
-      </trans-unit>
-      <trans-unit id="loadingObjectsCompleted">
-        <source xml:lang="en">loading objects completed.</source>
-        <target state="translated">已完成載入物件。</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabasesCompleted">
-        <source xml:lang="en">loading databases completed.</source>
-        <target state="translated">已完成載入資料庫。</target>
-      </trans-unit>
-      <trans-unit id="seachObjects">
-        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
-        <target state="translated">依類型名稱搜尋 (t:、v:、f: 或 sp:)</target>
-      </trans-unit>
-      <trans-unit id="searchDatabases">
-        <source xml:lang="en">Search databases</source>
-        <target state="translated">搜尋資料庫</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectError">
-        <source xml:lang="en">Unable to load objects</source>
-        <target state="translated">無法載入物件</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.databaseError">
-        <source xml:lang="en">Unable to load databases</source>
-        <target state="translated">無法載入資料庫</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="loadingProperties">
-        <source xml:lang="en">Loading properties</source>
-        <target state="translated">正在載入屬性</target>
-      </trans-unit>
-      <trans-unit id="loadingPropertiesCompleted">
-        <source xml:lang="en">Loading properties completed</source>
-        <target state="translated">已完成載入屬性</target>
-      </trans-unit>
-      <trans-unit id="dashboard.properties.error">
-        <source xml:lang="en">Unable to load dashboard properties</source>
-        <target state="translated">無法載入儀表板屬性</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="insightsWidgetLoadingMessage">
-        <source xml:lang="en">Loading {0}</source>
-        <target state="translated">正在載入 {0}</target>
-      </trans-unit>
-      <trans-unit id="insightsWidgetLoadingCompletedMessage">
-        <source xml:lang="en">Loading {0} completed</source>
-        <target state="translated">已完成載入 {0}</target>
-      </trans-unit>
-      <trans-unit id="insights.autoRefreshOffState">
-        <source xml:lang="en">Auto Refresh: OFF</source>
-        <target state="translated">自動重新整理: 關閉</target>
-      </trans-unit>
-      <trans-unit id="insights.lastUpdated">
-        <source xml:lang="en">Last Updated: {0} {1}</source>
-        <target state="translated">最近更新: {0} {1}</target>
-      </trans-unit>
-      <trans-unit id="noResults">
-        <source xml:lang="en">No results to show</source>
-        <target state="translated">沒有可顯示的結果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="agent.steps">
-        <source xml:lang="en">Steps</source>
-        <target state="translated">步驟</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="saveAsCsv">
-        <source xml:lang="en">Save As CSV</source>
-        <target state="translated">另存為 CSV</target>
-      </trans-unit>
-      <trans-unit id="saveAsJson">
-        <source xml:lang="en">Save As JSON</source>
-        <target state="translated">另存為 JSON</target>
-      </trans-unit>
-      <trans-unit id="saveAsExcel">
-        <source xml:lang="en">Save As Excel</source>
-        <target state="translated">另存為 Excel</target>
-      </trans-unit>
-      <trans-unit id="saveAsXml">
-        <source xml:lang="en">Save As XML</source>
-        <target state="translated">另存為 XML</target>
-      </trans-unit>
-      <trans-unit id="jsonEncoding">
-        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
-        <target state="translated">匯出至 JSON 時將不會儲存結果編碼，請務必在建立檔案後儲存所需的編碼。</target>
-      </trans-unit>
-      <trans-unit id="saveToFileNotSupported">
-        <source xml:lang="en">Save to file is not supported by the backing data source</source>
-        <target state="translated">回溯資料來源不支援儲存為檔案</target>
-      </trans-unit>
-      <trans-unit id="copySelection">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">複製</target>
-      </trans-unit>
-      <trans-unit id="copyWithHeaders">
-        <source xml:lang="en">Copy With Headers</source>
-        <target state="translated">隨標題一同複製</target>
-      </trans-unit>
-      <trans-unit id="selectAll">
-        <source xml:lang="en">Select All</source>
-        <target state="translated">全選</target>
-      </trans-unit>
-      <trans-unit id="maximize">
-        <source xml:lang="en">Maximize</source>
-        <target state="translated">最大化</target>
-      </trans-unit>
-      <trans-unit id="restore">
-        <source xml:lang="en">Restore</source>
-        <target state="translated">還原</target>
-      </trans-unit>
-      <trans-unit id="chart">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">圖表</target>
-      </trans-unit>
-      <trans-unit id="visualizer">
-        <source xml:lang="en">Visualizer</source>
-        <target state="translated">視覺化檢視</target>
+      <trans-unit id="runActiveCell">
+        <source xml:lang="en">F5 shortcut key requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">F5 快速鍵需要選取程式碼資料格。請選取要執行的程式碼資料格。</target>
+      </trans-unit>
+      <trans-unit id="clearResultActiveCell">
+        <source xml:lang="en">Clear result requires a code cell to be selected. Please select a code cell to run.</source>
+        <target state="translated">清除結果需要選取程式碼資料格。請選取要執行的程式碼資料格。</target>
       </trans-unit>
     </body>
   </file>
@@ -5052,349 +689,495 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/api/common/extHostModelViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="stepRow.stepID">
-        <source xml:lang="en">Step ID</source>
-        <target state="translated">步驟識別碼</target>
+      <trans-unit id="dialogDoneLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">完成</target>
       </trans-unit>
-      <trans-unit id="stepRow.stepName">
-        <source xml:lang="en">Step Name</source>
-        <target state="translated">步驟名稱</target>
+      <trans-unit id="dialogCancelLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
-      <trans-unit id="stepRow.message">
-        <source xml:lang="en">Message</source>
-        <target state="translated">訊息</target>
+      <trans-unit id="generateScriptLabel">
+        <source xml:lang="en">Generate script</source>
+        <target state="translated">產生指令碼</target>
+      </trans-unit>
+      <trans-unit id="dialogNextLabel">
+        <source xml:lang="en">Next</source>
+        <target state="translated">下一個</target>
+      </trans-unit>
+      <trans-unit id="dialogPreviousLabel">
+        <source xml:lang="en">Previous</source>
+        <target state="translated">上一個</target>
+      </trans-unit>
+      <trans-unit id="dashboardNotInitialized">
+        <source xml:lang="en">Tabs are not initialized</source>
+        <target state="translated">索引標籤未初始化</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/api/common/extHostModelViewTree" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">尋找</target>
+      <trans-unit id="treeView.notRegistered">
+        <source xml:lang="en">No tree view with id '{0}' registered.</source>
+        <target state="translated">未註冊識別碼為 '{0}' 的樹狀檢視。</target>
       </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">尋找</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebook" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">必須將具有有效 providerId 的 NotebookProvider 傳遞給此方法</target>
       </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">上一個相符</target>
+      <trans-unit id="errNoProvider">
+        <source xml:lang="en">no notebook provider found</source>
+        <target state="translated">找不到任何筆記本提供者</target>
       </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">下一個相符</target>
+      <trans-unit id="errNoManager">
+        <source xml:lang="en">No Manager found</source>
+        <target state="translated">找不到管理員</target>
       </trans-unit>
-      <trans-unit id="label.closeButton">
+      <trans-unit id="noServerManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a server manager. Cannot perform operations on it</source>
+        <target state="translated">筆記本 {0} 的 Notebook 管理員沒有伺服器管理員。無法對其執行作業</target>
+      </trans-unit>
+      <trans-unit id="noContentManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a content manager. Cannot perform operations on it</source>
+        <target state="translated">筆記本 {0} 的 Notebook 管理員沒有內容管理員。無法對其執行作業</target>
+      </trans-unit>
+      <trans-unit id="noSessionManager">
+        <source xml:lang="en">Notebook Manager for notebook {0} does not have a session manager. Cannot perform operations on it</source>
+        <target state="translated">筆記本 {0} 的 Notebook 管理員沒有工作階段管理員。無法對其執行作業</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="providerRequired">
+        <source xml:lang="en">A NotebookProvider with valid providerId must be passed to this method</source>
+        <target state="translated">必須將具有有效 providerId 的 NotebookProvider 傳遞給此方法</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
+      </trans-unit>
+      <trans-unit id="showDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">顯示詳細資訊</target>
+      </trans-unit>
+      <trans-unit id="configureDashboardLearnMore">
+        <source xml:lang="en">Learn More</source>
+        <target state="translated">深入了解</target>
+      </trans-unit>
+      <trans-unit id="clearSavedAccounts">
+        <source xml:lang="en">Clear all saved accounts</source>
+        <target state="translated">清除所有儲存的帳戶</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/actions.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="previewFeatures.configTitle">
+        <source xml:lang="en">Preview Features</source>
+        <target state="translated">預覽功能</target>
+      </trans-unit>
+      <trans-unit id="previewFeatures.configEnable">
+        <source xml:lang="en">Enable unreleased preview features</source>
+        <target state="translated">啟用未發佈的預覽功能</target>
+      </trans-unit>
+      <trans-unit id="showConnectDialogOnStartup">
+        <source xml:lang="en">Show connect dialog on startup</source>
+        <target state="translated">啟動時顯示連線對話方塊</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotificationTitle">
+        <source xml:lang="en">Obsolete API Notification</source>
+        <target state="translated">淘汰 API 通知</target>
+      </trans-unit>
+      <trans-unit id="enableObsoleteApiUsageNotification">
+        <source xml:lang="en">Enable/disable obsolete API usage notification</source>
+        <target state="translated">啟用/停用使用淘汰的 API 通知</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editData/editDataInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectionFailure">
+        <source xml:lang="en">Edit Data Session Failed To Connect</source>
+        <target state="translated">編輯資料工作階段連線失敗</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/profiler/profilerInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="profilerInput.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">分析工具</target>
+      </trans-unit>
+      <trans-unit id="profilerInput.notConnected">
+        <source xml:lang="en">Not connected</source>
+        <target state="translated">未連線</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionStopped">
+        <source xml:lang="en">XEvent Profiler Session stopped unexpectedly on the server {0}.</source>
+        <target state="translated">伺服器 {0} 上的 XEvent 分析工具工作階段意外停止。</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionCreationError">
+        <source xml:lang="en">Error while starting new session</source>
+        <target state="translated">啟動新的工作階段時發生錯誤</target>
+      </trans-unit>
+      <trans-unit id="profiler.eventsLost">
+        <source xml:lang="en">The XEvent Profiler session for {0} has lost events.</source>
+        <target state="translated">{0} 的 XEvent 分析工具工作階段遺失事件。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="resourceViewer.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">顯示動作</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerInput.resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">資源檢視器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modal/modal" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="infoAltText">
+        <source xml:lang="en">Information</source>
+        <target state="translated">資訊</target>
+      </trans-unit>
+      <trans-unit id="warningAltText">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">警告</target>
+      </trans-unit>
+      <trans-unit id="errorAltText">
+        <source xml:lang="en">Error</source>
+        <target state="translated">錯誤</target>
+      </trans-unit>
+      <trans-unit id="showMessageDetails">
+        <source xml:lang="en">Show Details</source>
+        <target state="translated">顯示詳細資訊</target>
+      </trans-unit>
+      <trans-unit id="copyMessage">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">複製</target>
+      </trans-unit>
+      <trans-unit id="closeMessage">
         <source xml:lang="en">Close</source>
         <target state="translated">關閉</target>
       </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">您的搜尋傳回了大量結果，只會將前 999 個相符項目醒目提示。</target>
+      <trans-unit id="modal.back">
+        <source xml:lang="en">Back</source>
+        <target state="translated">返回</target>
       </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{0}/{1} 個</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">沒有任何結果</target>
+      <trans-unit id="hideMessageDetails">
+        <source xml:lang="en">Hide Details</source>
+        <target state="translated">隱藏詳細資料</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/browser/modal/optionsDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="horizontalBarAltName">
-        <source xml:lang="en">Horizontal Bar</source>
-        <target state="translated">水平橫條圖</target>
+      <trans-unit id="optionsDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
       </trans-unit>
-      <trans-unit id="barAltName">
-        <source xml:lang="en">Bar</source>
-        <target state="translated">橫條圖</target>
-      </trans-unit>
-      <trans-unit id="lineAltName">
-        <source xml:lang="en">Line</source>
-        <target state="translated">折線圖</target>
-      </trans-unit>
-      <trans-unit id="pieAltName">
-        <source xml:lang="en">Pie</source>
-        <target state="translated">圓形圖</target>
-      </trans-unit>
-      <trans-unit id="scatterAltName">
-        <source xml:lang="en">Scatter</source>
-        <target state="translated">散佈圖</target>
-      </trans-unit>
-      <trans-unit id="timeSeriesAltName">
-        <source xml:lang="en">Time Series</source>
-        <target state="translated">時間序列</target>
-      </trans-unit>
-      <trans-unit id="imageAltName">
-        <source xml:lang="en">Image</source>
-        <target state="translated">映像</target>
-      </trans-unit>
-      <trans-unit id="countAltName">
-        <source xml:lang="en">Count</source>
-        <target state="translated">計數</target>
-      </trans-unit>
-      <trans-unit id="tableAltName">
-        <source xml:lang="en">Table</source>
-        <target state="translated">資料表</target>
-      </trans-unit>
-      <trans-unit id="doughnutAltName">
-        <source xml:lang="en">Doughnut</source>
-        <target state="translated">環圈圖</target>
-      </trans-unit>
-      <trans-unit id="charting.failedToGetRows">
-        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
-        <target state="translated">無法取得資料集的資料列以繪製圖表。</target>
-      </trans-unit>
-      <trans-unit id="charting.unsupportedType">
-        <source xml:lang="en">Chart type '{0}' is not supported.</source>
-        <target state="translated">不支援圖表類型 '{0}'。</target>
+      <trans-unit id="optionsDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/browser/modal/optionsDialogHelper" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="parametersText">
-        <source xml:lang="en">Parameters</source>
-        <target state="translated">參數</target>
+      <trans-unit id="optionsDialog.missingRequireField">
+        <source xml:lang="en"> is required.</source>
+        <target state="translated">是必要的。</target>
+      </trans-unit>
+      <trans-unit id="optionsDialog.invalidInput">
+        <source xml:lang="en">Invalid input.  Numeric value expected.</source>
+        <target state="translated">輸入無效。預期為數字。</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/browser/modelComponents/componentBase" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="onDidConnectMessage">
-        <source xml:lang="en">Connected to</source>
-        <target state="translated">已連線到</target>
+      <trans-unit id="invalidIndex">
+        <source xml:lang="en">The index {0} is invalid.</source>
+        <target state="translated">索引 {0} 無效。</target>
       </trans-unit>
-      <trans-unit id="onDidDisconnectMessage">
-        <source xml:lang="en">Disconnected</source>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/declarativeTable.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="blankValue">
+        <source xml:lang="en">blank</source>
+        <target state="translated">空白</target>
+      </trans-unit>
+      <trans-unit id="checkAllColumnLabel">
+        <source xml:lang="en">check all checkboxes in column: {0}</source>
+        <target state="translated">選取資料行中的所有核取方塊: {0}</target>
+      </trans-unit>
+      <trans-unit id="declarativeTable.showActions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">顯示動作</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/dropdown.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">正在載入</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">已完成載入</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/inputbox.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="invalidValueError">
+        <source xml:lang="en">Invalid value</source>
+        <target state="translated">值無效</target>
+      </trans-unit>
+      <trans-unit id="period">
+        <source xml:lang="en">{0}. {1}</source>
+        <target state="translated">{0}. {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/loadingComponent.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="loadingMessage">
+        <source xml:lang="en">Loading</source>
+        <target state="translated">正在載入</target>
+      </trans-unit>
+      <trans-unit id="loadingCompletedMessage">
+        <source xml:lang="en">Loading completed</source>
+        <target state="translated">已完成載入</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/queryTextEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="queryTextEditorAriaLabel">
+        <source xml:lang="en">modelview code editor for view model.</source>
+        <target state="translated">檢視模型的 modelview 程式碼編輯器。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="componentTypeNotRegistered">
+        <source xml:lang="en">Could not find component for type {0}</source>
+        <target state="translated">找不到類型 {0} 的元件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="languageChangeUnsupported">
+        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
+        <target state="translated">無法變更尚未儲存之檔案的編輯器類型</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">選取前 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">取用 10 筆</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">作為指令碼執行</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">修改指令碼</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">編輯資料</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">建立指令碼</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">將指令碼編寫為 Drop</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/browser/scriptingUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="scriptSelectNotFound">
+        <source xml:lang="en">No script was returned when calling select script on object </source>
+        <target state="translated">在物件上呼叫選取的指令碼時沒有回傳任何指令碼</target>
+      </trans-unit>
+      <trans-unit id="selectOperationName">
+        <source xml:lang="en">Select</source>
+        <target state="translated">選擇</target>
+      </trans-unit>
+      <trans-unit id="createOperationName">
+        <source xml:lang="en">Create</source>
+        <target state="translated">建立</target>
+      </trans-unit>
+      <trans-unit id="insertOperationName">
+        <source xml:lang="en">Insert</source>
+        <target state="translated">插入</target>
+      </trans-unit>
+      <trans-unit id="updateOperationName">
+        <source xml:lang="en">Update</source>
+        <target state="translated">更新</target>
+      </trans-unit>
+      <trans-unit id="deleteOperationName">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">刪除</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFoundForObject">
+        <source xml:lang="en">No script was returned when scripting as {0} on object {1}</source>
+        <target state="translated">在物件 {1} 指令碼為 {0} 時無回傳任何指令碼</target>
+      </trans-unit>
+      <trans-unit id="scriptingFailed">
+        <source xml:lang="en">Scripting Failed</source>
+        <target state="translated">指令碼失敗</target>
+      </trans-unit>
+      <trans-unit id="scriptNotFound">
+        <source xml:lang="en">No script was returned when scripting as {0}</source>
+        <target state="translated">指令碼為 {0} 時無回傳任何指令</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/editor/query/queryEditorInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="disconnected">
+        <source xml:lang="en">disconnected</source>
         <target state="translated">已中斷連線</target>
       </trans-unit>
-      <trans-unit id="unsavedGroupLabel">
-        <source xml:lang="en">Unsaved Connections</source>
-        <target state="translated">未儲存的連線</target>
-      </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/common/editor/query/queryResultsInput" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="connectionDialog.browser">
-        <source xml:lang="en">Browse (Preview)</source>
-        <target state="translated">瀏覽 (預覽)</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterPlaceHolder">
-        <source xml:lang="en">Type here to filter the list</source>
-        <target state="translated">在此鍵入以篩選清單</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterInputTitle">
-        <source xml:lang="en">Filter connections</source>
-        <target state="translated">篩選連線</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.ApplyingFilter">
-        <source xml:lang="en">Applying filter</source>
-        <target state="translated">正在套用篩選</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.RemovingFilter">
-        <source xml:lang="en">Removing filter</source>
-        <target state="translated">正在移除篩選</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterApplied">
-        <source xml:lang="en">Filter applied</source>
-        <target state="translated">已套用篩選</target>
-      </trans-unit>
-      <trans-unit id="connectionDialog.FilterRemoved">
-        <source xml:lang="en">Filter removed</source>
-        <target state="translated">已移除篩選</target>
-      </trans-unit>
-      <trans-unit id="savedConnections">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">已儲存的連線</target>
-      </trans-unit>
-      <trans-unit id="savedConnection">
-        <source xml:lang="en">Saved Connections</source>
-        <target state="translated">已儲存的連線</target>
-      </trans-unit>
-      <trans-unit id="connectionBrowserTree">
-        <source xml:lang="en">Connection Browser Tree</source>
-        <target state="translated">連線瀏覽器樹狀結構</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="defaultRecommendations">
-        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
-        <target state="translated">Azure Data Studio 建議使用此延伸模組。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="neverShowAgain">
-        <source xml:lang="en">Don't Show Again</source>
-        <target state="translated">不要再顯示</target>
-      </trans-unit>
-      <trans-unit id="ExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
-        <target state="translated">Azure Data Studio 有延伸模組建議。</target>
-      </trans-unit>
-      <trans-unit id="VisualizerExtensionsRecommended">
-        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
-Once installed, you can select the Visualizer icon to visualize your query results.</source>
-        <target state="translated">Azure Data Studio 有資料視覺效果的延伸模組建議。
-安裝之後，即可選取視覺化檢視圖示，將查詢結果視覺化。</target>
-      </trans-unit>
-      <trans-unit id="installAll">
-        <source xml:lang="en">Install All</source>
-        <target state="translated">全部安裝</target>
-      </trans-unit>
-      <trans-unit id="showRecommendations">
-        <source xml:lang="en">Show Recommendations</source>
-        <target state="translated">顯示建議</target>
-      </trans-unit>
-      <trans-unit id="scenarioTypeUndefined">
-        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
-        <target state="translated">必須提供延伸模組建議的案例類型。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="welcomePage.previewBody">
-        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
-        <target state="translated">這個功能頁面仍在預覽階段。預覽功能會引進新功能，並逐步成為產品中永久的一部分。這些功能雖然穩定，但在使用上仍需要改善。歡迎您在功能開發期間提供早期的意見反應。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.preview">
-        <source xml:lang="en">Preview</source>
-        <target state="translated">預覽</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnection">
-        <source xml:lang="en">Create a connection</source>
-        <target state="translated">建立連線</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createConnectionBody">
-        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
-        <target state="translated">透過連線對話方塊連線到資料庫執行個體。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQuery">
-        <source xml:lang="en">Run a query</source>
-        <target state="translated">執行查詢</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.runQueryBody">
-        <source xml:lang="en">Interact with data through a query editor.</source>
-        <target state="translated">透過查詢編輯器與資料互動。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebook">
-        <source xml:lang="en">Create a notebook</source>
-        <target state="translated">建立筆記本</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.createNotebookBody">
-        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
-        <target state="translated">使用原生筆記本編輯器建置新的筆記本。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServer">
-        <source xml:lang="en">Deploy a server</source>
-        <target state="translated">部署伺服器</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.deployServerBody">
-        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
-        <target state="translated">在您選擇的平台上建立關聯式資料服務的新執行個體。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.resources">
-        <source xml:lang="en">Resources</source>
-        <target state="translated">資源</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.history">
-        <source xml:lang="en">History</source>
-        <target state="translated">記錄</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.location">
-        <source xml:lang="en">Location</source>
-        <target state="translated">位置</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.moreRecent">
-        <source xml:lang="en">Show more</source>
-        <target state="translated">顯示更多</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.showOnStartup">
-        <source xml:lang="en">Show welcome page on startup</source>
-        <target state="translated">啟動時顯示歡迎頁面</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.usefuLinks">
-        <source xml:lang="en">Useful Links</source>
-        <target state="translated">實用的連結</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStarted">
-        <source xml:lang="en">Getting Started</source>
-        <target state="translated">使用者入門</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.gettingStartedBody">
-        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
-        <target state="translated">探索 Azure Data Studio 提供的功能，並了解如何充分利用。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentation">
-        <source xml:lang="en">Documentation</source>
-        <target state="translated">文件</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.documentationBody">
-        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
-        <target state="translated">如需快速入門、操作指南及 PowerShell、API 等參考，請瀏覽文件中心。</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionOverview">
-        <source xml:lang="en">Overview of Azure Data Studio</source>
-        <target state="translated">Azure Data Studio 概觀</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.videoDescriptionIntroduction">
-        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
-        <target state="translated">Azure Data Studio Notebooks 簡介 | 公開的資料</target>
-      </trans-unit>
-      <trans-unit id="welcomePage.extensions">
-        <source xml:lang="en">Extensions</source>
+      <trans-unit id="extensionsInputName">
+        <source xml:lang="en">Extension</source>
         <target state="translated">延伸模組</target>
       </trans-unit>
-      <trans-unit id="welcomePage.showAll">
-        <source xml:lang="en">Show All</source>
-        <target state="translated">全部顯示</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/common/theme" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="verticalTabActiveBackground">
+        <source xml:lang="en">Active tab background color for vertical tabs</source>
+        <target state="translated">垂直索引標籤的作用中索引標籤背景色彩</target>
       </trans-unit>
-      <trans-unit id="welcomePage.learnMore">
-        <source xml:lang="en">Learn more </source>
-        <target state="translated">深入了解 </target>
+      <trans-unit id="dashboardBorder">
+        <source xml:lang="en">Color for borders in dashboard</source>
+        <target state="translated">儀表板中框線的色彩</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidget">
+        <source xml:lang="en">Color of dashboard widget title</source>
+        <target state="translated">儀表板 Widget 標題的色彩</target>
+      </trans-unit>
+      <trans-unit id="dashboardWidgetSubtext">
+        <source xml:lang="en">Color for dashboard widget subtext</source>
+        <target state="translated">儀表板 Widget 次文字的色彩</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyValue">
+        <source xml:lang="en">Color for property values displayed in the properties container component</source>
+        <target state="translated">屬性容器元件中顯示的屬性值色彩</target>
+      </trans-unit>
+      <trans-unit id="propertiesContainerPropertyName">
+        <source xml:lang="en">Color for property names displayed in the properties container component</source>
+        <target state="translated">屬性容器元件中顯示的屬性名稱色彩</target>
+      </trans-unit>
+      <trans-unit id="toolbarOverflowShadow">
+        <source xml:lang="en">Toolbar overflow shadow color</source>
+        <target state="translated">工具列溢位陰影色彩</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/accounts/browser/accountManagement.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="notebookHistory.dateCreatedTooltip">
-        <source xml:lang="en">Date Created: </source>
-        <target state="translated">建立日期:</target>
+      <trans-unit id="carbon.extension.contributes.account.id">
+        <source xml:lang="en">Identifier of the account type</source>
+        <target state="translated">帳戶類型的識別碼</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.notebookErrorTooltip">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Notebook 錯誤:</target>
+      <trans-unit id="carbon.extension.contributes.account.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration</source>
+        <target state="translated">(選用) 用於 UI 中表示 accpunt 的圖示。任一檔案路徑或主題化的設定。</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.ErrorTooltip">
-        <source xml:lang="en">Job Error: </source>
-        <target state="translated">作業錯誤:</target>
+      <trans-unit id="carbon.extension.contributes.account.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">使用亮色主題時的圖示路徑</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pinnedTitle">
-        <source xml:lang="en">Pinned</source>
-        <target state="translated">已釘選</target>
+      <trans-unit id="carbon.extension.contributes.account.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">使用暗色主題時的圖像路徑</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.recentRunsTitle">
-        <source xml:lang="en">Recent Runs</source>
-        <target state="translated">最近的執行</target>
+      <trans-unit id="carbon.extension.contributes.account">
+        <source xml:lang="en">Contributes icons to account provider.</source>
+        <target state="translated">將圖示貢獻給帳戶供應者。</target>
       </trans-unit>
-      <trans-unit id="notebookHistory.pastRunsTitle">
-        <source xml:lang="en">Past Runs</source>
-        <target state="translated">過去的執行</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="asmtaction.server.getitems">
+        <source xml:lang="en">View applicable rules</source>
+        <target state="translated">檢視適用的規則</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.getitems">
+        <source xml:lang="en">View applicable rules for {0}</source>
+        <target state="translated">檢視適用於 {0} 的規則</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.server.invokeitems">
+        <source xml:lang="en">Invoke Assessment</source>
+        <target state="translated">叫用評定</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.database.invokeitems">
+        <source xml:lang="en">Invoke Assessment for {0}</source>
+        <target state="translated">為 {0} 叫用評定</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.exportasscript">
+        <source xml:lang="en">Export As Script</source>
+        <target state="translated">匯出為指令碼</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.showsamples">
+        <source xml:lang="en">View all rules and learn more on GitHub</source>
+        <target state="translated">檢視所有規則，並前往 GitHub 深入了解</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.generatehtmlreport">
+        <source xml:lang="en">Create HTML Report</source>
+        <target state="translated">建立 HTML 報表</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.openReport">
+        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
+        <target state="translated">已儲存報表。要開啟嗎?</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.open">
+        <source xml:lang="en">Open</source>
+        <target state="translated">開啟</target>
+      </trans-unit>
+      <trans-unit id="asmtaction.label.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
       </trans-unit>
     </body>
   </file>
@@ -5423,390 +1206,6 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       <trans-unit id="asmt.TargetDatabaseComplient">
         <source xml:lang="en">Database {0} is totally compliant with the best practices. Good job!</source>
         <target state="translated">資料庫 {0} 完全符合最佳做法。做得好!</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="chartTabTitle">
-        <source xml:lang="en">Chart</source>
-        <target state="translated">圖表</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="topOperations.operation">
-        <source xml:lang="en">Operation</source>
-        <target state="translated">作業</target>
-      </trans-unit>
-      <trans-unit id="topOperations.object">
-        <source xml:lang="en">Object</source>
-        <target state="translated">物件</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCost">
-        <source xml:lang="en">Est Cost</source>
-        <target state="translated">估計成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estSubtreeCost">
-        <source xml:lang="en">Est Subtree Cost</source>
-        <target state="translated">估計的樹狀子目錄成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRows">
-        <source xml:lang="en">Actual Rows</source>
-        <target state="translated">實際資料列數</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRows">
-        <source xml:lang="en">Est Rows</source>
-        <target state="translated">估計資料列數</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualExecutions">
-        <source xml:lang="en">Actual Executions</source>
-        <target state="translated">實際執行次數</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estCPUCost">
-        <source xml:lang="en">Est CPU Cost</source>
-        <target state="translated">估計 CPU 成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estIOCost">
-        <source xml:lang="en">Est IO Cost</source>
-        <target state="translated">估計 IO 成本</target>
-      </trans-unit>
-      <trans-unit id="topOperations.parallel">
-        <source xml:lang="en">Parallel</source>
-        <target state="translated">平行作業</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRebinds">
-        <source xml:lang="en">Actual Rebinds</source>
-        <target state="translated">實際重新繫結數</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRebinds">
-        <source xml:lang="en">Est Rebinds</source>
-        <target state="translated">估計重新繫結數</target>
-      </trans-unit>
-      <trans-unit id="topOperations.actualRewinds">
-        <source xml:lang="en">Actual Rewinds</source>
-        <target state="translated">實際倒轉數</target>
-      </trans-unit>
-      <trans-unit id="topOperations.estRewinds">
-        <source xml:lang="en">Est Rewinds</source>
-        <target state="translated">估計倒轉數</target>
-      </trans-unit>
-      <trans-unit id="topOperations.partitioned">
-        <source xml:lang="en">Partitioned</source>
-        <target state="translated">已分割</target>
-      </trans-unit>
-      <trans-unit id="topOperationsTitle">
-        <source xml:lang="en">Top Operations</source>
-        <target state="translated">最前幾項操作</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="servers.noConnections">
-        <source xml:lang="en">No connections found.</source>
-        <target state="translated">找不到連線。</target>
-      </trans-unit>
-      <trans-unit id="serverTree.addConnection">
-        <source xml:lang="en">Add Connection</source>
-        <target state="translated">新增連線</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="connectionWidget.AddAzureAccount">
-        <source xml:lang="en">Add an account...</source>
-        <target state="translated">新增帳戶...</target>
-      </trans-unit>
-      <trans-unit id="defaultDatabaseOption">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;預設&gt;</target>
-      </trans-unit>
-      <trans-unit id="loadingDatabaseOption">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">正在載入...</target>
-      </trans-unit>
-      <trans-unit id="serverGroup">
-        <source xml:lang="en">Server group</source>
-        <target state="translated">伺服器群組</target>
-      </trans-unit>
-      <trans-unit id="defaultServerGroup">
-        <source xml:lang="en">&lt;Default&gt;</source>
-        <target state="translated">&lt;預設&gt;</target>
-      </trans-unit>
-      <trans-unit id="addNewServerGroup">
-        <source xml:lang="en">Add new group...</source>
-        <target state="translated">新增群組...</target>
-      </trans-unit>
-      <trans-unit id="noneServerGroup">
-        <source xml:lang="en">&lt;Do not save&gt;</source>
-        <target state="translated">&lt;不要儲存&gt;</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.missingRequireField">
-        <source xml:lang="en">{0} is required.</source>
-        <target state="translated">{0} 為必要項。</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
-        <source xml:lang="en">{0} will be trimmed.</source>
-        <target state="translated">{0} 將受到修剪。</target>
-      </trans-unit>
-      <trans-unit id="rememberPassword">
-        <source xml:lang="en">Remember password</source>
-        <target state="translated">記住密碼</target>
-      </trans-unit>
-      <trans-unit id="connection.azureAccountDropdownLabel">
-        <source xml:lang="en">Account</source>
-        <target state="translated">帳戶</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.refreshAzureCredentials">
-        <source xml:lang="en">Refresh account credentials</source>
-        <target state="translated">重新整理帳戶登入資訊</target>
-      </trans-unit>
-      <trans-unit id="connection.azureTenantDropdownLabel">
-        <source xml:lang="en">Azure AD tenant</source>
-        <target state="translated">Azure AD 租用戶</target>
-      </trans-unit>
-      <trans-unit id="connectionName">
-        <source xml:lang="en">Name (optional)</source>
-        <target state="translated">名稱 (選用)</target>
-      </trans-unit>
-      <trans-unit id="advanced">
-        <source xml:lang="en">Advanced...</source>
-        <target state="translated">進階...</target>
-      </trans-unit>
-      <trans-unit id="connectionWidget.invalidAzureAccount">
-        <source xml:lang="en">You must select an account</source>
-        <target state="translated">您必須選取帳戶</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="backup.labelDatabase">
-        <source xml:lang="en">Database</source>
-        <target state="translated">資料庫</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFilegroup">
-        <source xml:lang="en">Files and filegroups</source>
-        <target state="translated">檔案與檔案群組</target>
-      </trans-unit>
-      <trans-unit id="backup.labelFull">
-        <source xml:lang="en">Full</source>
-        <target state="translated">完整</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDifferential">
-        <source xml:lang="en">Differential</source>
-        <target state="translated">差異</target>
-      </trans-unit>
-      <trans-unit id="backup.labelLog">
-        <source xml:lang="en">Transaction Log</source>
-        <target state="translated">交易記錄</target>
-      </trans-unit>
-      <trans-unit id="backup.labelDisk">
-        <source xml:lang="en">Disk</source>
-        <target state="translated">磁碟</target>
-      </trans-unit>
-      <trans-unit id="backup.labelUrl">
-        <source xml:lang="en">Url</source>
-        <target state="translated">URL</target>
-      </trans-unit>
-      <trans-unit id="backup.defaultCompression">
-        <source xml:lang="en">Use the default server setting</source>
-        <target state="translated">使用預設伺服器設定</target>
-      </trans-unit>
-      <trans-unit id="backup.compressBackup">
-        <source xml:lang="en">Compress backup</source>
-        <target state="translated">壓縮備份</target>
-      </trans-unit>
-      <trans-unit id="backup.doNotCompress">
-        <source xml:lang="en">Do not compress backup</source>
-        <target state="translated">不要壓縮備份</target>
-      </trans-unit>
-      <trans-unit id="backup.serverCertificate">
-        <source xml:lang="en">Server Certificate</source>
-        <target state="translated">伺服器憑證</target>
-      </trans-unit>
-      <trans-unit id="backup.asymmetricKey">
-        <source xml:lang="en">Asymmetric Key</source>
-        <target state="translated">非對稱金鑰</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="searchWithoutFolder">
-        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
-        <target state="translated">您尚未開啟任何包含筆記本/書籍的資料夾。</target>
-      </trans-unit>
-      <trans-unit id="openNotebookFolder">
-        <source xml:lang="en">Open Notebooks</source>
-        <target state="translated">開啟筆記本</target>
-      </trans-unit>
-      <trans-unit id="searchMaxResultsWarning">
-        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
-        <target state="translated">結果集只包含所有符合項的子集。請提供更具體的搜尋條件以縮小結果範圍。</target>
-      </trans-unit>
-      <trans-unit id="searchInProgress">
-        <source xml:lang="en">Search in progress... - </source>
-        <target state="translated">正在搜尋... - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludesExcludes">
-        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
-        <target state="translated">在 '{0}' 中找不到排除 '{1}' 的結果 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsIncludes">
-        <source xml:lang="en">No results found in '{0}' - </source>
-        <target state="translated">在 '{0}' 中找不到結果 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsExcludes">
-        <source xml:lang="en">No results found excluding '{0}' - </source>
-        <target state="translated">找不到排除 '{0}' 的結果 - </target>
-      </trans-unit>
-      <trans-unit id="noResultsFound">
-        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
-        <target state="translated">找不到任何結果。請檢閱您所設定排除的設定，並檢查您的 gitignore 檔案 -</target>
-      </trans-unit>
-      <trans-unit id="rerunSearch.message">
-        <source xml:lang="en">Search again</source>
-        <target state="translated">再次搜尋</target>
-      </trans-unit>
-      <trans-unit id="cancelSearch.message">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">取消搜尋</target>
-      </trans-unit>
-      <trans-unit id="rerunSearchInAll.message">
-        <source xml:lang="en">Search again in all files</source>
-        <target state="translated">在所有檔案中再次搜尋</target>
-      </trans-unit>
-      <trans-unit id="openSettings.message">
-        <source xml:lang="en">Open Settings</source>
-        <target state="translated">開啟設定</target>
-      </trans-unit>
-      <trans-unit id="ariaSearchResultsStatus">
-        <source xml:lang="en">Search returned {0} results in {1} files</source>
-        <target state="translated">搜尋傳回 {1} 個檔案中的 {0} 個結果</target>
-      </trans-unit>
-      <trans-unit id="ToggleCollapseAndExpandAction.label">
-        <source xml:lang="en">Toggle Collapse and Expand</source>
-        <target state="translated">切換折疊和展開</target>
-      </trans-unit>
-      <trans-unit id="CancelSearchAction.label">
-        <source xml:lang="en">Cancel Search</source>
-        <target state="translated">取消搜尋</target>
-      </trans-unit>
-      <trans-unit id="ExpandAllAction.label">
-        <source xml:lang="en">Expand All</source>
-        <target state="translated">全部展開</target>
-      </trans-unit>
-      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
-        <source xml:lang="en">Collapse All</source>
-        <target state="translated">全部摺疊</target>
-      </trans-unit>
-      <trans-unit id="ClearSearchResultsAction.label">
-        <source xml:lang="en">Clear Search Results</source>
-        <target state="translated">清除搜尋結果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="GuidedTour.connections">
-        <source xml:lang="en">Connections</source>
-        <target state="translated">連線</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnections">
-        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
-        <target state="translated">從 SQL Server、Azure 等處進行連線、查詢及管理您的連線。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.one">
-        <source xml:lang="en">1</source>
-        <target state="translated">1</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.next">
-        <source xml:lang="en">Next</source>
-        <target state="translated">下一個</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.notebooks">
-        <source xml:lang="en">Notebooks</source>
-        <target state="translated">筆記本</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.gettingStartedNotebooks">
-        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
-        <target state="translated">開始在單一位置建立您自己的筆記本或筆記本系列。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.two">
-        <source xml:lang="en">2</source>
-        <target state="translated">2</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.extensions">
-        <source xml:lang="en">Extensions</source>
-        <target state="translated">延伸模組</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.addExtensions">
-        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
-        <target state="translated">安裝由我們 (Microsoft) 及第三方社群 (您!) 所開發的延伸模組，來擴充 Azure Data Studio 的功能。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.three">
-        <source xml:lang="en">3</source>
-        <target state="translated">3</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.settings">
-        <source xml:lang="en">Settings</source>
-        <target state="translated">設定</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.makeConnesetSettings">
-        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
-        <target state="translated">根據您的喜好自訂 Azure Data Studio。您可以進行自動儲存及索引標籤大小等 [設定]、將 [鍵盤快速鍵] 個人化，以及切換至您喜歡的 [色彩佈景主題]。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.four">
-        <source xml:lang="en">4</source>
-        <target state="translated">4</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.welcomePage">
-        <source xml:lang="en">Welcome Page</source>
-        <target state="translated">歡迎頁面</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.discoverWelcomePage">
-        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
-        <target state="translated">在歡迎頁面中探索常用功能、最近開啟的檔案及建議的延伸模組。如需詳細資訊，以了解如何開始使用 Azure Data Studio，請參閱我們的影片及文件。</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.five">
-        <source xml:lang="en">5</source>
-        <target state="translated">5</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.finish">
-        <source xml:lang="en">Finish</source>
-        <target state="translated">完成</target>
-      </trans-unit>
-      <trans-unit id="guidedTour">
-        <source xml:lang="en">User Welcome Tour</source>
-        <target state="translated">使用者歡迎導覽</target>
-      </trans-unit>
-      <trans-unit id="hideGuidedTour">
-        <source xml:lang="en">Hide Welcome Tour</source>
-        <target state="translated">隱藏歡迎導覽</target>
-      </trans-unit>
-      <trans-unit id="GuidedTour.readMore">
-        <source xml:lang="en">Read more</source>
-        <target state="translated">深入了解</target>
-      </trans-unit>
-      <trans-unit id="help">
-        <source xml:lang="en">Help</source>
-        <target state="translated">說明</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="deleteRow">
-        <source xml:lang="en">Delete Row</source>
-        <target state="translated">刪除資料列</target>
-      </trans-unit>
-      <trans-unit id="revertRow">
-        <source xml:lang="en">Revert Current Row</source>
-        <target state="translated">還原目前的資料列</target>
       </trans-unit>
     </body>
   </file>
@@ -5894,575 +1293,283 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/azure/browser/azure.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="messagePanel">
-        <source xml:lang="en">Message Panel</source>
-        <target state="translated">訊息面板</target>
-      </trans-unit>
-      <trans-unit id="copy">
-        <source xml:lang="en">Copy</source>
-        <target state="translated">複製</target>
-      </trans-unit>
-      <trans-unit id="copyAll">
-        <source xml:lang="en">Copy All</source>
-        <target state="translated">全部複製</target>
+      <trans-unit id="azure.openInAzurePortal.title">
+        <source xml:lang="en">Open in Azure Portal</source>
+        <target state="translated">在 Azure 入口網站中開啟</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="loadingMessage">
-        <source xml:lang="en">Loading</source>
-        <target state="translated">正在載入</target>
+      <trans-unit id="backup.backupName">
+        <source xml:lang="en">Backup name</source>
+        <target state="translated">備份名稱</target>
       </trans-unit>
-      <trans-unit id="loadingCompletedMessage">
-        <source xml:lang="en">Loading completed</source>
-        <target state="translated">已完成載入</target>
+      <trans-unit id="backup.recoveryModel">
+        <source xml:lang="en">Recovery model</source>
+        <target state="translated">復原模式</target>
+      </trans-unit>
+      <trans-unit id="backup.backupType">
+        <source xml:lang="en">Backup type</source>
+        <target state="translated">備份類型</target>
+      </trans-unit>
+      <trans-unit id="backup.backupDevice">
+        <source xml:lang="en">Backup files</source>
+        <target state="translated">備份檔案</target>
+      </trans-unit>
+      <trans-unit id="backup.algorithm">
+        <source xml:lang="en">Algorithm</source>
+        <target state="translated">演算法</target>
+      </trans-unit>
+      <trans-unit id="backup.certificateOrAsymmetricKey">
+        <source xml:lang="en">Certificate or Asymmetric key</source>
+        <target state="translated">憑證或非對稱金鑰</target>
+      </trans-unit>
+      <trans-unit id="backup.media">
+        <source xml:lang="en">Media</source>
+        <target state="translated">媒體</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOption">
+        <source xml:lang="en">Backup to the existing media set</source>
+        <target state="translated">備份到現有的媒體集</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaOptionFormat">
+        <source xml:lang="en">Backup to a new media set</source>
+        <target state="translated">備份到新媒體集</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaAppend">
+        <source xml:lang="en">Append to the existing backup set</source>
+        <target state="translated">附加至現有的備份組</target>
+      </trans-unit>
+      <trans-unit id="backup.existingMediaOverwrite">
+        <source xml:lang="en">Overwrite all existing backup sets</source>
+        <target state="translated">覆寫所有現有的備份集</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetName">
+        <source xml:lang="en">New media set name</source>
+        <target state="translated">新增媒體集名稱</target>
+      </trans-unit>
+      <trans-unit id="backup.newMediaSetDescription">
+        <source xml:lang="en">New media set description</source>
+        <target state="translated">新增媒體集描述</target>
+      </trans-unit>
+      <trans-unit id="backup.checksumContainer">
+        <source xml:lang="en">Perform checksum before writing to media</source>
+        <target state="translated">在寫入媒體前執行檢查碼</target>
+      </trans-unit>
+      <trans-unit id="backup.verifyContainer">
+        <source xml:lang="en">Verify backup when finished</source>
+        <target state="translated">完成後驗證備份</target>
+      </trans-unit>
+      <trans-unit id="backup.continueOnErrorContainer">
+        <source xml:lang="en">Continue on error</source>
+        <target state="translated">錯誤時繼續</target>
+      </trans-unit>
+      <trans-unit id="backup.expiration">
+        <source xml:lang="en">Expiration</source>
+        <target state="translated">逾期</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupRetainDays">
+        <source xml:lang="en">Set backup retain days</source>
+        <target state="translated">設定備份保留天數</target>
+      </trans-unit>
+      <trans-unit id="backup.copyOnly">
+        <source xml:lang="en">Copy-only backup</source>
+        <target state="translated">僅複製備份</target>
+      </trans-unit>
+      <trans-unit id="backup.advancedConfiguration">
+        <source xml:lang="en">Advanced Configuration</source>
+        <target state="translated">進階組態</target>
+      </trans-unit>
+      <trans-unit id="backup.compression">
+        <source xml:lang="en">Compression</source>
+        <target state="translated">壓縮</target>
+      </trans-unit>
+      <trans-unit id="backup.setBackupCompression">
+        <source xml:lang="en">Set backup compression</source>
+        <target state="translated">設定備份壓縮</target>
+      </trans-unit>
+      <trans-unit id="backup.encryption">
+        <source xml:lang="en">Encryption</source>
+        <target state="translated">加密</target>
+      </trans-unit>
+      <trans-unit id="backup.transactionLog">
+        <source xml:lang="en">Transaction log</source>
+        <target state="translated">交易記錄</target>
+      </trans-unit>
+      <trans-unit id="backup.truncateTransactionLog">
+        <source xml:lang="en">Truncate the transaction log</source>
+        <target state="translated">截斷交易記錄</target>
+      </trans-unit>
+      <trans-unit id="backup.backupTail">
+        <source xml:lang="en">Backup the tail of the log</source>
+        <target state="translated">備份最後的記錄</target>
+      </trans-unit>
+      <trans-unit id="backup.reliability">
+        <source xml:lang="en">Reliability</source>
+        <target state="translated">可靠性</target>
+      </trans-unit>
+      <trans-unit id="backup.mediaNameRequired">
+        <source xml:lang="en">Media name is required</source>
+        <target state="translated">需要媒體名稱</target>
+      </trans-unit>
+      <trans-unit id="backup.noEncryptorWarning">
+        <source xml:lang="en">No certificate or asymmetric key is available</source>
+        <target state="translated">沒有憑證或非對稱金鑰可用</target>
+      </trans-unit>
+      <trans-unit id="addFile">
+        <source xml:lang="en">Add a file</source>
+        <target state="translated">增加檔案</target>
+      </trans-unit>
+      <trans-unit id="removeFile">
+        <source xml:lang="en">Remove files</source>
+        <target state="translated">移除檔案</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.invalidInput">
+        <source xml:lang="en">Invalid input. Value must be greater than or equal 0.</source>
+        <target state="translated">輸入無效。值必須大於或等於 0。</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">指令碼</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">備份</target>
+      </trans-unit>
+      <trans-unit id="backupComponent.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="backup.containsBackupToUrlError">
+        <source xml:lang="en">Only backup to file is supported</source>
+        <target state="translated">僅支援備份到檔案</target>
+      </trans-unit>
+      <trans-unit id="backup.backupFileRequired">
+        <source xml:lang="en">Backup file path is required</source>
+        <target state="translated">需要備份檔案路徑</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/backup/browser/backup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="clickOn">
-        <source xml:lang="en">Click on</source>
-        <target state="translated">按一下</target>
-      </trans-unit>
-      <trans-unit id="plusCode">
-        <source xml:lang="en">+ Code</source>
-        <target state="translated">+ 程式碼</target>
-      </trans-unit>
-      <trans-unit id="or">
-        <source xml:lang="en">or</source>
-        <target state="translated">或</target>
-      </trans-unit>
-      <trans-unit id="plusText">
-        <source xml:lang="en">+ Text</source>
-        <target state="translated">+ 文字</target>
-      </trans-unit>
-      <trans-unit id="toAddCell">
-        <source xml:lang="en">to add a code or text cell</source>
-        <target state="translated">新增程式碼或文字資料格</target>
+      <trans-unit id="backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">備份</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/backup/browser/backupActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="stdInLabel">
-        <source xml:lang="en">StdIn:</source>
-        <target state="translated">Stdin: </target>
+      <trans-unit id="backup.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use backup</source>
+        <target state="translated">您必須啟用預覽功能才能使用備份</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupportedForServer">
+        <source xml:lang="en">Backup command is not supported outside of a database context. Please select a database and try again.</source>
+        <target state="translated">資料庫內容中不支援備份命令。請選取資料庫並再試一次。</target>
+      </trans-unit>
+      <trans-unit id="backup.commandNotSupported">
+        <source xml:lang="en">Backup command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL 資料庫不支援備份命令。</target>
+      </trans-unit>
+      <trans-unit id="backupAction.backup">
+        <source xml:lang="en">Backup</source>
+        <target state="translated">備份</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/backup/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="expandCellContents">
-        <source xml:lang="en">Expand code cell contents</source>
-        <target state="translated">展開程式碼資料格內容</target>
+      <trans-unit id="backup.labelDatabase">
+        <source xml:lang="en">Database</source>
+        <target state="translated">資料庫</target>
       </trans-unit>
-      <trans-unit id="collapseCellContents">
-        <source xml:lang="en">Collapse code cell contents</source>
-        <target state="translated">摺疊程式碼資料格內容</target>
+      <trans-unit id="backup.labelFilegroup">
+        <source xml:lang="en">Files and filegroups</source>
+        <target state="translated">檔案與檔案群組</target>
+      </trans-unit>
+      <trans-unit id="backup.labelFull">
+        <source xml:lang="en">Full</source>
+        <target state="translated">完整</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDifferential">
+        <source xml:lang="en">Differential</source>
+        <target state="translated">差異</target>
+      </trans-unit>
+      <trans-unit id="backup.labelLog">
+        <source xml:lang="en">Transaction Log</source>
+        <target state="translated">交易記錄</target>
+      </trans-unit>
+      <trans-unit id="backup.labelDisk">
+        <source xml:lang="en">Disk</source>
+        <target state="translated">磁碟</target>
+      </trans-unit>
+      <trans-unit id="backup.labelUrl">
+        <source xml:lang="en">Url</source>
+        <target state="translated">URL</target>
+      </trans-unit>
+      <trans-unit id="backup.defaultCompression">
+        <source xml:lang="en">Use the default server setting</source>
+        <target state="translated">使用預設伺服器設定</target>
+      </trans-unit>
+      <trans-unit id="backup.compressBackup">
+        <source xml:lang="en">Compress backup</source>
+        <target state="translated">壓縮備份</target>
+      </trans-unit>
+      <trans-unit id="backup.doNotCompress">
+        <source xml:lang="en">Do not compress backup</source>
+        <target state="translated">不要壓縮備份</target>
+      </trans-unit>
+      <trans-unit id="backup.serverCertificate">
+        <source xml:lang="en">Server Certificate</source>
+        <target state="translated">伺服器憑證</target>
+      </trans-unit>
+      <trans-unit id="backup.asymmetricKey">
+        <source xml:lang="en">Asymmetric Key</source>
+        <target state="translated">非對稱金鑰</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="xmlShowplan">
-        <source xml:lang="en">XML Showplan</source>
-        <target state="translated">XML 執行程序表</target>
-      </trans-unit>
-      <trans-unit id="resultsGrid">
-        <source xml:lang="en">Results grid</source>
-        <target state="translated">結果方格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="buttonAdd">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">新增資料格</target>
-      </trans-unit>
-      <trans-unit id="optionCodeCell">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">程式碼資料格</target>
-      </trans-unit>
-      <trans-unit id="optionTextCell">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">文字資料格</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveDown">
-        <source xml:lang="en">Move cell down</source>
-        <target state="translated">下移資料格</target>
-      </trans-unit>
-      <trans-unit id="buttonMoveUp">
-        <source xml:lang="en">Move cell up</source>
-        <target state="translated">上移資料格</target>
-      </trans-unit>
-      <trans-unit id="buttonDelete">
-        <source xml:lang="en">Delete</source>
-        <target state="translated">刪除</target>
-      </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">新增資料格</target>
-      </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">程式碼資料格</target>
-      </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">文字資料格</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="sqlKernelError">
-        <source xml:lang="en">SQL kernel error</source>
-        <target state="translated">SQL 核心錯誤</target>
-      </trans-unit>
-      <trans-unit id="connectionRequired">
-        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
-        <target state="translated">必須選擇連線來執行筆記本資料格</target>
-      </trans-unit>
-      <trans-unit id="sqlMaxRowsDisplayed">
-        <source xml:lang="en">Displaying Top {0} rows.</source>
-        <target state="translated">目前顯示前 {0} 列。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="jobColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">上次執行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">下次執行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.enabled">
-        <source xml:lang="en">Enabled</source>
-        <target state="translated">啟用</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">狀態</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.category">
-        <source xml:lang="en">Category</source>
-        <target state="translated">分類</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.runnable">
-        <source xml:lang="en">Runnable</source>
-        <target state="translated">可執行</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.schedule">
-        <source xml:lang="en">Schedule</source>
-        <target state="translated">排程</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">上次執行結果</target>
-      </trans-unit>
-      <trans-unit id="jobColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">先前的執行內容</target>
-      </trans-unit>
-      <trans-unit id="jobsView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">沒有任何此作業可用的步驟。</target>
-      </trans-unit>
-      <trans-unit id="jobsView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">錯誤:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/browser/modelComponents/viewBase" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="componentTypeNotRegistered">
-        <source xml:lang="en">Could not find component for type {0}</source>
-        <target state="translated">找不到類型 {0} 的元件</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="label.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">尋找</target>
-      </trans-unit>
-      <trans-unit id="placeholder.find">
-        <source xml:lang="en">Find</source>
-        <target state="translated">尋找</target>
-      </trans-unit>
-      <trans-unit id="label.previousMatchButton">
-        <source xml:lang="en">Previous match</source>
-        <target state="translated">上一個符合項目</target>
-      </trans-unit>
-      <trans-unit id="label.nextMatchButton">
-        <source xml:lang="en">Next match</source>
-        <target state="translated">下一個符合項目</target>
-      </trans-unit>
-      <trans-unit id="label.closeButton">
-        <source xml:lang="en">Close</source>
-        <target state="translated">關閉</target>
-      </trans-unit>
-      <trans-unit id="title.matchesCountLimit">
-        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
-        <target state="translated">您的搜尋傳回了大量結果，只會將前 999 個相符項目醒目提示。</target>
-      </trans-unit>
-      <trans-unit id="label.matchesLocation">
-        <source xml:lang="en">{0} of {1}</source>
-        <target state="translated">{1} 的 {0}</target>
-      </trans-unit>
-      <trans-unit id="label.noResults">
-        <source xml:lang="en">No Results</source>
-        <target state="translated">查無結果</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.schemaDisplayValue">
-        <source xml:lang="en">Schema</source>
-        <target state="translated">結構描述</target>
-      </trans-unit>
-      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
-        <source xml:lang="en">Type</source>
-        <target state="translated">類型</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="insights.runQuery">
-        <source xml:lang="en">Run Query</source>
-        <target state="translated">執行查詢</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="noMimeTypeFound">
-        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
-        <target state="translated">找不到輸出的 {0} 轉譯器。其有下列 MIME 類型: {1}</target>
-      </trans-unit>
-      <trans-unit id="safe">
-        <source xml:lang="en">safe </source>
-        <target state="translated">安全</target>
-      </trans-unit>
-      <trans-unit id="noSelectorFound">
-        <source xml:lang="en">No component could be found for selector {0}</source>
-        <target state="translated">找不到選取器 {0} 的元件</target>
-      </trans-unit>
-      <trans-unit id="componentRenderError">
-        <source xml:lang="en">Error rendering component: {0}</source>
-        <target state="translated">轉譯元件時發生錯誤: {0}</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">正在載入...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="loading">
-        <source xml:lang="en">Loading...</source>
-        <target state="translated">正在載入...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="editDashboard">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">編輯</target>
-      </trans-unit>
-      <trans-unit id="editDashboardExit">
-        <source xml:lang="en">Exit</source>
-        <target state="translated">結束</target>
-      </trans-unit>
-      <trans-unit id="refreshWidget">
-        <source xml:lang="en">Refresh</source>
-        <target state="translated">重新整理</target>
-      </trans-unit>
-      <trans-unit id="toggleMore">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">顯示動作</target>
-      </trans-unit>
-      <trans-unit id="deleteWidget">
-        <source xml:lang="en">Delete Widget</source>
-        <target state="translated">刪除小工具</target>
-      </trans-unit>
-      <trans-unit id="clickToUnpin">
-        <source xml:lang="en">Click to unpin</source>
-        <target state="translated">按一下以取消釘選</target>
-      </trans-unit>
-      <trans-unit id="clickToPin">
-        <source xml:lang="en">Click to pin</source>
-        <target state="translated">按一下以釘選</target>
-      </trans-unit>
-      <trans-unit id="addFeatureAction.openInstalledFeatures">
-        <source xml:lang="en">Open installed features</source>
-        <target state="translated">開啟已安裝的功能</target>
-      </trans-unit>
-      <trans-unit id="collapseWidget">
-        <source xml:lang="en">Collapse Widget</source>
-        <target state="translated">摺疊小工具</target>
-      </trans-unit>
-      <trans-unit id="expandWidget">
-        <source xml:lang="en">Expand Widget</source>
-        <target state="translated">展開小工具</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="unknownDashboardContainerError">
-        <source xml:lang="en">{0} is an unknown container.</source>
-        <target state="translated">{0} 是不明容器。</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="notebookColumns.name">
-        <source xml:lang="en">Name</source>
-        <target state="translated">名稱</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.targetDatbase">
-        <source xml:lang="en">Target Database</source>
-        <target state="translated">目標資料庫</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRun">
-        <source xml:lang="en">Last Run</source>
-        <target state="translated">上次執行</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.nextRun">
-        <source xml:lang="en">Next Run</source>
-        <target state="translated">下次執行</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.status">
-        <source xml:lang="en">Status</source>
-        <target state="translated">狀態</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.lastRunOutcome">
-        <source xml:lang="en">Last Run Outcome</source>
-        <target state="translated">上次執行結果</target>
-      </trans-unit>
-      <trans-unit id="notebookColumns.previousRuns">
-        <source xml:lang="en">Previous Runs</source>
-        <target state="translated">先前的執行內容</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.noSteps">
-        <source xml:lang="en">No Steps available for this job.</source>
-        <target state="translated">沒有任何此作業可用的步驟。</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.error">
-        <source xml:lang="en">Error: </source>
-        <target state="translated">錯誤:</target>
-      </trans-unit>
-      <trans-unit id="notebooksView.notebookError">
-        <source xml:lang="en">Notebook Error: </source>
-        <target state="translated">Notebook 錯誤:</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/base/browser/ui/table/plugins/rowDetailView" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="rowDetailView.loadError">
-        <source xml:lang="en">Loading Error...</source>
-        <target state="translated">正在載入錯誤...</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="dashboard.explorer.actions">
-        <source xml:lang="en">Show Actions</source>
-        <target state="translated">顯示動作</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchNoMatchResultMessage">
-        <source xml:lang="en">No matching item found</source>
-        <target state="translated">找不到相符的項目</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchSingleMatchResultMessage">
-        <source xml:lang="en">Filtered search list to 1 item</source>
-        <target state="translated">已將搜尋清單篩選為 1 個項目</target>
-      </trans-unit>
-      <trans-unit id="explorerSearchMatchResultMessage">
-        <source xml:lang="en">Filtered search list to {0} items</source>
-        <target state="translated">已將搜尋清單篩選為 {0} 個項目</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="agentUtilities.failed">
-        <source xml:lang="en">Failed</source>
-        <target state="translated">失敗</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.succeeded">
-        <source xml:lang="en">Succeeded</source>
-        <target state="translated">已成功</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.retry">
-        <source xml:lang="en">Retry</source>
-        <target state="translated">重試</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.canceled">
-        <source xml:lang="en">Cancelled</source>
-        <target state="translated">已取消</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.inProgress">
-        <source xml:lang="en">In Progress</source>
-        <target state="translated">正在進行</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.statusUnknown">
-        <source xml:lang="en">Status Unknown</source>
-        <target state="translated">狀態未知</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.executing">
-        <source xml:lang="en">Executing</source>
-        <target state="translated">正在執行</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.waitingForThread">
-        <source xml:lang="en">Waiting for Thread</source>
-        <target state="translated">正在等候執行緒</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.betweenRetries">
-        <source xml:lang="en">Between Retries</source>
-        <target state="translated">正在重試</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.idle">
-        <source xml:lang="en">Idle</source>
-        <target state="translated">閒置</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.suspended">
-        <source xml:lang="en">Suspended</source>
-        <target state="translated">暫止</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.obsolete">
-        <source xml:lang="en">[Obsolete]</source>
-        <target state="translated">[已淘汰]</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.yes">
-        <source xml:lang="en">Yes</source>
-        <target state="translated">是</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.no">
-        <source xml:lang="en">No</source>
-        <target state="translated">否</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.notScheduled">
-        <source xml:lang="en">Not Scheduled</source>
-        <target state="translated">未排程</target>
-      </trans-unit>
-      <trans-unit id="agentUtilities.neverRun">
-        <source xml:lang="en">Never Run</source>
-        <target state="translated">從未執行</target>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="buttonBold">
-        <source xml:lang="en">Bold</source>
-        <target state="translated">粗體</target>
-      </trans-unit>
-      <trans-unit id="buttonItalic">
-        <source xml:lang="en">Italic</source>
-        <target state="translated">斜體</target>
-      </trans-unit>
-      <trans-unit id="buttonUnderline">
-        <source xml:lang="en">Underline</source>
-        <target state="translated">底線</target>
-      </trans-unit>
-      <trans-unit id="buttonHighlight">
-        <source xml:lang="en">Highlight</source>
-        <target state="translated">醒目提示</target>
-      </trans-unit>
-      <trans-unit id="buttonCode">
-        <source xml:lang="en">Code</source>
-        <target state="translated">程式碼</target>
-      </trans-unit>
-      <trans-unit id="buttonLink">
-        <source xml:lang="en">Link</source>
-        <target state="translated">連結</target>
-      </trans-unit>
-      <trans-unit id="buttonList">
-        <source xml:lang="en">List</source>
-        <target state="translated">清單</target>
-      </trans-unit>
-      <trans-unit id="buttonOrderedList">
-        <source xml:lang="en">Ordered list</source>
-        <target state="translated">排序清單</target>
-      </trans-unit>
-      <trans-unit id="buttonImage">
-        <source xml:lang="en">Image</source>
-        <target state="translated">影像</target>
-      </trans-unit>
-      <trans-unit id="buttonPreview">
-        <source xml:lang="en">Markdown preview toggle - off</source>
-        <target state="translated">Markdown 預覽切換 - 關閉</target>
-      </trans-unit>
-      <trans-unit id="dropdownHeading">
-        <source xml:lang="en">Heading</source>
-        <target state="translated">標題</target>
-      </trans-unit>
-      <trans-unit id="optionHeading1">
-        <source xml:lang="en">Heading 1</source>
-        <target state="translated">標題 1</target>
-      </trans-unit>
-      <trans-unit id="optionHeading2">
-        <source xml:lang="en">Heading 2</source>
-        <target state="translated">標題 2</target>
-      </trans-unit>
-      <trans-unit id="optionHeading3">
-        <source xml:lang="en">Heading 3</source>
-        <target state="translated">標題 3</target>
-      </trans-unit>
-      <trans-unit id="optionParagraph">
-        <source xml:lang="en">Paragraph</source>
-        <target state="translated">段落</target>
-      </trans-unit>
-      <trans-unit id="callout.insertLinkHeading">
-        <source xml:lang="en">Insert link</source>
-        <target state="translated">插入連結</target>
-      </trans-unit>
-      <trans-unit id="callout.insertImageHeading">
-        <source xml:lang="en">Insert image</source>
-        <target state="translated">插入影像</target>
-      </trans-unit>
-      <trans-unit id="richTextViewButton">
-        <source xml:lang="en">Rich Text View</source>
-        <target state="translated">RTF 檢視</target>
-      </trans-unit>
-      <trans-unit id="splitViewButton">
-        <source xml:lang="en">Split View</source>
-        <target state="translated">分割檢視</target>
-      </trans-unit>
-      <trans-unit id="markdownViewButton">
-        <source xml:lang="en">Markdown View</source>
-        <target state="translated">Markdown 檢視</target>
+      <trans-unit id="createInsightLabel">
+        <source xml:lang="en">Create Insight</source>
+        <target state="translated">建立見解</target>
+      </trans-unit>
+      <trans-unit id="createInsightNoEditor">
+        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
+        <target state="translated">啟用的編輯器不是 SQL 編輯器，無法建立見解</target>
+      </trans-unit>
+      <trans-unit id="myWidgetName">
+        <source xml:lang="en">My-Widget</source>
+        <target state="translated">我的小工具</target>
+      </trans-unit>
+      <trans-unit id="configureChartLabel">
+        <source xml:lang="en">Configure Chart</source>
+        <target state="translated">設定圖表</target>
+      </trans-unit>
+      <trans-unit id="copyChartLabel">
+        <source xml:lang="en">Copy as image</source>
+        <target state="translated">複製為映像</target>
+      </trans-unit>
+      <trans-unit id="chartNotFound">
+        <source xml:lang="en">Could not find chart to save</source>
+        <target state="translated">找不到要儲存的圖表</target>
+      </trans-unit>
+      <trans-unit id="saveImageLabel">
+        <source xml:lang="en">Save as image</source>
+        <target state="translated">另存為映像</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
+        <source xml:lang="en">PNG</source>
+        <target state="translated">PNG</target>
+      </trans-unit>
+      <trans-unit id="chartSaved">
+        <source xml:lang="en">Saved Chart to path: {0}</source>
+        <target state="translated">已將圖表儲存到路徑: {0}</target>
       </trans-unit>
     </body>
   </file>
@@ -6550,19 +1657,411 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/base/browser/ui/panel/tabActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/charts/browser/chartTab" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="closeTab">
+      <trans-unit id="chartTabTitle">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">圖表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/chartView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="horizontalBarAltName">
+        <source xml:lang="en">Horizontal Bar</source>
+        <target state="translated">水平橫條圖</target>
+      </trans-unit>
+      <trans-unit id="barAltName">
+        <source xml:lang="en">Bar</source>
+        <target state="translated">橫條圖</target>
+      </trans-unit>
+      <trans-unit id="lineAltName">
+        <source xml:lang="en">Line</source>
+        <target state="translated">折線圖</target>
+      </trans-unit>
+      <trans-unit id="pieAltName">
+        <source xml:lang="en">Pie</source>
+        <target state="translated">圓形圖</target>
+      </trans-unit>
+      <trans-unit id="scatterAltName">
+        <source xml:lang="en">Scatter</source>
+        <target state="translated">散佈圖</target>
+      </trans-unit>
+      <trans-unit id="timeSeriesAltName">
+        <source xml:lang="en">Time Series</source>
+        <target state="translated">時間序列</target>
+      </trans-unit>
+      <trans-unit id="imageAltName">
+        <source xml:lang="en">Image</source>
+        <target state="translated">映像</target>
+      </trans-unit>
+      <trans-unit id="countAltName">
+        <source xml:lang="en">Count</source>
+        <target state="translated">計數</target>
+      </trans-unit>
+      <trans-unit id="tableAltName">
+        <source xml:lang="en">Table</source>
+        <target state="translated">資料表</target>
+      </trans-unit>
+      <trans-unit id="doughnutAltName">
+        <source xml:lang="en">Doughnut</source>
+        <target state="translated">環圈圖</target>
+      </trans-unit>
+      <trans-unit id="charting.failedToGetRows">
+        <source xml:lang="en">Failed to get rows for the dataset to chart.</source>
+        <target state="translated">無法取得資料集的資料列以繪製圖表。</target>
+      </trans-unit>
+      <trans-unit id="charting.unsupportedType">
+        <source xml:lang="en">Chart type '{0}' is not supported.</source>
+        <target state="translated">不支援圖表類型 '{0}'。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/charts.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="builtinChartsConfigurationTitle">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">內建圖表</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts.maxRowCountDescription">
+        <source xml:lang="en">The maximum number of rows for charts to display. Warning: increasing this may impact performance.</source>
+        <target state="translated">要顯示之圖表的資料列數目上限。警告: 增加此數目可能會影響效能。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="configureChartDialog.close">
         <source xml:lang="en">Close</source>
         <target state="translated">關閉</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/platform/connection/common/connectionConfig" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="invalidServerName">
-        <source xml:lang="en">A server group with the same name already exists.</source>
-        <target state="translated">伺服器群組名稱已經存在。</target>
+      <trans-unit id="series">
+        <source xml:lang="en">Series {0}</source>
+        <target state="translated">系列 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="invalidImage">
+        <source xml:lang="en">Table does not contain a valid image</source>
+        <target state="translated">資料表不含有效的映像</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/charts/browser/utils" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="charts.maxAllowedRowsExceeded">
+        <source xml:lang="en">Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.</source>
+        <target state="translated">已超過內建圖表的資料列計數上限，只會使用最先 {0} 個資料列。若要設定值，您可以開啟使用者設定並搜尋: 'builtinCharts.maxRowCount'。</target>
+      </trans-unit>
+      <trans-unit id="charts.neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">不要再顯示</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/commandLine/electron-browser/commandLine" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectingLabel">
+        <source xml:lang="en">Connecting: {0}</source>
+        <target state="translated">正在連線: {0}</target>
+      </trans-unit>
+      <trans-unit id="runningCommandLabel">
+        <source xml:lang="en">Running command: {0}</source>
+        <target state="translated">正在執行命令: {0}</target>
+      </trans-unit>
+      <trans-unit id="openingNewQueryLabel">
+        <source xml:lang="en">Opening new query: {0}</source>
+        <target state="translated">正在開啟新查詢: {0}</target>
+      </trans-unit>
+      <trans-unit id="warnServerRequired">
+        <source xml:lang="en">Cannot connect as no server information was provided</source>
+        <target state="translated">因為未提供伺服器資訊，所以無法連線</target>
+      </trans-unit>
+      <trans-unit id="errConnectUrl">
+        <source xml:lang="en">Could not open URL due to error {0}</source>
+        <target state="translated">因為發生錯誤 {0}，導致無法開啟 URL</target>
+      </trans-unit>
+      <trans-unit id="connectServerDetail">
+        <source xml:lang="en">This will connect to server {0}</source>
+        <target state="translated">這會連線到伺服器 {0}</target>
+      </trans-unit>
+      <trans-unit id="confirmConnect">
+        <source xml:lang="en">Are you sure you want to connect?</source>
+        <target state="translated">確定要連線嗎?</target>
+      </trans-unit>
+      <trans-unit id="open">
+        <source xml:lang="en">&amp;&amp;Open</source>
+        <target state="translated">開啟(&amp;&amp;O)</target>
+      </trans-unit>
+      <trans-unit id="connectingQueryLabel">
+        <source xml:lang="en">Connecting query file</source>
+        <target state="translated">正在連線到查詢檔案</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/configuration/common/configurationUpgrader" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="workbench.configuration.upgradeUser">
+        <source xml:lang="en">{0} was replaced with {1} in your user settings.</source>
+        <target state="translated">您使用者設定中的 {1} 已取代 {0}。</target>
+      </trans-unit>
+      <trans-unit id="workbench.configuration.upgradeWorkspace">
+        <source xml:lang="en">{0} was replaced with {1} in your workspace settings.</source>
+        <target state="translated">您工作區設定中的 {1} 已取代 {0}。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="sql.maxRecentConnectionsDescription">
+        <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+        <target state="translated">連線列表內最近使用的連線數上限。</target>
+      </trans-unit>
+      <trans-unit id="sql.defaultEngineDescription">
+        <source xml:lang="en">Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection.</source>
+        <target state="translated">要使用的預設 SQL 引擎。這會驅動 .sql 檔案中的預設語言提供者，以及建立新連線時要使用的預設。</target>
+      </trans-unit>
+      <trans-unit id="connection.parseClipboardForConnectionStringDescription">
+        <source xml:lang="en">Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.</source>
+        <target state="translated">嘗試在連線對話方塊開啟或已執行貼上時剖析剪貼簿的內容。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/browser/connectionStatus" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="status.connection.status">
+        <source xml:lang="en">Connection Status</source>
+        <target state="translated">連線狀態</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionProviderExtension" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="schema.providerId">
+        <source xml:lang="en">Common id for the provider</source>
+        <target state="translated">提供者的通用識別碼。</target>
+      </trans-unit>
+      <trans-unit id="schema.displayName">
+        <source xml:lang="en">Display Name for the provider</source>
+        <target state="translated">提供者的顯示名稱</target>
+      </trans-unit>
+      <trans-unit id="schema.notebookKernelAlias">
+        <source xml:lang="en">Notebook Kernel Alias for the provider</source>
+        <target state="translated">提供者的筆記本核心別名</target>
+      </trans-unit>
+      <trans-unit id="schema.iconPath">
+        <source xml:lang="en">Icon path for the server type</source>
+        <target state="translated">伺服器類型的圖示路徑</target>
+      </trans-unit>
+      <trans-unit id="schema.connectionOptions">
+        <source xml:lang="en">Options for connection</source>
+        <target state="translated">連線選項</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectionTreeProvider.schema.name">
+        <source xml:lang="en">User visible name for the tree provider</source>
+        <target state="translated">樹狀提供者向使用者顯示的名稱</target>
+      </trans-unit>
+      <trans-unit id="connectionTreeProvider.schema.id">
+        <source xml:lang="en">Id for the provider, must be the same as when registering the tree data provider and must start with `connectionDialog/`</source>
+        <target state="translated">提供者的識別碼，必須與註冊樹狀資料提供者時的識別碼相同，而且必須以 `connectionDialog/` 開頭</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.id">
+        <source xml:lang="en">Unique identifier for this container.</source>
+        <target state="translated">此容器的唯一識別碼。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.container.container">
+        <source xml:lang="en">The container that will be displayed in the tab.</source>
+        <target state="translated">顯示於索引標籤的容器。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.containers">
+        <source xml:lang="en">Contributes a single or multiple dashboard containers for users to add to their dashboard.</source>
+        <target state="translated">提供一個或多個儀表板容器，讓使用者可增加至其儀表板中。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noIdError">
+        <source xml:lang="en">No id in dashboard container specified for extension.</source>
+        <target state="translated">為延伸模組指定的儀表板容器中沒有任何識別碼。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.noContainerError">
+        <source xml:lang="en">No container in dashboard container specified for extension.</source>
+        <target state="translated">為延伸模組指定的儀表板容器中沒有任何容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboardContainer.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">至少須為每個空間定義剛好 1 個儀表板容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.unKnownContainerType">
+        <source xml:lang="en">Unknown container type defines in dashboard container for extension.</source>
+        <target state="translated">延伸模組的儀表板容器中有不明的容器類型定義。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardControlHostContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.container.controlhost">
+        <source xml:lang="en">The controlhost that will be displayed in this tab.</source>
+        <target state="translated">會在此索引標籤中顯示的 controlhost。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardErrorContainer.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboardNavSection.loadTabError">
+        <source xml:lang="en">The "{0}" section has invalid content. Please contact extension owner.</source>
+        <target state="translated">"{0}" 區段有無效的內容。請連絡延伸模組擁有者。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.container.gridtab.items">
+        <source xml:lang="en">The list of widgets or webviews that will be displayed in this tab.</source>
+        <target state="translated">顯示在此索引標籤的小工具或 Web 檢視的清單。</target>
+      </trans-unit>
+      <trans-unit id="gridContainer.invalidInputs">
+        <source xml:lang="en">widgets or webviews are expected inside widgets-container for extension.</source>
+        <target state="translated">延伸模組的 widgets-container 中應有 widgets 或 webviews。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.container.modelview">
+        <source xml:lang="en">The model-backed view that will be displayed in this tab.</source>
+        <target state="translated">將在此索引標籤中顯示的 model-backed 檢視。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.container.left-nav-bar.id">
+        <source xml:lang="en">Unique identifier for this nav section. Will be passed to the extension for any requests.</source>
+        <target state="translated">導覽區的唯一識別碼。將傳遞給任何要求的延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(選用) 用於 UI 中表示導覽區的圖示。任一檔案路徑或主題化的設定。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">使用亮色主題時的圖示路徑</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">使用暗色主題時的圖像路徑</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.title">
+        <source xml:lang="en">Title of the nav section to show the user.</source>
+        <target state="translated">顯示給使用者的導覽區標題。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar.container">
+        <source xml:lang="en">The container that will be displayed in this nav section.</source>
+        <target state="translated">顯示在此導覽區的容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboard.container.left-nav-bar">
+        <source xml:lang="en">The list of dashboard containers that will be displayed in this navigation section.</source>
+        <target state="translated">在導覽區顯示儀表板容器清單。</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingTitle.error">
+        <source xml:lang="en">No title in nav section specified for extension.</source>
+        <target state="translated">為延伸模組指定的導覽區段中沒有標題。</target>
+      </trans-unit>
+      <trans-unit id="navSection.missingContainer.error">
+        <source xml:lang="en">No container in nav section specified for extension.</source>
+        <target state="translated">為延伸模組指定的導覽區段中沒有任何容器。</target>
+      </trans-unit>
+      <trans-unit id="navSection.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space.</source>
+        <target state="translated">至少須為每個空間定義剛好 1 個儀表板容器。</target>
+      </trans-unit>
+      <trans-unit id="navSection.invalidContainer.error">
+        <source xml:lang="en">NAV_SECTION within NAV_SECTION is an invalid container for extension.</source>
+        <target state="translated">NAV_SECTION 中的 NAV_SECTION 對延伸模組而言是無效的容器。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWebviewContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.container.webview">
+        <source xml:lang="en">The webview that will be displayed in this tab.</source>
+        <target state="translated">顯示在此索引標籤的 Web 檢視。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/containers/dashboardWidgetContainer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.container.widgets">
+        <source xml:lang="en">The list of widgets that will be displayed in this tab.</source>
+        <target state="translated">顯示在此索引標籤中的小工具清單。</target>
+      </trans-unit>
+      <trans-unit id="widgetContainer.invalidInputs">
+        <source xml:lang="en">The list of widgets is expected inside widgets-container for extension.</source>
+        <target state="translated">延伸模組的 widgets-container 中應有 widgets 的清單。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="editDashboard">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">編輯</target>
+      </trans-unit>
+      <trans-unit id="editDashboardExit">
+        <source xml:lang="en">Exit</source>
+        <target state="translated">結束</target>
+      </trans-unit>
+      <trans-unit id="refreshWidget">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">重新整理</target>
+      </trans-unit>
+      <trans-unit id="toggleMore">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">顯示動作</target>
+      </trans-unit>
+      <trans-unit id="deleteWidget">
+        <source xml:lang="en">Delete Widget</source>
+        <target state="translated">刪除小工具</target>
+      </trans-unit>
+      <trans-unit id="clickToUnpin">
+        <source xml:lang="en">Click to unpin</source>
+        <target state="translated">按一下以取消釘選</target>
+      </trans-unit>
+      <trans-unit id="clickToPin">
+        <source xml:lang="en">Click to pin</source>
+        <target state="translated">按一下以釘選</target>
+      </trans-unit>
+      <trans-unit id="addFeatureAction.openInstalledFeatures">
+        <source xml:lang="en">Open installed features</source>
+        <target state="translated">開啟已安裝的功能</target>
+      </trans-unit>
+      <trans-unit id="collapseWidget">
+        <source xml:lang="en">Collapse Widget</source>
+        <target state="translated">摺疊小工具</target>
+      </trans-unit>
+      <trans-unit id="expandWidget">
+        <source xml:lang="en">Expand Widget</source>
+        <target state="translated">展開小工具</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardHelper" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="unknownDashboardContainerError">
+        <source xml:lang="en">{0} is an unknown container.</source>
+        <target state="translated">{0} 是不明容器。</target>
       </trans-unit>
     </body>
   </file>
@@ -6582,111 +2081,1025 @@ Once installed, you can select the Visualizer icon to visualize your query resul
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="createInsightLabel">
-        <source xml:lang="en">Create Insight</source>
-        <target state="translated">建立見解</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">此索引標籤的唯一識別碼。將傳遞給任何要求的延伸模組。</target>
       </trans-unit>
-      <trans-unit id="createInsightNoEditor">
-        <source xml:lang="en">Cannot create insight as the active editor is not a SQL Editor</source>
-        <target state="translated">啟用的編輯器不是 SQL 編輯器，無法建立見解</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.title">
+        <source xml:lang="en">Title of the tab to show the user.</source>
+        <target state="translated">顯示給使用者的索引標籤的標題。</target>
       </trans-unit>
-      <trans-unit id="myWidgetName">
-        <source xml:lang="en">My-Widget</source>
-        <target state="translated">我的小工具</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.description">
+        <source xml:lang="en">Description of this tab that will be shown to the user.</source>
+        <target state="translated">此索引標籤的描述將顯示給使用者。</target>
       </trans-unit>
-      <trans-unit id="configureChartLabel">
-        <source xml:lang="en">Configure Chart</source>
-        <target state="translated">設定圖表</target>
+      <trans-unit id="azdata.extension.contributes.tab.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">必須為 True 以顯示此項目的條件</target>
       </trans-unit>
-      <trans-unit id="copyChartLabel">
-        <source xml:lang="en">Copy as image</source>
-        <target state="translated">複製為映像</target>
+      <trans-unit id="azdata.extension.contributes.tab.provider">
+        <source xml:lang="en">Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set</source>
+        <target state="translated">定義與此索引標籤相容的連線類型。若未設定，則預設值為 'MSSQL'</target>
       </trans-unit>
-      <trans-unit id="chartNotFound">
-        <source xml:lang="en">Could not find chart to save</source>
-        <target state="translated">找不到要儲存的圖表</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.container">
+        <source xml:lang="en">The container that will be displayed in this tab.</source>
+        <target state="translated">將在此索引標籤中顯示的容器。</target>
       </trans-unit>
-      <trans-unit id="saveImageLabel">
-        <source xml:lang="en">Save as image</source>
-        <target state="translated">另存為映像</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.alwaysShow">
+        <source xml:lang="en">Whether or not this tab should always be shown or only when the user adds it.</source>
+        <target state="translated">是否應一律顯示此索引標籤或僅當使用者增加時顯示。</target>
       </trans-unit>
-      <trans-unit id="resultsSerializer.saveAsFileExtensionPNGTitle">
-        <source xml:lang="en">PNG</source>
-        <target state="translated">PNG</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.isHomeTab">
+        <source xml:lang="en">Whether or not this tab should be used as the Home tab for a connection type.</source>
+        <target state="translated">是否應將此索引標籤用作連線類型的首頁索引標籤。</target>
       </trans-unit>
-      <trans-unit id="chartSaved">
-        <source xml:lang="en">Saved Chart to path: {0}</source>
-        <target state="translated">已將圖表儲存到路徑: {0}</target>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.group">
+        <source xml:lang="en">The unique identifier of the group this tab belongs to, value for home group: home.</source>
+        <target state="translated">此索引標籤所屬群組的唯一識別碼，常用 (群組) 的值: 常用。</target>
+      </trans-unit>
+      <trans-unit id="dazdata.extension.contributes.dashboard.tab.icon">
+        <source xml:lang="en">(Optional) Icon which is used to represent this tab in the UI. Either a file path or a themeable configuration</source>
+        <target state="translated">(選用) 用於在 UI 中代表此索引標籤的圖示。這會是檔案路徑或可設定佈景主題的組態</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.light">
+        <source xml:lang="en">Icon path when a light theme is used</source>
+        <target state="translated">使用亮色主題時的圖示路徑</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tab.icon.dark">
+        <source xml:lang="en">Icon path when a dark theme is used</source>
+        <target state="translated">使用暗色主題時的圖像路徑</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabs">
+        <source xml:lang="en">Contributes a single or multiple tabs for users to add to their dashboard.</source>
+        <target state="translated">提供一或多個索引標籤，讓使用者可將其增加至儀表板中。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noTitleError">
+        <source xml:lang="en">No title specified for extension.</source>
+        <target state="translated">未為延伸模組指定標題。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noDescriptionWarning">
+        <source xml:lang="en">No description specified to show.</source>
+        <target state="translated">未指定要顯示的描述。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.noContainerError">
+        <source xml:lang="en">No container specified for extension.</source>
+        <target state="translated">未為延伸模組指定任何容器。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTab.contribution.moreThanOneDashboardContainersError">
+        <source xml:lang="en">Exactly 1 dashboard container must be defined per space</source>
+        <target state="translated">每個空間必須明確定義 1 個儀表板容器</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.id">
+        <source xml:lang="en">Unique identifier for this tab group.</source>
+        <target state="translated">此索引標籤群組的唯一識別碼。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboard.tabGroup.title">
+        <source xml:lang="en">Title of the tab group.</source>
+        <target state="translated">索引標籤群組的標題。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.tabGroups">
+        <source xml:lang="en">Contributes a single or multiple tab groups for users to add to their dashboard.</source>
+        <target state="translated">提供一或多個索引標籤群組，讓使用者可將其增加至儀表板中。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noIdError">
+        <source xml:lang="en">No id specified for tab group.</source>
+        <target state="translated">沒有為索引標籤群組指定任何識別碼。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabGroup.contribution.noTitleError">
+        <source xml:lang="en">No title specified for tab group.</source>
+        <target state="translated">沒有為索引標籤群組指定任何標題。</target>
+      </trans-unit>
+      <trans-unit id="administrationTabGroup">
+        <source xml:lang="en">Administration</source>
+        <target state="translated">管理</target>
+      </trans-unit>
+      <trans-unit id="monitoringTabGroup">
+        <source xml:lang="en">Monitoring</source>
+        <target state="translated">監視</target>
+      </trans-unit>
+      <trans-unit id="performanceTabGroup">
+        <source xml:lang="en">Performance</source>
+        <target state="translated">效能</target>
+      </trans-unit>
+      <trans-unit id="securityTabGroup">
+        <source xml:lang="en">Security</source>
+        <target state="translated">安全性</target>
+      </trans-unit>
+      <trans-unit id="troubleshootingTabGroup">
+        <source xml:lang="en">Troubleshooting</source>
+        <target state="translated">疑難排解</target>
+      </trans-unit>
+      <trans-unit id="settingsTabGroup">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">設定</target>
+      </trans-unit>
+      <trans-unit id="databasesTabDescription">
+        <source xml:lang="en">databases tab</source>
+        <target state="translated">資料庫索引標籤</target>
+      </trans-unit>
+      <trans-unit id="databasesTabTitle">
+        <source xml:lang="en">Databases</source>
+        <target state="translated">資料庫</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboard.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="addCodeLabel">
-        <source xml:lang="en">Add code</source>
-        <target state="translated">新增程式碼</target>
+      <trans-unit id="manage">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
       </trans-unit>
-      <trans-unit id="addTextLabel">
-        <source xml:lang="en">Add text</source>
-        <target state="translated">新增文字</target>
+      <trans-unit id="dashboard.editor.label">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">儀表板</target>
       </trans-unit>
-      <trans-unit id="createFile">
-        <source xml:lang="en">Create File</source>
-        <target state="translated">建立檔案</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="ManageAction">
+        <source xml:lang="en">Manage</source>
+        <target state="translated">管理</target>
       </trans-unit>
-      <trans-unit id="displayFailed">
-        <source xml:lang="en">Could not display contents: {0}</source>
-        <target state="translated">無法顯示內容: {0}</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardIconUtil" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="opticon">
+        <source xml:lang="en">property `icon` can be omitted or must be either a string or a literal like `{dark, light}`</source>
+        <target state="translated">屬性 `icon` 可以省略，否則必須為字串或類似 `{dark, light}` 的常值</target>
       </trans-unit>
-      <trans-unit id="codeCellsPreview">
-        <source xml:lang="en">Add cell</source>
-        <target state="translated">新增資料格</target>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/dashboardRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.properties.property">
+        <source xml:lang="en">Defines a property to show on the dashboard</source>
+        <target state="translated">定義顯示於儀表板上的屬性</target>
       </trans-unit>
-      <trans-unit id="codePreview">
-        <source xml:lang="en">Code cell</source>
-        <target state="translated">程式碼資料格</target>
+      <trans-unit id="dashboard.properties.property.displayName">
+        <source xml:lang="en">What value to use as a label for the property</source>
+        <target state="translated">做為屬性標籤的值</target>
       </trans-unit>
-      <trans-unit id="textPreview">
-        <source xml:lang="en">Text cell</source>
-        <target state="translated">文字資料格</target>
+      <trans-unit id="dashboard.properties.property.value">
+        <source xml:lang="en">What value in the object to access for the value</source>
+        <target state="translated">要在物件中存取的值</target>
       </trans-unit>
-      <trans-unit id="runAllPreview">
-        <source xml:lang="en">Run all</source>
-        <target state="translated">全部執行</target>
+      <trans-unit id="dashboard.properties.property.ignore">
+        <source xml:lang="en">Specify values to be ignored</source>
+        <target state="translated">指定要忽略的值</target>
       </trans-unit>
-      <trans-unit id="addCell">
-        <source xml:lang="en">Cell</source>
-        <target state="translated">資料格</target>
+      <trans-unit id="dashboard.properties.property.default">
+        <source xml:lang="en">Default value to show if ignored or no value</source>
+        <target state="translated">如果忽略或沒有值，則顯示預設值</target>
       </trans-unit>
-      <trans-unit id="code">
-        <source xml:lang="en">Code</source>
-        <target state="translated">程式碼</target>
+      <trans-unit id="dashboard.properties.flavor">
+        <source xml:lang="en">A flavor for defining dashboard properties</source>
+        <target state="translated">定義儀表板屬性變體</target>
       </trans-unit>
-      <trans-unit id="text">
-        <source xml:lang="en">Text</source>
-        <target state="translated">文字</target>
+      <trans-unit id="dashboard.properties.flavor.id">
+        <source xml:lang="en">Id of the flavor</source>
+        <target state="translated">類別的變體的識別碼</target>
       </trans-unit>
-      <trans-unit id="runAll">
-        <source xml:lang="en">Run Cells</source>
-        <target state="translated">執行資料格</target>
+      <trans-unit id="dashboard.properties.flavor.condition">
+        <source xml:lang="en">Condition to use this flavor</source>
+        <target state="translated">使用此變體的條件</target>
       </trans-unit>
-      <trans-unit id="previousButtonLabel">
-        <source xml:lang="en">&lt; Previous</source>
-        <target state="translated">&lt; 上一步</target>
+      <trans-unit id="dashboard.properties.flavor.condition.field">
+        <source xml:lang="en">Field to compare to</source>
+        <target state="translated">要比較的欄位</target>
       </trans-unit>
-      <trans-unit id="nextButtonLabel">
-        <source xml:lang="en">Next &gt;</source>
-        <target state="translated">下一步 &gt;</target>
+      <trans-unit id="dashboard.properties.flavor.condition.operator">
+        <source xml:lang="en">Which operator to use for comparison</source>
+        <target state="translated">用於比較的運算子</target>
       </trans-unit>
-      <trans-unit id="cellNotFound">
-        <source xml:lang="en">cell with URI {0} was not found in this model</source>
-        <target state="translated">無法在此模型中找到 URI 為 {0} 的資料格</target>
+      <trans-unit id="dashboard.properties.flavor.condition.value">
+        <source xml:lang="en">Value to compare the field to</source>
+        <target state="translated">用於比較該欄位的值</target>
       </trans-unit>
-      <trans-unit id="cellRunFailed">
-        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
-        <target state="translated">執行資料格失敗 - 如需詳細資訊，請參閱目前所選資料格之輸出中的錯誤。</target>
+      <trans-unit id="dashboard.properties.databaseProperties">
+        <source xml:lang="en">Properties to show for database page</source>
+        <target state="translated">顯示資料庫頁的屬性</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.serverProperties">
+        <source xml:lang="en">Properties to show for server page</source>
+        <target state="translated">顯示伺服器頁的屬性</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.dashboard">
+        <source xml:lang="en">Defines that this provider supports the dashboard</source>
+        <target state="translated">定義此提供者支援儀表板</target>
+      </trans-unit>
+      <trans-unit id="dashboard.id">
+        <source xml:lang="en">Provider id (ex. MSSQL)</source>
+        <target state="translated">提供者識別碼 (例如 MSSQL)</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties">
+        <source xml:lang="en">Property values to show on dashboard</source>
+        <target state="translated">在儀表板上顯示的屬性值</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="azdata.extension.contributes.widget.when">
+        <source xml:lang="en">Condition which must be true to show this item</source>
+        <target state="translated">必須為 True 以顯示此項目的條件</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.widget.hideHeader">
+        <source xml:lang="en">Whether to hide the header of the widget, default value is false</source>
+        <target state="translated">是否要隱藏 Widget 的標題，預設值為 false</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.tabName">
+        <source xml:lang="en">The title of the container</source>
+        <target state="translated">容器的標題</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowNumber">
+        <source xml:lang="en">The row of the component in the grid</source>
+        <target state="translated">方格中元件的資料列</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.rowSpan">
+        <source xml:lang="en">The rowspan of the component in the grid. Default value is 1. Use '*' to set to number of rows in the grid.</source>
+        <target state="translated">方格中元件的 rowspan。預設值為 1。使用 '*' 即可設定方格中的資料列數。</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colNumber">
+        <source xml:lang="en">The column of the component in the grid</source>
+        <target state="translated">方格中元件的資料行</target>
+      </trans-unit>
+      <trans-unit id="dashboardpage.colspan">
+        <source xml:lang="en">The colspan of the component in the grid. Default value is 1. Use '*' to set to number of columns in the grid.</source>
+        <target state="translated">方格內元件的 colspan。預設值為 1。使用 '*' 即可設定方格中的資料行數。</target>
+      </trans-unit>
+      <trans-unit id="azdata.extension.contributes.dashboardPage.tab.id">
+        <source xml:lang="en">Unique identifier for this tab. Will be passed to the extension for any requests.</source>
+        <target state="translated">此索引標籤的唯一識別碼。將傳遞給任何要求的延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="dashboardTabError">
+        <source xml:lang="en">Extension tab is unknown or not installed.</source>
+        <target state="translated">未知的延伸模組索引標籤或未安裝。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="databasePageName">
+        <source xml:lang="en">Database Properties</source>
+        <target state="translated">資料庫屬性</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboardDatabaseProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">啟用或禁用屬性小工具</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">顯示屬性值</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">顯示屬性的名稱</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.value">
+        <source xml:lang="en">Value in the Database Info Object</source>
+        <target state="translated">資料庫資訊物件中的值</target>
+      </trans-unit>
+      <trans-unit id="dashboard.databaseproperties.ignore">
+        <source xml:lang="en">Specify specific values to ignore</source>
+        <target state="translated">指定要忽略的特定值</target>
+      </trans-unit>
+      <trans-unit id="recoveryModel">
+        <source xml:lang="en">Recovery Model</source>
+        <target state="translated">復原模式</target>
+      </trans-unit>
+      <trans-unit id="lastDatabaseBackup">
+        <source xml:lang="en">Last Database Backup</source>
+        <target state="translated">上次資料庫備份</target>
+      </trans-unit>
+      <trans-unit id="lastLogBackup">
+        <source xml:lang="en">Last Log Backup</source>
+        <target state="translated">上次記錄備份</target>
+      </trans-unit>
+      <trans-unit id="compatibilityLevel">
+        <source xml:lang="en">Compatibility Level</source>
+        <target state="translated">相容性層級</target>
+      </trans-unit>
+      <trans-unit id="owner">
+        <source xml:lang="en">Owner</source>
+        <target state="translated">擁有者</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabase">
+        <source xml:lang="en">Customizes the database dashboard page</source>
+        <target state="translated">自訂 "資料庫儀表板" 頁</target>
+      </trans-unit>
+      <trans-unit id="objectsWidgetTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜尋</target>
+      </trans-unit>
+      <trans-unit id="dashboardDatabaseTabs">
+        <source xml:lang="en">Customizes the database dashboard tabs</source>
+        <target state="translated">自訂資料庫儀表板索引標籤</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="serverPageName">
+        <source xml:lang="en">Server Properties</source>
+        <target state="translated">伺服器屬性</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboardServerProperties">
+        <source xml:lang="en">Enable or disable the properties widget</source>
+        <target state="translated">啟用或禁用屬性小工具</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties">
+        <source xml:lang="en">Property values to show</source>
+        <target state="translated">顯示屬性值</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.displayName">
+        <source xml:lang="en">Display name of the property</source>
+        <target state="translated">顯示屬性的名稱</target>
+      </trans-unit>
+      <trans-unit id="dashboard.serverproperties.value">
+        <source xml:lang="en">Value in the Server Info Object</source>
+        <target state="translated">伺服器資訊物件中的值</target>
+      </trans-unit>
+      <trans-unit id="version">
+        <source xml:lang="en">Version</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="edition">
+        <source xml:lang="en">Edition</source>
+        <target state="translated">版本</target>
+      </trans-unit>
+      <trans-unit id="computerName">
+        <source xml:lang="en">Computer Name</source>
+        <target state="translated">電腦名稱</target>
+      </trans-unit>
+      <trans-unit id="osVersion">
+        <source xml:lang="en">OS Version</source>
+        <target state="translated">作業系統版本</target>
+      </trans-unit>
+      <trans-unit id="explorerWidgetsTitle">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜尋</target>
+      </trans-unit>
+      <trans-unit id="dashboardServer">
+        <source xml:lang="en">Customizes the server dashboard page</source>
+        <target state="translated">自訂伺服器儀表板頁面</target>
+      </trans-unit>
+      <trans-unit id="dashboardServerTabs">
+        <source xml:lang="en">Customizes the Server dashboard tabs</source>
+        <target state="translated">自訂伺服器儀表板索引標籤</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/breadcrumb.service" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="homeCrumb">
+        <source xml:lang="en">Home</source>
+        <target state="translated">首頁</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.changeDatabaseFailure">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">變更資料庫失敗</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.explorer.actions">
+        <source xml:lang="en">Show Actions</source>
+        <target state="translated">顯示動作</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchNoMatchResultMessage">
+        <source xml:lang="en">No matching item found</source>
+        <target state="translated">找不到相符的項目</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchSingleMatchResultMessage">
+        <source xml:lang="en">Filtered search list to 1 item</source>
+        <target state="translated">已將搜尋清單篩選為 1 個項目</target>
+      </trans-unit>
+      <trans-unit id="explorerSearchMatchResultMessage">
+        <source xml:lang="en">Filtered search list to {0} items</source>
+        <target state="translated">已將搜尋清單篩選為 {0} 個項目</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dashboard.explorer.namePropertyDisplayValue">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.schemaDisplayValue">
+        <source xml:lang="en">Schema</source>
+        <target state="translated">結構描述</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectTypeDisplayValue">
+        <source xml:lang="en">Type</source>
+        <target state="translated">類型</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="loadingObjects">
+        <source xml:lang="en">loading objects</source>
+        <target state="translated">正在載入物件</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabases">
+        <source xml:lang="en">loading databases</source>
+        <target state="translated">正在載入資料庫</target>
+      </trans-unit>
+      <trans-unit id="loadingObjectsCompleted">
+        <source xml:lang="en">loading objects completed.</source>
+        <target state="translated">已完成載入物件。</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabasesCompleted">
+        <source xml:lang="en">loading databases completed.</source>
+        <target state="translated">已完成載入資料庫。</target>
+      </trans-unit>
+      <trans-unit id="seachObjects">
+        <source xml:lang="en">Search by name of type (t:, v:, f:, or sp:)</source>
+        <target state="translated">依類型名稱搜尋 (t:、v:、f: 或 sp:)</target>
+      </trans-unit>
+      <trans-unit id="searchDatabases">
+        <source xml:lang="en">Search databases</source>
+        <target state="translated">搜尋資料庫</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.objectError">
+        <source xml:lang="en">Unable to load objects</source>
+        <target state="translated">無法載入物件</target>
+      </trans-unit>
+      <trans-unit id="dashboard.explorer.databaseError">
+        <source xml:lang="en">Unable to load databases</source>
+        <target state="translated">無法載入資料庫</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="insights.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">執行查詢</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="insightsWidgetLoadingMessage">
+        <source xml:lang="en">Loading {0}</source>
+        <target state="translated">正在載入 {0}</target>
+      </trans-unit>
+      <trans-unit id="insightsWidgetLoadingCompletedMessage">
+        <source xml:lang="en">Loading {0} completed</source>
+        <target state="translated">已完成載入 {0}</target>
+      </trans-unit>
+      <trans-unit id="insights.autoRefreshOffState">
+        <source xml:lang="en">Auto Refresh: OFF</source>
+        <target state="translated">自動重新整理: 關閉</target>
+      </trans-unit>
+      <trans-unit id="insights.lastUpdated">
+        <source xml:lang="en">Last Updated: {0} {1}</source>
+        <target state="translated">最近更新: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="noResults">
+        <source xml:lang="en">No results to show</source>
+        <target state="translated">沒有可顯示的結果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidgetSchemas" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="insightWidgetDescription">
+        <source xml:lang="en">Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more</source>
+        <target state="translated">新增一個可查詢伺服器或資料庫並以多種方式呈現結果的小工具，如圖表、計數總結等。</target>
+      </trans-unit>
+      <trans-unit id="insightIdDescription">
+        <source xml:lang="en">Unique Identifier used for caching the results of the insight.</source>
+        <target state="translated">用於快取見解結果的唯一識別碼。</target>
+      </trans-unit>
+      <trans-unit id="insightQueryDescription">
+        <source xml:lang="en">SQL query to run. This should return exactly 1 resultset.</source>
+        <target state="translated">要執行的 SQL 查詢。這僅會回傳 1 個結果集。</target>
+      </trans-unit>
+      <trans-unit id="insightQueryFileDescription">
+        <source xml:lang="en">[Optional] path to a file that contains a query. Use if 'query' is not set</source>
+        <target state="translated">[選用] 包含查詢之檔案的路徑。這會在未設定 'query' 時使用</target>
+      </trans-unit>
+      <trans-unit id="insightAutoRefreshIntervalDescription">
+        <source xml:lang="en">[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh</source>
+        <target state="translated">[選用] 自動重新整理間隔 (分鐘)，如未設定，就不會自動重新整理</target>
+      </trans-unit>
+      <trans-unit id="actionTypes">
+        <source xml:lang="en">Which actions to use</source>
+        <target state="translated">要使用的動作</target>
+      </trans-unit>
+      <trans-unit id="actionDatabaseDescription">
+        <source xml:lang="en">Target database for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">此動作的目標資料庫；可使用格式 '${ columnName }'，以使用資料驅動的資料行名稱。</target>
+      </trans-unit>
+      <trans-unit id="actionServerDescription">
+        <source xml:lang="en">Target server for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">此動作的目標伺服器；可使用格式 '${ columnName }'，以使用資料驅動的資料列名稱。</target>
+      </trans-unit>
+      <trans-unit id="actionUserDescription">
+        <source xml:lang="en">Target user for the action; can use the format '${ columnName }' to use a data driven column name.</source>
+        <target state="translated">請指定執行此動作的使用者；可使用格式 '${ columnName }'，以使用資料驅動的資料行名稱。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insightType.id">
+        <source xml:lang="en">Identifier of the insight</source>
+        <target state="translated">見解識別碼</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.insights">
+        <source xml:lang="en">Contributes insights to the dashboard palette.</source>
+        <target state="translated">在儀表板選擇區提供見解。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="chartErrorMessage">
+        <source xml:lang="en">Chart cannot be displayed with the given data</source>
+        <target state="translated">無法以指定的資料顯示圖表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="chartInsightDescription">
+        <source xml:lang="en">Displays results of a query as a chart on the dashboard</source>
+        <target state="translated">將查詢結果以圖表方式顯示在儀表板上</target>
+      </trans-unit>
+      <trans-unit id="colorMapDescription">
+        <source xml:lang="en">Maps 'column name' -&gt; color. for example add 'column1': red to ensure this column uses a red color </source>
+        <target state="translated">對應 'column name' -&gt; 色彩。例如，新增 'column1': red 可確保資料行使用紅色</target>
+      </trans-unit>
+      <trans-unit id="legendDescription">
+        <source xml:lang="en">Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry</source>
+        <target state="translated">指定圖表圖例的優先位置和可見度。這些是您查詢中的欄位名稱，並對應到每個圖表項目的標籤</target>
+      </trans-unit>
+      <trans-unit id="labelFirstColumnDescription">
+        <source xml:lang="en">If dataDirection is horizontal, setting this to true uses the first columns value for the legend.</source>
+        <target state="translated">若 dataDirection 是水平的，設定為 True 時則使用第一個欄位值為其圖例。</target>
+      </trans-unit>
+      <trans-unit id="columnsAsLabels">
+        <source xml:lang="en">If dataDirection is vertical, setting this to true will use the columns names for the legend.</source>
+        <target state="translated">若 dataDirection 是垂直的，設定為 True 時則使用欄位名稱為其圖例。</target>
+      </trans-unit>
+      <trans-unit id="dataDirectionDescription">
+        <source xml:lang="en">Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.</source>
+        <target state="translated">定義是否從行 (垂直) 或列 (水平) 讀取資料。對於時間序列，當呈現方向為垂直時會被忽略。</target>
+      </trans-unit>
+      <trans-unit id="showTopNData">
+        <source xml:lang="en">If showTopNData is set, showing only top N data in the chart.</source>
+        <target state="translated">如已設定 showTopNData，則僅顯示圖表中的前 N 個資料。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/barChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="yAxisMin">
+        <source xml:lang="en">Minimum value of the y axis</source>
+        <target state="translated">y 軸的最小值</target>
+      </trans-unit>
+      <trans-unit id="yAxisMax">
+        <source xml:lang="en">Maximum value of the y axis</source>
+        <target state="translated">y 軸的最大值</target>
+      </trans-unit>
+      <trans-unit id="barchart.yAxisLabel">
+        <source xml:lang="en">Label for the y axis</source>
+        <target state="translated">Y 軸的標籤</target>
+      </trans-unit>
+      <trans-unit id="xAxisMin">
+        <source xml:lang="en">Minimum value of the x axis</source>
+        <target state="translated">X 軸的最小值</target>
+      </trans-unit>
+      <trans-unit id="xAxisMax">
+        <source xml:lang="en">Maximum value of the x axis</source>
+        <target state="translated">X 軸的最大值</target>
+      </trans-unit>
+      <trans-unit id="barchart.xAxisLabel">
+        <source xml:lang="en">Label for the x axis</source>
+        <target state="translated">X 軸標籤</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dataTypeDescription">
+        <source xml:lang="en">Indicates data property of a data set for a chart.</source>
+        <target state="translated">指定圖表資料集的資料屬性。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/countInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="countInsightDescription">
+        <source xml:lang="en">For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1</source>
+        <target state="translated">為結果集中的每一個資料行，在資料列 0 中先顯示計數值，再顯示資料行名稱。例如，支援 '1 Healthy'，'3 Unhealthy'；其中 'Healthy' 為資料行名稱，1 為資料列 1 中資料格 1 的值</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/imageInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="imageInsightDescription">
+        <source xml:lang="en">Displays an image, for example one returned by an R query using ggplot2</source>
+        <target state="translated">顯示映像，如使用 ggplot2 R 查詢返回的映像。</target>
+      </trans-unit>
+      <trans-unit id="imageFormatDescription">
+        <source xml:lang="en">What format is expected - is this a JPEG, PNG or other format?</source>
+        <target state="translated">預期格式是什麼 - 是 JPEG、PNG 或其他格式?</target>
+      </trans-unit>
+      <trans-unit id="encodingDescription">
+        <source xml:lang="en">Is this encoded as hex, base64 or some other format?</source>
+        <target state="translated">此編碼為十六進位、base64 或是其他格式?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/insights/views/tableInsight.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="tableInsightDescription">
+        <source xml:lang="en">Displays the results in a simple table</source>
+        <target state="translated">在簡單資料表中顯示結果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="loadingProperties">
+        <source xml:lang="en">Loading properties</source>
+        <target state="translated">正在載入屬性</target>
+      </trans-unit>
+      <trans-unit id="loadingPropertiesCompleted">
+        <source xml:lang="en">Loading properties completed</source>
+        <target state="translated">已完成載入屬性</target>
+      </trans-unit>
+      <trans-unit id="dashboard.properties.error">
+        <source xml:lang="en">Unable to load dashboard properties</source>
+        <target state="translated">無法載入儀表板屬性</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="databaseConnections">
+        <source xml:lang="en">Database Connections</source>
+        <target state="translated">資料庫連線</target>
+      </trans-unit>
+      <trans-unit id="datasource.connections">
+        <source xml:lang="en">data source connections</source>
+        <target state="translated">資料來源連線</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionGroups">
+        <source xml:lang="en">data source groups</source>
+        <target state="translated">資料來源群組</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.dateAdded">
+        <source xml:lang="en">Saved connections are sorted by the dates they were added.</source>
+        <target state="translated">儲存的連線依新增的日期排序。</target>
+      </trans-unit>
+      <trans-unit id="connectionsSortOrder.displayName">
+        <source xml:lang="en">Saved connections are sorted by their display names alphabetically.</source>
+        <target state="translated">儲存的連線依其顯示名稱以字母順序排序。</target>
+      </trans-unit>
+      <trans-unit id="datasource.connectionsSortOrder">
+        <source xml:lang="en">Controls sorting order of saved connections and connection groups.</source>
+        <target state="translated">控制儲存連線和連線群組的排列順序。</target>
+      </trans-unit>
+      <trans-unit id="startupConfig">
+        <source xml:lang="en">Startup Configuration</source>
+        <target state="translated">啟動組態</target>
+      </trans-unit>
+      <trans-unit id="startup.alwaysShowServersView">
+        <source xml:lang="en">True for the Servers view to be shown on launch of Azure Data Studio default; false if the last opened view should be shown</source>
+        <target state="translated">預設為在 Azure Data Studio 啟動時要顯示的伺服器檢視即為 True；如應顯示上次開啟的檢視則為 False</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="vscode.extension.contributes.view.id">
+        <source xml:lang="en">Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.</source>
+        <target state="translated">檢視的識別碼。請使用此識別碼透過 `vscode.window.registerTreeDataProviderForView` API 登錄資料提供者。並藉由將 `onView:${id}` 事件登錄至 `activationEvents` 以觸發啟用您的延伸模組。</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">使用人性化顯示名稱。會顯示</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.view.when">
+        <source xml:lang="en">Condition which must be true to show this view</source>
+        <target state="translated">必須為 True 以顯示此檢視的條件</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.dataExplorer">
+        <source xml:lang="en">Contributes views to the editor</source>
+        <target state="translated">提供檢視給編輯者</target>
+      </trans-unit>
+      <trans-unit id="extension.dataExplorer">
+        <source xml:lang="en">Contributes views to Data Explorer container in the Activity bar</source>
+        <target state="translated">將檢視提供到活動列中的資料總管容器</target>
+      </trans-unit>
+      <trans-unit id="dataExplorer.contributed">
+        <source xml:lang="en">Contributes views to contributed views container</source>
+        <target state="translated">在參與檢視容器中提供檢視</target>
+      </trans-unit>
+      <trans-unit id="duplicateView1">
+        <source xml:lang="en">Cannot register multiple views with same id `{0}` in the view container `{1}`</source>
+        <target state="translated">無法在檢視容器 '{1}' 中以同一個識別碼 '{0}' 註冊多個檢視</target>
+      </trans-unit>
+      <trans-unit id="duplicateView2">
+        <source xml:lang="en">A view with id `{0}` is already registered in the view container `{1}`</source>
+        <target state="translated">已在檢視容器 '{1}' 中註冊識別碼為 '{0}' 的檢視</target>
+      </trans-unit>
+      <trans-unit id="requirearray">
+        <source xml:lang="en">views must be an array</source>
+        <target state="translated">項目必須為陣列</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">屬性 '{0}' 為強制項目且必須屬於 `string` 類型</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">屬性 `{0}` 可以省略或必須屬於 `string` 類型</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dataExplorer.servers">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">伺服器</target>
+      </trans-unit>
+      <trans-unit id="dataexplorer.name">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">連線</target>
+      </trans-unit>
+      <trans-unit id="showDataExplorer">
+        <source xml:lang="en">Show Connections</source>
+        <target state="translated">顯示連線</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/dataExplorer/browser/nodeActions.common.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">中斷連線</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">重新整理</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editData.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="showEditDataSqlPaneOnStartup">
+        <source xml:lang="en">Show Edit Data SQL pane on startup</source>
+        <target state="translated">啟動時顯示 [編輯資料] SQL 窗格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="editData.run">
+        <source xml:lang="en">Run</source>
+        <target state="translated">執行</target>
+      </trans-unit>
+      <trans-unit id="disposeEditFailure">
+        <source xml:lang="en">Dispose Edit Failed With Error: </source>
+        <target state="translated">處理編輯失敗，出現錯誤:</target>
+      </trans-unit>
+      <trans-unit id="editData.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="editData.showSql">
+        <source xml:lang="en">Show SQL Pane</source>
+        <target state="translated">顯示 SQL 窗格</target>
+      </trans-unit>
+      <trans-unit id="editData.closeSql">
+        <source xml:lang="en">Close SQL Pane</source>
+        <target state="translated">關閉 SQL 窗格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="maxRowTaskbar">
+        <source xml:lang="en">Max Rows:</source>
+        <target state="translated">最大資料列數:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/editDataGridActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="deleteRow">
+        <source xml:lang="en">Delete Row</source>
+        <target state="translated">刪除資料列</target>
+      </trans-unit>
+      <trans-unit id="revertRow">
+        <source xml:lang="en">Revert Current Row</source>
+        <target state="translated">還原目前的資料列</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/editData/browser/gridActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">另存為 CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">另存為 JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">另存為 Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">另存為 XML</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">複製</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">隨標題一併複製</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">全選</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="tabs">
+        <source xml:lang="en">Dashboard Tabs ({0})</source>
+        <target state="translated">儀表板索引標籤 ({0})</target>
+      </trans-unit>
+      <trans-unit id="tabId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">識別碼</target>
+      </trans-unit>
+      <trans-unit id="tabTitle">
+        <source xml:lang="en">Title</source>
+        <target state="translated">標題</target>
+      </trans-unit>
+      <trans-unit id="tabDescription">
+        <source xml:lang="en">Description</source>
+        <target state="translated">描述</target>
+      </trans-unit>
+      <trans-unit id="insights">
+        <source xml:lang="en">Dashboard Insights ({0})</source>
+        <target state="translated">儀表板見解 ({0})</target>
+      </trans-unit>
+      <trans-unit id="insightId">
+        <source xml:lang="en">Id</source>
+        <target state="translated">識別碼</target>
+      </trans-unit>
+      <trans-unit id="name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
+      </trans-unit>
+      <trans-unit id="insight condition">
+        <source xml:lang="en">When</source>
+        <target state="translated">時間</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensions.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.description">
+        <source xml:lang="en">Gets extension information from the gallery</source>
+        <target state="translated">從資源庫取得延伸模組資訊</target>
+      </trans-unit>
+      <trans-unit id="workbench.extensions.getExtensionFromGallery.arg.name">
+        <source xml:lang="en">Extension id</source>
+        <target state="translated">延伸模組識別碼</target>
+      </trans-unit>
+      <trans-unit id="notFound">
+        <source xml:lang="en">Extension '{0}' not found.</source>
+        <target state="translated">找不到延伸模組 '{0}'。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/extensionsActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">顯示建議</target>
+      </trans-unit>
+      <trans-unit id="Install Extensions">
+        <source xml:lang="en">Install Extensions</source>
+        <target state="translated">安裝延伸模組</target>
+      </trans-unit>
+      <trans-unit id="openExtensionAuthoringDocs">
+        <source xml:lang="en">Author an Extension...</source>
+        <target state="translated">撰寫延伸模組...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/scenarioRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="neverShowAgain">
+        <source xml:lang="en">Don't Show Again</source>
+        <target state="translated">不要再顯示</target>
+      </trans-unit>
+      <trans-unit id="ExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations.</source>
+        <target state="translated">Azure Data Studio 有延伸模組建議。</target>
+      </trans-unit>
+      <trans-unit id="VisualizerExtensionsRecommended">
+        <source xml:lang="en">Azure Data Studio has extension recommendations for data visualization.
+Once installed, you can select the Visualizer icon to visualize your query results.</source>
+        <target state="translated">Azure Data Studio 有資料視覺效果的延伸模組建議。
+安裝之後，即可選取視覺化檢視圖示，將查詢結果視覺化。</target>
+      </trans-unit>
+      <trans-unit id="installAll">
+        <source xml:lang="en">Install All</source>
+        <target state="translated">全部安裝</target>
+      </trans-unit>
+      <trans-unit id="showRecommendations">
+        <source xml:lang="en">Show Recommendations</source>
+        <target state="translated">顯示建議</target>
+      </trans-unit>
+      <trans-unit id="scenarioTypeUndefined">
+        <source xml:lang="en">The scenario type for extension recommendations must be provided.</source>
+        <target state="translated">必須提供延伸模組建議的案例類型。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/extensions/browser/staticRecommendations" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="defaultRecommendations">
+        <source xml:lang="en">This extension is recommended by Azure Data Studio.</source>
+        <target state="translated">Azure Data Studio 建議使用此延伸模組。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/agentView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="jobview.Jobs">
+        <source xml:lang="en">Jobs</source>
+        <target state="translated">作業</target>
+      </trans-unit>
+      <trans-unit id="jobview.Notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">Notebooks</target>
+      </trans-unit>
+      <trans-unit id="jobview.Alerts">
+        <source xml:lang="en">Alerts</source>
+        <target state="translated">警示</target>
+      </trans-unit>
+      <trans-unit id="jobview.Proxies">
+        <source xml:lang="en">Proxies</source>
+        <target state="translated">Proxy</target>
+      </trans-unit>
+      <trans-unit id="jobview.Operators">
+        <source xml:lang="en">Operators</source>
+        <target state="translated">運算子</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/jobManagement/browser/alertsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="jobAlertColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.lastOccurrenceDate">
+        <source xml:lang="en">Last Occurrence</source>
+        <target state="translated">上次發生</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">啟用</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.delayBetweenResponses">
+        <source xml:lang="en">Delay Between Responses (in secs)</source>
+        <target state="translated">回應之間的延遲 (秒)</target>
+      </trans-unit>
+      <trans-unit id="jobAlertColumns.categoryName">
+        <source xml:lang="en">Category Name</source>
+        <target state="translated">類別名稱</target>
       </trans-unit>
     </body>
   </file>
@@ -6906,257 +3319,187 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/assessment/browser/asmtActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="asmtaction.server.getitems">
-        <source xml:lang="en">View applicable rules</source>
-        <target state="translated">檢視適用的規則</target>
+      <trans-unit id="stepRow.stepID">
+        <source xml:lang="en">Step ID</source>
+        <target state="translated">步驟識別碼</target>
       </trans-unit>
-      <trans-unit id="asmtaction.database.getitems">
-        <source xml:lang="en">View applicable rules for {0}</source>
-        <target state="translated">檢視適用於 {0} 的規則</target>
+      <trans-unit id="stepRow.stepName">
+        <source xml:lang="en">Step Name</source>
+        <target state="translated">步驟名稱</target>
       </trans-unit>
-      <trans-unit id="asmtaction.server.invokeitems">
-        <source xml:lang="en">Invoke Assessment</source>
-        <target state="translated">叫用評定</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.database.invokeitems">
-        <source xml:lang="en">Invoke Assessment for {0}</source>
-        <target state="translated">為 {0} 叫用評定</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.exportasscript">
-        <source xml:lang="en">Export As Script</source>
-        <target state="translated">匯出為指令碼</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.showsamples">
-        <source xml:lang="en">View all rules and learn more on GitHub</source>
-        <target state="translated">檢視所有規則，並前往 GitHub 深入了解</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.generatehtmlreport">
-        <source xml:lang="en">Create HTML Report</source>
-        <target state="translated">建立 HTML 報表</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.openReport">
-        <source xml:lang="en">Report has been saved. Do you want to open it?</source>
-        <target state="translated">已儲存報表。要開啟嗎?</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.open">
-        <source xml:lang="en">Open</source>
-        <target state="translated">開啟</target>
-      </trans-unit>
-      <trans-unit id="asmtaction.label.cancel">
-        <source xml:lang="en">Cancel</source>
-        <target state="translated">取消</target>
+      <trans-unit id="stepRow.message">
+        <source xml:lang="en">Message</source>
+        <target state="translated">訊息</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="data">
-        <source xml:lang="en">Data</source>
-        <target state="translated">資料</target>
-      </trans-unit>
-      <trans-unit id="connection">
-        <source xml:lang="en">Connection</source>
-        <target state="translated">連線</target>
-      </trans-unit>
-      <trans-unit id="queryEditor">
-        <source xml:lang="en">Query Editor</source>
-        <target state="translated">查詢編輯器</target>
-      </trans-unit>
-      <trans-unit id="notebook">
-        <source xml:lang="en">Notebook</source>
-        <target state="translated">Notebook</target>
-      </trans-unit>
-      <trans-unit id="dashboard">
-        <source xml:lang="en">Dashboard</source>
-        <target state="translated">儀表板</target>
-      </trans-unit>
-      <trans-unit id="profiler">
-        <source xml:lang="en">Profiler</source>
-        <target state="translated">分析工具</target>
+      <trans-unit id="agent.steps">
+        <source xml:lang="en">Steps</source>
+        <target state="translated">步驟</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/extensions/browser/contributionRenders" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/jobsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="tabs">
-        <source xml:lang="en">Dashboard Tabs ({0})</source>
-        <target state="translated">儀表板索引標籤 ({0})</target>
-      </trans-unit>
-      <trans-unit id="tabId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">識別碼</target>
-      </trans-unit>
-      <trans-unit id="tabTitle">
-        <source xml:lang="en">Title</source>
-        <target state="translated">標題</target>
-      </trans-unit>
-      <trans-unit id="tabDescription">
-        <source xml:lang="en">Description</source>
-        <target state="translated">描述</target>
-      </trans-unit>
-      <trans-unit id="insights">
-        <source xml:lang="en">Dashboard Insights ({0})</source>
-        <target state="translated">儀表板見解 ({0})</target>
-      </trans-unit>
-      <trans-unit id="insightId">
-        <source xml:lang="en">Id</source>
-        <target state="translated">識別碼</target>
-      </trans-unit>
-      <trans-unit id="name">
+      <trans-unit id="jobColumns.name">
         <source xml:lang="en">Name</source>
         <target state="translated">名稱</target>
       </trans-unit>
-      <trans-unit id="insight condition">
-        <source xml:lang="en">When</source>
-        <target state="translated">時間</target>
+      <trans-unit id="jobColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">上次執行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">下次執行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">啟用</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">狀態</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.category">
+        <source xml:lang="en">Category</source>
+        <target state="translated">分類</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.runnable">
+        <source xml:lang="en">Runnable</source>
+        <target state="translated">可執行</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.schedule">
+        <source xml:lang="en">Schedule</source>
+        <target state="translated">排程</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">上次執行結果</target>
+      </trans-unit>
+      <trans-unit id="jobColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">先前的執行內容</target>
+      </trans-unit>
+      <trans-unit id="jobsView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">沒有任何此作業可用的步驟。</target>
+      </trans-unit>
+      <trans-unit id="jobsView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">錯誤:</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/imageInsight" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="invalidImage">
-        <source xml:lang="en">Table does not contain a valid image</source>
-        <target state="translated">資料表不含有效的映像</target>
+      <trans-unit id="notebookHistory.dateCreatedTooltip">
+        <source xml:lang="en">Date Created: </source>
+        <target state="translated">建立日期:</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.notebookErrorTooltip">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Notebook 錯誤:</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.ErrorTooltip">
+        <source xml:lang="en">Job Error: </source>
+        <target state="translated">作業錯誤:</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pinnedTitle">
+        <source xml:lang="en">Pinned</source>
+        <target state="translated">已釘選</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.recentRunsTitle">
+        <source xml:lang="en">Recent Runs</source>
+        <target state="translated">最近的執行</target>
+      </trans-unit>
+      <trans-unit id="notebookHistory.pastRunsTitle">
+        <source xml:lang="en">Past Runs</source>
+        <target state="translated">過去的執行</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/notebooksView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="moreActionsLabel">
-        <source xml:lang="en">More</source>
-        <target state="translated">更多</target>
+      <trans-unit id="notebookColumns.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
       </trans-unit>
-      <trans-unit id="editLabel">
-        <source xml:lang="en">Edit</source>
-        <target state="translated">編輯</target>
+      <trans-unit id="notebookColumns.targetDatbase">
+        <source xml:lang="en">Target Database</source>
+        <target state="translated">目標資料庫</target>
       </trans-unit>
-      <trans-unit id="closeLabel">
-        <source xml:lang="en">Close</source>
-        <target state="translated">關閉</target>
+      <trans-unit id="notebookColumns.lastRun">
+        <source xml:lang="en">Last Run</source>
+        <target state="translated">上次執行</target>
       </trans-unit>
-      <trans-unit id="convertCell">
-        <source xml:lang="en">Convert Cell</source>
-        <target state="translated">轉換資料格</target>
+      <trans-unit id="notebookColumns.nextRun">
+        <source xml:lang="en">Next Run</source>
+        <target state="translated">下次執行</target>
       </trans-unit>
-      <trans-unit id="runAllAbove">
-        <source xml:lang="en">Run Cells Above</source>
-        <target state="translated">執行上方的資料格</target>
+      <trans-unit id="notebookColumns.status">
+        <source xml:lang="en">Status</source>
+        <target state="translated">狀態</target>
       </trans-unit>
-      <trans-unit id="runAllBelow">
-        <source xml:lang="en">Run Cells Below</source>
-        <target state="translated">執行下方的資料格</target>
+      <trans-unit id="notebookColumns.lastRunOutcome">
+        <source xml:lang="en">Last Run Outcome</source>
+        <target state="translated">上次執行結果</target>
       </trans-unit>
-      <trans-unit id="codeAbove">
-        <source xml:lang="en">Insert Code Above</source>
-        <target state="translated">在上方插入程式碼</target>
+      <trans-unit id="notebookColumns.previousRuns">
+        <source xml:lang="en">Previous Runs</source>
+        <target state="translated">先前的執行內容</target>
       </trans-unit>
-      <trans-unit id="codeBelow">
-        <source xml:lang="en">Insert Code Below</source>
-        <target state="translated">在下方插入程式碼</target>
+      <trans-unit id="notebooksView.noSteps">
+        <source xml:lang="en">No Steps available for this job.</source>
+        <target state="translated">沒有任何此作業可用的步驟。</target>
       </trans-unit>
-      <trans-unit id="markdownAbove">
-        <source xml:lang="en">Insert Text Above</source>
-        <target state="translated">在上方插入文字</target>
+      <trans-unit id="notebooksView.error">
+        <source xml:lang="en">Error: </source>
+        <target state="translated">錯誤:</target>
       </trans-unit>
-      <trans-unit id="markdownBelow">
-        <source xml:lang="en">Insert Text Below</source>
-        <target state="translated">在下方插入文字</target>
-      </trans-unit>
-      <trans-unit id="collapseCell">
-        <source xml:lang="en">Collapse Cell</source>
-        <target state="translated">摺疊資料格</target>
-      </trans-unit>
-      <trans-unit id="expandCell">
-        <source xml:lang="en">Expand Cell</source>
-        <target state="translated">展開資料格</target>
-      </trans-unit>
-      <trans-unit id="makeParameterCell">
-        <source xml:lang="en">Make parameter cell</source>
-        <target state="translated">製作參數資料格</target>
-      </trans-unit>
-      <trans-unit id="RemoveParameterCell">
-        <source xml:lang="en">Remove parameter cell</source>
-        <target state="translated">移除參數資料格</target>
-      </trans-unit>
-      <trans-unit id="clear">
-        <source xml:lang="en">Clear Result</source>
-        <target state="translated">清除結果</target>
+      <trans-unit id="notebooksView.notebookError">
+        <source xml:lang="en">Notebook Error: </source>
+        <target state="translated">Notebook 錯誤:</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/operatorsView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="clientSession.unknownError">
-        <source xml:lang="en">An error occurred while starting the notebook session</source>
-        <target state="translated">啟動筆記本工作階段時發生錯誤</target>
+      <trans-unit id="jobOperatorsView.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
       </trans-unit>
-      <trans-unit id="ServerNotStarted">
-        <source xml:lang="en">Server did not start for unknown reason</source>
-        <target state="translated">伺服器因為不明原因而未啟動</target>
+      <trans-unit id="jobOperatorsView.emailAddress">
+        <source xml:lang="en">Email Address</source>
+        <target state="translated">電子郵件地址</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
-        <target state="translated">找不到核心 {0}。會改用預設核心。</target>
+      <trans-unit id="jobOperatorsView.enabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">啟用</target>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/contrib/charts/browser/graphInsight" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/contrib/jobManagement/browser/proxiesView.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="series">
-        <source xml:lang="en">Series {0}</source>
-        <target state="translated">系列 {0}</target>
+      <trans-unit id="jobProxiesView.accountName">
+        <source xml:lang="en">Account Name</source>
+        <target state="translated">帳戶名稱</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/contrib/charts/browser/configureChartDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="configureChartDialog.close">
-        <source xml:lang="en">Close</source>
-        <target state="translated">關閉</target>
+      <trans-unit id="jobProxiesView.credentialName">
+        <source xml:lang="en">Credential Name</source>
+        <target state="translated">認證名稱</target>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="zh-Hant">
-    <body>
-      <trans-unit id="injectedParametersMsg">
-        <source xml:lang="en"># Injected-Parameters
-</source>
-        <target state="translated"># 個插入的參數
-</target>
+      <trans-unit id="jobProxiesView.description">
+        <source xml:lang="en">Description</source>
+        <target state="translated">描述</target>
       </trans-unit>
-      <trans-unit id="kernelRequiresConnection">
-        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
-        <target state="translated">請選取要為此核心執行資料格的連線</target>
-      </trans-unit>
-      <trans-unit id="deleteCellFailed">
-        <source xml:lang="en">Failed to delete cell.</source>
-        <target state="translated">無法刪除資料格。</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailedRetry">
-        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
-        <target state="translated">無法變更核心。將會使用核心 {0}。錯誤為: {1}</target>
-      </trans-unit>
-      <trans-unit id="changeKernelFailed">
-        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
-        <target state="translated">因為錯誤所以無法變更核心: {0}</target>
-      </trans-unit>
-      <trans-unit id="changeContextFailed">
-        <source xml:lang="en">Changing context failed: {0}</source>
-        <target state="translated">無法變更內容: {0}</target>
-      </trans-unit>
-      <trans-unit id="startSessionFailed">
-        <source xml:lang="en">Could not start session: {0}</source>
-        <target state="translated">無法啟動工作階段: {0}</target>
-      </trans-unit>
-      <trans-unit id="shutdownClientSessionError">
-        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
-        <target state="translated">關閉筆記本時發生用戶端工作階段錯誤: {0}</target>
-      </trans-unit>
-      <trans-unit id="ProviderNoManager">
-        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
-        <target state="translated">找不到提供者 {0} 的筆記本管理員</target>
+      <trans-unit id="jobProxiesView.isEnabled">
+        <source xml:lang="en">Enabled</source>
+        <target state="translated">啟用</target>
       </trans-unit>
     </body>
   </file>
@@ -7228,6 +3571,3317 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellToolbarActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="moreActionsLabel">
+        <source xml:lang="en">More</source>
+        <target state="translated">更多</target>
+      </trans-unit>
+      <trans-unit id="editLabel">
+        <source xml:lang="en">Edit</source>
+        <target state="translated">編輯</target>
+      </trans-unit>
+      <trans-unit id="closeLabel">
+        <source xml:lang="en">Close</source>
+        <target state="translated">關閉</target>
+      </trans-unit>
+      <trans-unit id="convertCell">
+        <source xml:lang="en">Convert Cell</source>
+        <target state="translated">轉換資料格</target>
+      </trans-unit>
+      <trans-unit id="runAllAbove">
+        <source xml:lang="en">Run Cells Above</source>
+        <target state="translated">執行上方的資料格</target>
+      </trans-unit>
+      <trans-unit id="runAllBelow">
+        <source xml:lang="en">Run Cells Below</source>
+        <target state="translated">執行下方的資料格</target>
+      </trans-unit>
+      <trans-unit id="codeAbove">
+        <source xml:lang="en">Insert Code Above</source>
+        <target state="translated">在上方插入程式碼</target>
+      </trans-unit>
+      <trans-unit id="codeBelow">
+        <source xml:lang="en">Insert Code Below</source>
+        <target state="translated">在下方插入程式碼</target>
+      </trans-unit>
+      <trans-unit id="markdownAbove">
+        <source xml:lang="en">Insert Text Above</source>
+        <target state="translated">在上方插入文字</target>
+      </trans-unit>
+      <trans-unit id="markdownBelow">
+        <source xml:lang="en">Insert Text Below</source>
+        <target state="translated">在下方插入文字</target>
+      </trans-unit>
+      <trans-unit id="collapseCell">
+        <source xml:lang="en">Collapse Cell</source>
+        <target state="translated">摺疊資料格</target>
+      </trans-unit>
+      <trans-unit id="expandCell">
+        <source xml:lang="en">Expand Cell</source>
+        <target state="translated">展開資料格</target>
+      </trans-unit>
+      <trans-unit id="makeParameterCell">
+        <source xml:lang="en">Make parameter cell</source>
+        <target state="translated">製作參數資料格</target>
+      </trans-unit>
+      <trans-unit id="RemoveParameterCell">
+        <source xml:lang="en">Remove parameter cell</source>
+        <target state="translated">移除參數資料格</target>
+      </trans-unit>
+      <trans-unit id="clear">
+        <source xml:lang="en">Clear Result</source>
+        <target state="translated">清除結果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="buttonAdd">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">新增資料格</target>
+      </trans-unit>
+      <trans-unit id="optionCodeCell">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">程式碼資料格</target>
+      </trans-unit>
+      <trans-unit id="optionTextCell">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">文字資料格</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveDown">
+        <source xml:lang="en">Move cell down</source>
+        <target state="translated">下移資料格</target>
+      </trans-unit>
+      <trans-unit id="buttonMoveUp">
+        <source xml:lang="en">Move cell up</source>
+        <target state="translated">上移資料格</target>
+      </trans-unit>
+      <trans-unit id="buttonDelete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">刪除</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">新增資料格</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">程式碼資料格</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">文字資料格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/code.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="parametersText">
+        <source xml:lang="en">Parameters</source>
+        <target state="translated">參數</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/codeActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebook.failed">
+        <source xml:lang="en">Please select active cell and try again</source>
+        <target state="translated">請選取作用資料格並再試一次</target>
+      </trans-unit>
+      <trans-unit id="runCell">
+        <source xml:lang="en">Run cell</source>
+        <target state="translated">執行資料格</target>
+      </trans-unit>
+      <trans-unit id="stopCell">
+        <source xml:lang="en">Cancel execution</source>
+        <target state="translated">取消執行</target>
+      </trans-unit>
+      <trans-unit id="errorRunCell">
+        <source xml:lang="en">Error on last run. Click to run again</source>
+        <target state="translated">上一個執行發生錯誤。按一下即可重新執行</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="expandCellContents">
+        <source xml:lang="en">Expand code cell contents</source>
+        <target state="translated">展開程式碼資料格內容</target>
+      </trans-unit>
+      <trans-unit id="collapseCellContents">
+        <source xml:lang="en">Collapse code cell contents</source>
+        <target state="translated">摺疊程式碼資料格內容</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="buttonBold">
+        <source xml:lang="en">Bold</source>
+        <target state="translated">粗體</target>
+      </trans-unit>
+      <trans-unit id="buttonItalic">
+        <source xml:lang="en">Italic</source>
+        <target state="translated">斜體</target>
+      </trans-unit>
+      <trans-unit id="buttonUnderline">
+        <source xml:lang="en">Underline</source>
+        <target state="translated">底線</target>
+      </trans-unit>
+      <trans-unit id="buttonHighlight">
+        <source xml:lang="en">Highlight</source>
+        <target state="translated">醒目提示</target>
+      </trans-unit>
+      <trans-unit id="buttonCode">
+        <source xml:lang="en">Code</source>
+        <target state="translated">程式碼</target>
+      </trans-unit>
+      <trans-unit id="buttonLink">
+        <source xml:lang="en">Link</source>
+        <target state="translated">連結</target>
+      </trans-unit>
+      <trans-unit id="buttonList">
+        <source xml:lang="en">List</source>
+        <target state="translated">清單</target>
+      </trans-unit>
+      <trans-unit id="buttonOrderedList">
+        <source xml:lang="en">Ordered list</source>
+        <target state="translated">排序清單</target>
+      </trans-unit>
+      <trans-unit id="buttonImage">
+        <source xml:lang="en">Image</source>
+        <target state="translated">影像</target>
+      </trans-unit>
+      <trans-unit id="buttonPreview">
+        <source xml:lang="en">Markdown preview toggle - off</source>
+        <target state="translated">Markdown 預覽切換 - 關閉</target>
+      </trans-unit>
+      <trans-unit id="dropdownHeading">
+        <source xml:lang="en">Heading</source>
+        <target state="translated">標題</target>
+      </trans-unit>
+      <trans-unit id="optionHeading1">
+        <source xml:lang="en">Heading 1</source>
+        <target state="translated">標題 1</target>
+      </trans-unit>
+      <trans-unit id="optionHeading2">
+        <source xml:lang="en">Heading 2</source>
+        <target state="translated">標題 2</target>
+      </trans-unit>
+      <trans-unit id="optionHeading3">
+        <source xml:lang="en">Heading 3</source>
+        <target state="translated">標題 3</target>
+      </trans-unit>
+      <trans-unit id="optionParagraph">
+        <source xml:lang="en">Paragraph</source>
+        <target state="translated">段落</target>
+      </trans-unit>
+      <trans-unit id="callout.insertLinkHeading">
+        <source xml:lang="en">Insert link</source>
+        <target state="translated">插入連結</target>
+      </trans-unit>
+      <trans-unit id="callout.insertImageHeading">
+        <source xml:lang="en">Insert image</source>
+        <target state="translated">插入影像</target>
+      </trans-unit>
+      <trans-unit id="richTextViewButton">
+        <source xml:lang="en">Rich Text View</source>
+        <target state="translated">RTF 檢視</target>
+      </trans-unit>
+      <trans-unit id="splitViewButton">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">分割檢視</target>
+      </trans-unit>
+      <trans-unit id="markdownViewButton">
+        <source xml:lang="en">Markdown View</source>
+        <target state="translated">Markdown 檢視</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/output.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="noMimeTypeFound">
+        <source xml:lang="en">No {0}renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">找不到輸出的 {0} 轉譯器。其有下列 MIME 類型: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">safe </source>
+        <target state="translated">安全</target>
+      </trans-unit>
+      <trans-unit id="noSelectorFound">
+        <source xml:lang="en">No component could be found for selector {0}</source>
+        <target state="translated">找不到選取器 {0} 的元件</target>
+      </trans-unit>
+      <trans-unit id="componentRenderError">
+        <source xml:lang="en">Error rendering component: {0}</source>
+        <target state="translated">轉譯元件時發生錯誤: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="clickOn">
+        <source xml:lang="en">Click on</source>
+        <target state="translated">按一下</target>
+      </trans-unit>
+      <trans-unit id="plusCode">
+        <source xml:lang="en">+ Code</source>
+        <target state="translated">+ 程式碼</target>
+      </trans-unit>
+      <trans-unit id="or">
+        <source xml:lang="en">or</source>
+        <target state="translated">或</target>
+      </trans-unit>
+      <trans-unit id="plusText">
+        <source xml:lang="en">+ Text</source>
+        <target state="translated">+ 文字</target>
+      </trans-unit>
+      <trans-unit id="toAddCell">
+        <source xml:lang="en">to add a code or text cell</source>
+        <target state="translated">新增程式碼或文字資料格</target>
+      </trans-unit>
+      <trans-unit id="plusCodeAriaLabel">
+        <source xml:lang="en">Add a code cell</source>
+        <target state="translated">新增程式碼儲存格</target>
+      </trans-unit>
+      <trans-unit id="plusTextAriaLabel">
+        <source xml:lang="en">Add a text cell</source>
+        <target state="translated">新增文字儲存格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/stdin.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="stdInLabel">
+        <source xml:lang="en">StdIn:</source>
+        <target state="translated">Stdin: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="doubleClickEdit">
+        <source xml:lang="en">&lt;i&gt;Double-click to edit&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;按兩下即可編輯&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="addContent">
+        <source xml:lang="en">&lt;i&gt;Add content here...&lt;/i&gt;</source>
+        <target state="translated">&lt;i&gt;在這裡新增內容...&lt;/i&gt;</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">尋找</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">尋找</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">上一個相符</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">下一個相符</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">關閉</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">您的搜尋傳回了大量結果，只會將前 999 個相符項目醒目提示。</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{0}/{1} 個</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">沒有任何結果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="addCodeLabel">
+        <source xml:lang="en">Add code</source>
+        <target state="translated">新增程式碼</target>
+      </trans-unit>
+      <trans-unit id="addTextLabel">
+        <source xml:lang="en">Add text</source>
+        <target state="translated">新增文字</target>
+      </trans-unit>
+      <trans-unit id="createFile">
+        <source xml:lang="en">Create File</source>
+        <target state="translated">建立檔案</target>
+      </trans-unit>
+      <trans-unit id="displayFailed">
+        <source xml:lang="en">Could not display contents: {0}</source>
+        <target state="translated">無法顯示內容: {0}</target>
+      </trans-unit>
+      <trans-unit id="codeCellsPreview">
+        <source xml:lang="en">Add cell</source>
+        <target state="translated">新增資料格</target>
+      </trans-unit>
+      <trans-unit id="codePreview">
+        <source xml:lang="en">Code cell</source>
+        <target state="translated">程式碼資料格</target>
+      </trans-unit>
+      <trans-unit id="textPreview">
+        <source xml:lang="en">Text cell</source>
+        <target state="translated">文字資料格</target>
+      </trans-unit>
+      <trans-unit id="runAllPreview">
+        <source xml:lang="en">Run all</source>
+        <target state="translated">全部執行</target>
+      </trans-unit>
+      <trans-unit id="addCell">
+        <source xml:lang="en">Cell</source>
+        <target state="translated">資料格</target>
+      </trans-unit>
+      <trans-unit id="code">
+        <source xml:lang="en">Code</source>
+        <target state="translated">程式碼</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">文字</target>
+      </trans-unit>
+      <trans-unit id="runAll">
+        <source xml:lang="en">Run Cells</source>
+        <target state="translated">執行資料格</target>
+      </trans-unit>
+      <trans-unit id="previousButtonLabel">
+        <source xml:lang="en">&lt; Previous</source>
+        <target state="translated">&lt; 上一步</target>
+      </trans-unit>
+      <trans-unit id="nextButtonLabel">
+        <source xml:lang="en">Next &gt;</source>
+        <target state="translated">下一步 &gt;</target>
+      </trans-unit>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">無法在此模型中找到 URI 為 {0} 的資料格</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">執行資料格失敗 - 如需詳細資訊，請參閱目前所選資料格之輸出中的錯誤。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebook.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="newNotebook">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新增 Notebook</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新增 Notebook</target>
+      </trans-unit>
+      <trans-unit id="workbench.action.setWorkspaceAndOpen">
+        <source xml:lang="en">Set Workspace And Open</source>
+        <target state="translated">設定工作區並開啟</target>
+      </trans-unit>
+      <trans-unit id="notebook.sqlStopOnError">
+        <source xml:lang="en">SQL kernel: stop Notebook execution when error occurs in a cell.</source>
+        <target state="translated">SQL 核心: 當資料格發生錯誤時，停止執行 Notebook。</target>
+      </trans-unit>
+      <trans-unit id="notebook.showAllKernels">
+        <source xml:lang="en">(Preview) show all kernels for the current notebook provider.</source>
+        <target state="translated">(預覽) 顯示目前筆記本提供者的所有核心。</target>
+      </trans-unit>
+      <trans-unit id="notebook.allowADSCommands">
+        <source xml:lang="en">Allow notebooks to run Azure Data Studio commands.</source>
+        <target state="translated">允許筆記本執行 Azure Data Studio 命令。</target>
+      </trans-unit>
+      <trans-unit id="notebook.enableDoubleClickEdit">
+        <source xml:lang="en">Enable double click to edit for text cells in notebooks</source>
+        <target state="translated">為筆記本中的文字資料格啟用按兩下編輯的功能</target>
+      </trans-unit>
+      <trans-unit id="notebook.richTextModeDescription">
+        <source xml:lang="en">Text is displayed as Rich Text (also known as WYSIWYG).</source>
+        <target state="translated">文字顯示為 RTF 文字 (也稱為 WYSIWYG)。</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewModeDescription">
+        <source xml:lang="en">Markdown is displayed on the left, with a preview of the rendered text on the right.</source>
+        <target state="translated">Markdown 會在左側顯示，並在右側呈現文字預覽。</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownModeDescription">
+        <source xml:lang="en">Text is displayed as Markdown.</source>
+        <target state="translated">文字顯示為 Markdown。</target>
+      </trans-unit>
+      <trans-unit id="notebook.defaultTextEditMode">
+        <source xml:lang="en">The default editing mode used for text cells</source>
+        <target state="translated">用於文字儲存格的預設編輯模式</target>
+      </trans-unit>
+      <trans-unit id="notebook.saveConnectionName">
+        <source xml:lang="en">(Preview) Save connection name in notebook metadata.</source>
+        <target state="translated">(預覽) 儲存筆記本中繼資料中的連線名稱。</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownPreviewLineHeight">
+        <source xml:lang="en">Controls the line height used in the notebook markdown preview. This number is relative to the font size.</source>
+        <target state="translated">控制筆記本 Markdown 預覽中使用的行高。此數字相對於字型大小。</target>
+      </trans-unit>
+      <trans-unit id="notebook.showRenderedNotebookinDiffEditor">
+        <source xml:lang="en">(Preview) Show rendered notebook in diff editor.</source>
+        <target state="translated">(預覽) 在 Diff 編輯器中顯示轉譯的筆記本。</target>
+      </trans-unit>
+      <trans-unit id="notebook.maxRichTextUndoHistory">
+        <source xml:lang="en">The maximum number of changes stored in the undo history for the notebook Rich Text editor.</source>
+        <target state="translated">筆記本 RTF 文字編輯器復原歷程記錄中儲存的變更數目上限。</target>
+      </trans-unit>
+      <trans-unit id="searchConfigurationTitle">
+        <source xml:lang="en">Search Notebooks</source>
+        <target state="translated">搜尋筆記本</target>
+      </trans-unit>
+      <trans-unit id="exclude">
+        <source xml:lang="en">Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).</source>
+        <target state="translated">設定 Glob 模式，在全文檢索搜尋中排除檔案與資料夾，並快速開啟。繼承 `#files.exclude#` 設定的所有 Glob 模式。深入了解 Glob 模式 [這裡](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)。</target>
+      </trans-unit>
+      <trans-unit id="exclude.boolean">
+        <source xml:lang="en">The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.</source>
+        <target state="translated">要符合檔案路徑的 Glob 模式。設為 True 或 False 可啟用或停用模式。</target>
+      </trans-unit>
+      <trans-unit id="exclude.when">
+        <source xml:lang="en">Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.</source>
+        <target state="translated">在相符檔案同層級上額外的檢查。請使用 $(basename) 作為相符檔案名稱的變數。</target>
+      </trans-unit>
+      <trans-unit id="useRipgrep">
+        <source xml:lang="en">This setting is deprecated and now falls back on "search.usePCRE2".</source>
+        <target state="translated"> 此設定已淘汰，現在會回復至 "search.usePCRE2"。</target>
+      </trans-unit>
+      <trans-unit id="useRipgrepDeprecated">
+        <source xml:lang="en">Deprecated. Consider "search.usePCRE2" for advanced regex feature support.</source>
+        <target state="translated">已淘汰。請考慮使用 "search.usePCRE2" 來取得進階 regex 功能支援。</target>
+      </trans-unit>
+      <trans-unit id="search.maintainFileSearchCache">
+        <source xml:lang="en">When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.</source>
+        <target state="translated">若啟用，searchService 程序在處於非使用狀態一小時後會保持運作，而不是關閉。這會將檔案搜尋快取保留在記憶體中。</target>
+      </trans-unit>
+      <trans-unit id="useIgnoreFiles">
+        <source xml:lang="en">Controls whether to use `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">控制是否在搜尋檔案時使用 `.gitignore` 和 `.ignore` 檔案。</target>
+      </trans-unit>
+      <trans-unit id="useGlobalIgnoreFiles">
+        <source xml:lang="en">Controls whether to use global `.gitignore` and `.ignore` files when searching for files.</source>
+        <target state="translated">控制是否要在搜尋檔案時使用全域 `.gitignore` 和 `.ignore` 檔案。</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeSymbols">
+        <source xml:lang="en">Whether to include results from a global symbol search in the file results for Quick Open.</source>
+        <target state="translated">是否在 Quick Open 的檔案結果中，包含全域符號搜尋中的結果。</target>
+      </trans-unit>
+      <trans-unit id="search.quickOpen.includeHistory">
+        <source xml:lang="en">Whether to include results from recently opened files in the file results for Quick Open.</source>
+        <target state="translated">是否要在 Quick Open 中包含檔案結果中，來自最近開啟檔案的結果。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.default">
+        <source xml:lang="en">History entries are sorted by relevance based on the filter value used. More relevant entries appear first.</source>
+        <target state="translated">歷程記錄項目會依據所使用的篩選值，依相關性排序。相關性愈高的項目排在愈前面。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder.recency">
+        <source xml:lang="en">History entries are sorted by recency. More recently opened entries appear first.</source>
+        <target state="translated">依使用時序排序歷程記錄項目。最近開啟的項目顯示在最前面。</target>
+      </trans-unit>
+      <trans-unit id="filterSortOrder">
+        <source xml:lang="en">Controls sorting order of editor history in quick open when filtering.</source>
+        <target state="translated">控制篩選時，快速開啟的編輯器歷程記錄排列順序。</target>
+      </trans-unit>
+      <trans-unit id="search.followSymlinks">
+        <source xml:lang="en">Controls whether to follow symlinks while searching.</source>
+        <target state="translated">控制是否要在搜尋時遵循 symlink。</target>
+      </trans-unit>
+      <trans-unit id="search.smartCase">
+        <source xml:lang="en">Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.</source>
+        <target state="translated">若模式為全小寫，搜尋時不會區分大小寫; 否則會區分大小寫。</target>
+      </trans-unit>
+      <trans-unit id="search.globalFindClipboard">
+        <source xml:lang="en">Controls whether the search view should read or modify the shared find clipboard on macOS.</source>
+        <target state="translated">控制搜尋檢視應讀取或修改 macOS 上的共用尋找剪貼簿。 </target>
+      </trans-unit>
+      <trans-unit id="search.location">
+        <source xml:lang="en">Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.</source>
+        <target state="translated">控制搜尋要顯示為資訊看板中的檢視，或顯示為面板區域中的面板以增加水平空間。</target>
+      </trans-unit>
+      <trans-unit id="search.location.deprecationMessage">
+        <source xml:lang="en">This setting is deprecated. Please use the search view's context menu instead.</source>
+        <target state="translated">這個設定已淘汰。請改用搜尋檢視的操作功能表。</target>
+      </trans-unit>
+      <trans-unit id="search.collapseResults.auto">
+        <source xml:lang="en">Files with less than 10 results are expanded. Others are collapsed.</source>
+        <target state="translated">10 個結果以下的檔案將會展開，其他檔案則會摺疊。</target>
+      </trans-unit>
+      <trans-unit id="search.collapseAllResults">
+        <source xml:lang="en">Controls whether the search results will be collapsed or expanded.</source>
+        <target state="translated">控制要摺疊或展開搜尋結果。</target>
+      </trans-unit>
+      <trans-unit id="search.useReplacePreview">
+        <source xml:lang="en">Controls whether to open Replace Preview when selecting or replacing a match.</source>
+        <target state="translated">控制是否要在選取或取代相符項目時開啟 [取代預覽]。</target>
+      </trans-unit>
+      <trans-unit id="search.showLineNumbers">
+        <source xml:lang="en">Controls whether to show line numbers for search results.</source>
+        <target state="translated">控制是否要為搜尋結果顯示行號。</target>
+      </trans-unit>
+      <trans-unit id="search.usePCRE2">
+        <source xml:lang="en">Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.</source>
+        <target state="translated">是否要在文字搜尋中使用 PCRE2 規則運算式引擎。這可使用部分進階功能，如 lookahead 和 backreferences。但是，並不支援所有 PCRE2 功能，僅支援 JavaScript 也支援的功能。</target>
+      </trans-unit>
+      <trans-unit id="usePCRE2Deprecated">
+        <source xml:lang="en">Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.</source>
+        <target state="translated">已淘汰。當使用僅有 PCRE2 支援的 regex 功能時，會自動使用 PCRE 2。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionAuto">
+        <source xml:lang="en">Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.</source>
+        <target state="translated">當搜尋檢視較窄時，將動作列放在右邊，當搜尋檢視較寬時，立即放於內容之後。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPositionRight">
+        <source xml:lang="en">Always position the actionbar to the right.</source>
+        <target state="translated">永遠將動作列放在右邊。</target>
+      </trans-unit>
+      <trans-unit id="search.actionsPosition">
+        <source xml:lang="en">Controls the positioning of the actionbar on rows in the search view.</source>
+        <target state="translated">控制動作列在搜尋檢視列上的位置。</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnType">
+        <source xml:lang="en">Search all files as you type.</source>
+        <target state="translated">鍵入的同時搜尋所有檔案。</target>
+      </trans-unit>
+      <trans-unit id="search.seedWithNearestWord">
+        <source xml:lang="en">Enable seeding search from the word nearest the cursor when the active editor has no selection.</source>
+        <target state="translated">允許在使用中的編輯器沒有選取項目時，從最接近游標的文字植入搜尋。</target>
+      </trans-unit>
+      <trans-unit id="search.seedOnFocus">
+        <source xml:lang="en">Update workspace search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.</source>
+        <target state="translated">聚焦在搜尋檢視時，將工作區搜尋查詢更新為編輯器的選取文字。按一下或觸發 'workbench.views.search.focus' 命令時，即會發生此動作。</target>
+      </trans-unit>
+      <trans-unit id="search.searchOnTypeDebouncePeriod">
+        <source xml:lang="en">When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.</source>
+        <target state="translated">啟用 `#search.searchOnType#` 時，控制字元鍵入和搜尋開始之間的逾時 (毫秒)。當 `search.searchOnType` 停用時無效。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.selectWord">
+        <source xml:lang="en">Double clicking selects the word under the cursor.</source>
+        <target state="translated">點兩下選擇游標下的單字。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.goToLocation">
+        <source xml:lang="en">Double clicking opens the result in the active editor group.</source>
+        <target state="translated">按兩下將會在正在使用的編輯器群組中開啟結果。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour.openLocationToSide">
+        <source xml:lang="en">Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.</source>
+        <target state="translated">按兩下就會在側邊的編輯器群組中開啟結果，如果不存在就會建立一個。</target>
+      </trans-unit>
+      <trans-unit id="search.searchEditor.doubleClickBehaviour">
+        <source xml:lang="en">Configure effect of double clicking a result in a search editor.</source>
+        <target state="translated">設定在搜尋編輯器中按兩下結果的效果。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.default">
+        <source xml:lang="en">Results are sorted by folder and file names, in alphabetical order.</source>
+        <target state="translated">結果會根據資料夾和檔案名稱排序，按字母順序排列。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.filesOnly">
+        <source xml:lang="en">Results are sorted by file names ignoring folder order, in alphabetical order.</source>
+        <target state="translated">結果會忽略資料夾順序並根據檔案名稱排序，按字母順序排列。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.type">
+        <source xml:lang="en">Results are sorted by file extensions, in alphabetical order.</source>
+        <target state="translated">結果會根據副檔名排序，按字母順序排列。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.modified">
+        <source xml:lang="en">Results are sorted by file last modified date, in descending order.</source>
+        <target state="translated">結果會根據最後修改日期降冪排序。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countDescending">
+        <source xml:lang="en">Results are sorted by count per file, in descending order.</source>
+        <target state="translated">結果會根據每個檔案的計數降冪排序。</target>
+      </trans-unit>
+      <trans-unit id="searchSortOrder.countAscending">
+        <source xml:lang="en">Results are sorted by count per file, in ascending order.</source>
+        <target state="translated">結果會根據每個檔案的計數升冪排序。</target>
+      </trans-unit>
+      <trans-unit id="search.sortOrder">
+        <source xml:lang="en">Controls sorting order of search results.</source>
+        <target state="translated">控制搜尋結果的排列順序。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading kernels...</source>
+        <target state="translated">正在載入核心...</target>
+      </trans-unit>
+      <trans-unit id="changing">
+        <source xml:lang="en">Changing kernel...</source>
+        <target state="translated">正在變更核心...</target>
+      </trans-unit>
+      <trans-unit id="AttachTo">
+        <source xml:lang="en">Attach to </source>
+        <target state="translated">連結至 </target>
+      </trans-unit>
+      <trans-unit id="Kernel">
+        <source xml:lang="en">Kernel </source>
+        <target state="translated">核心 </target>
+      </trans-unit>
+      <trans-unit id="loadingContexts">
+        <source xml:lang="en">Loading contexts...</source>
+        <target state="translated">正在載入內容...</target>
+      </trans-unit>
+      <trans-unit id="changeConnection">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">變更連線</target>
+      </trans-unit>
+      <trans-unit id="selectConnection">
+        <source xml:lang="en">Select Connection</source>
+        <target state="translated">選取連線</target>
+      </trans-unit>
+      <trans-unit id="localhost">
+        <source xml:lang="en">localhost</source>
+        <target state="translated">localhost</target>
+      </trans-unit>
+      <trans-unit id="noKernel">
+        <source xml:lang="en">No Kernel</source>
+        <target state="translated">沒有核心</target>
+      </trans-unit>
+      <trans-unit id="kernelNotSupported">
+        <source xml:lang="en">This notebook cannot run with parameters as the kernel is not supported. Please use the supported kernels and format. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">由於不支援核心程序，因此此筆記本無法以參數執行。請使用支援的核心程序和格式。[深入了解] (https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="noParametersCell">
+        <source xml:lang="en">This notebook cannot run with parameters until a parameter cell is added. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">在新增參數儲存格之前，此筆記本無法以參數執行。[深入了解](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="noParametersInCell">
+        <source xml:lang="en">This notebook cannot run with parameters until there are parameters added to the parameter cell. [Learn more](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization).</source>
+        <target state="translated">在參數新增至參數儲存格之前，此筆記本無法以參數執行。[深入了解](https://docs.microsoft.com/sql/azure-data-studio/notebooks/notebooks-parameterization)。</target>
+      </trans-unit>
+      <trans-unit id="clearResults">
+        <source xml:lang="en">Clear Results</source>
+        <target state="translated">清除結果</target>
+      </trans-unit>
+      <trans-unit id="trustLabel">
+        <source xml:lang="en">Trusted</source>
+        <target state="translated">受信任</target>
+      </trans-unit>
+      <trans-unit id="untrustLabel">
+        <source xml:lang="en">Not Trusted</source>
+        <target state="translated">不受信任</target>
+      </trans-unit>
+      <trans-unit id="collapseAllCells">
+        <source xml:lang="en">Collapse Cells</source>
+        <target state="translated">摺疊資料格</target>
+      </trans-unit>
+      <trans-unit id="expandAllCells">
+        <source xml:lang="en">Expand Cells</source>
+        <target state="translated">展開資料格</target>
+      </trans-unit>
+      <trans-unit id="runParameters">
+        <source xml:lang="en">Run with Parameters</source>
+        <target state="translated">執行 (設有參數)</target>
+      </trans-unit>
+      <trans-unit id="noContextAvailable">
+        <source xml:lang="en">None</source>
+        <target state="translated">無</target>
+      </trans-unit>
+      <trans-unit id="newNotebookAction">
+        <source xml:lang="en">New Notebook</source>
+        <target state="translated">新增 Notebook</target>
+      </trans-unit>
+      <trans-unit id="notebook.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">尋找下一個字串</target>
+      </trans-unit>
+      <trans-unit id="notebook.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">尋找前一個字串</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebookEditor.name">
+        <source xml:lang="en">Notebook Editor</source>
+        <target state="new">Notebook Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebookExplorer.searchResults">
+        <source xml:lang="en">Search Results</source>
+        <target state="translated">搜尋結果</target>
+      </trans-unit>
+      <trans-unit id="searchPathNotFoundError">
+        <source xml:lang="en">Search path not found: {0}</source>
+        <target state="translated">找不到搜尋路徑: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebookExplorer.name">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">筆記本</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="searchWithoutFolder">
+        <source xml:lang="en">You have not opened any folder that contains notebooks/books. </source>
+        <target state="translated">您尚未開啟任何包含筆記本/書籍的資料夾。</target>
+      </trans-unit>
+      <trans-unit id="openNotebookFolder">
+        <source xml:lang="en">Open Notebooks</source>
+        <target state="translated">開啟筆記本</target>
+      </trans-unit>
+      <trans-unit id="searchMaxResultsWarning">
+        <source xml:lang="en">The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.</source>
+        <target state="translated">結果集只包含所有符合項的子集。請提供更具體的搜尋條件以縮小結果範圍。</target>
+      </trans-unit>
+      <trans-unit id="searchInProgress">
+        <source xml:lang="en">Search in progress... - </source>
+        <target state="translated">正在搜尋... - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludesExcludes">
+        <source xml:lang="en">No results found in '{0}' excluding '{1}' - </source>
+        <target state="translated">在 '{0}' 中找不到排除 '{1}' 的結果 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsIncludes">
+        <source xml:lang="en">No results found in '{0}' - </source>
+        <target state="translated">在 '{0}' 中找不到結果 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsExcludes">
+        <source xml:lang="en">No results found excluding '{0}' - </source>
+        <target state="translated">找不到排除 '{0}' 的結果 - </target>
+      </trans-unit>
+      <trans-unit id="noResultsFound">
+        <source xml:lang="en">No results found. Review your settings for configured exclusions and check your gitignore files - </source>
+        <target state="translated">找不到任何結果。請檢閱您所設定排除的設定，並檢查您的 gitignore 檔案 -</target>
+      </trans-unit>
+      <trans-unit id="rerunSearch.message">
+        <source xml:lang="en">Search again</source>
+        <target state="translated">再次搜尋</target>
+      </trans-unit>
+      <trans-unit id="rerunSearchInAll.message">
+        <source xml:lang="en">Search again in all files</source>
+        <target state="translated">在所有檔案中再次搜尋</target>
+      </trans-unit>
+      <trans-unit id="openSettings.message">
+        <source xml:lang="en">Open Settings</source>
+        <target state="translated">開啟設定</target>
+      </trans-unit>
+      <trans-unit id="ariaSearchResultsStatus">
+        <source xml:lang="en">Search returned {0} results in {1} files</source>
+        <target state="translated">搜尋傳回 {1} 個檔案中的 {0} 個結果</target>
+      </trans-unit>
+      <trans-unit id="ToggleCollapseAndExpandAction.label">
+        <source xml:lang="en">Toggle Collapse and Expand</source>
+        <target state="translated">切換折疊和展開</target>
+      </trans-unit>
+      <trans-unit id="CancelSearchAction.label">
+        <source xml:lang="en">Cancel Search</source>
+        <target state="translated">取消搜尋</target>
+      </trans-unit>
+      <trans-unit id="ExpandAllAction.label">
+        <source xml:lang="en">Expand All</source>
+        <target state="translated">全部展開</target>
+      </trans-unit>
+      <trans-unit id="CollapseDeepestExpandedLevelAction.label">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">全部摺疊</target>
+      </trans-unit>
+      <trans-unit id="ClearSearchResultsAction.label">
+        <source xml:lang="en">Clear Search Results</source>
+        <target state="translated">清除搜尋結果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearchWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="label.Search">
+        <source xml:lang="en">Search: Type Search Term and press Enter to search or Escape to cancel</source>
+        <target state="translated">搜尋: 輸入搜尋字詞，然後按 Enter 鍵搜尋或按 Esc 鍵取消</target>
+      </trans-unit>
+      <trans-unit id="search.placeHolder">
+        <source xml:lang="en">Search</source>
+        <target state="translated">搜尋</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViews.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="cellNotFound">
+        <source xml:lang="en">cell with URI {0} was not found in this model</source>
+        <target state="translated">無法在此模型中找到 URI 為 {0} 的資料格</target>
+      </trans-unit>
+      <trans-unit id="cellRunFailed">
+        <source xml:lang="en">Run Cells failed - See error in output of the currently selected cell for more information.</source>
+        <target state="translated">執行資料格失敗 - 如需詳細資訊，請參閱目前所選資料格之輸出中的錯誤。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsCodeCell.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="viewsCodeCell.emptyCellText">
+        <source xml:lang="en">Please run this cell to view outputs.</source>
+        <target state="translated">請執行此儲存格以檢視輸出。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/notebookViews/notebookViewsGrid.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="emptyText">
+        <source xml:lang="en">This view is empty. Add a cell to this view by clicking the Insert Cells button.</source>
+        <target state="translated">此檢視為空白。請按一下 [插入儲存格] 按鈕，將儲存格新增至此檢視。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">複製失敗。錯誤: {0}</target>
+      </trans-unit>
+      <trans-unit id="notebook.showChart">
+        <source xml:lang="en">Show chart</source>
+        <target state="translated">顯示圖表</target>
+      </trans-unit>
+      <trans-unit id="notebook.showTable">
+        <source xml:lang="en">Show table</source>
+        <target state="translated">顯示資料表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/mimeRenderer.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="noRendererFound">
+        <source xml:lang="en">No {0} renderer could be found for output. It has the following MIME types: {1}</source>
+        <target state="translated">找不到輸出的 {0} 轉譯器。其有下列 MIME 類型: {1}</target>
+      </trans-unit>
+      <trans-unit id="safe">
+        <source xml:lang="en">(safe) </source>
+        <target state="translated">(安全)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="plotlyError">
+        <source xml:lang="en">Error displaying Plotly graph: {0}</source>
+        <target state="translated">顯示 Plotly 圖表時發生錯誤: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/browser/serverTreeView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="servers.noConnections">
+        <source xml:lang="en">No connections found.</source>
+        <target state="translated">找不到連線。</target>
+      </trans-unit>
+      <trans-unit id="serverTree.addConnection">
+        <source xml:lang="en">Add Connection</source>
+        <target state="translated">新增連線</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/objectExplorer/common/serverGroup.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="serverGroup.colors">
+        <source xml:lang="en">Server Group color palette used in the Object Explorer viewlet.</source>
+        <target state="translated">在物件總管 Viewlet 中使用的伺服器群組調色盤。</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.autoExpand">
+        <source xml:lang="en">Auto-expand Server Groups in the Object Explorer viewlet.</source>
+        <target state="translated">物件總管 Viewlet 中的自動展開伺服器群組。</target>
+      </trans-unit>
+      <trans-unit id="serverTree.useAsyncServerTree">
+        <source xml:lang="en">(Preview) Use the new async server tree for the Servers view and Connection Dialog with support for new features such as dynamic node filtering.</source>
+        <target state="translated">(預覽) 針對伺服器檢視及連線對話方塊使用新的非同步伺服器樹狀結構，並支援動態節點篩選等新功能。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="data">
+        <source xml:lang="en">Data</source>
+        <target state="translated">資料</target>
+      </trans-unit>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">連線</target>
+      </trans-unit>
+      <trans-unit id="queryEditor">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">查詢編輯器</target>
+      </trans-unit>
+      <trans-unit id="notebook">
+        <source xml:lang="en">Notebook</source>
+        <target state="translated">Notebook</target>
+      </trans-unit>
+      <trans-unit id="dashboard">
+        <source xml:lang="en">Dashboard</source>
+        <target state="translated">儀表板</target>
+      </trans-unit>
+      <trans-unit id="profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">分析工具</target>
+      </trans-unit>
+      <trans-unit id="builtinCharts">
+        <source xml:lang="en">Built-in Charts</source>
+        <target state="translated">內建圖表</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profiler.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="profiler.settings.viewTemplates">
+        <source xml:lang="en">Specifies view templates</source>
+        <target state="translated">指定檢視範本</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.sessionTemplates">
+        <source xml:lang="en">Specifies session templates</source>
+        <target state="translated">指定工作階段範本</target>
+      </trans-unit>
+      <trans-unit id="profiler.settings.Filters">
+        <source xml:lang="en">Profiler Filters</source>
+        <target state="translated">分析工具篩選條件</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="profilerAction.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">連線</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.disconnect">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">中斷連線</target>
+      </trans-unit>
+      <trans-unit id="start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">開始</target>
+      </trans-unit>
+      <trans-unit id="create">
+        <source xml:lang="en">New Session</source>
+        <target state="translated">新增工作階段</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.pauseCapture">
+        <source xml:lang="en">Pause</source>
+        <target state="translated">暫停</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.resumeCapture">
+        <source xml:lang="en">Resume</source>
+        <target state="translated">繼續</target>
+      </trans-unit>
+      <trans-unit id="profilerStop.stop">
+        <source xml:lang="en">Stop</source>
+        <target state="translated">停止</target>
+      </trans-unit>
+      <trans-unit id="profiler.clear">
+        <source xml:lang="en">Clear Data</source>
+        <target state="translated">清除資料</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearDataPrompt">
+        <source xml:lang="en">Are you sure you want to clear the data?</source>
+        <target state="translated">確定要清除資料嗎?</target>
+      </trans-unit>
+      <trans-unit id="profiler.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="profiler.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOn">
+        <source xml:lang="en">Auto Scroll: On</source>
+        <target state="translated">自動捲動: 開啟</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.autoscrollOff">
+        <source xml:lang="en">Auto Scroll: Off</source>
+        <target state="translated">自動捲動: 關閉</target>
+      </trans-unit>
+      <trans-unit id="profiler.toggleCollapsePanel">
+        <source xml:lang="en">Toggle Collapsed Panel</source>
+        <target state="translated">切換折疊面板</target>
+      </trans-unit>
+      <trans-unit id="profiler.editColumns">
+        <source xml:lang="en">Edit Columns</source>
+        <target state="translated">編輯資料行</target>
+      </trans-unit>
+      <trans-unit id="profiler.findNext">
+        <source xml:lang="en">Find Next String</source>
+        <target state="translated">尋找下一個字串</target>
+      </trans-unit>
+      <trans-unit id="profiler.findPrevious">
+        <source xml:lang="en">Find Previous String</source>
+        <target state="translated">尋找前一個字串</target>
+      </trans-unit>
+      <trans-unit id="profilerAction.newProfiler">
+        <source xml:lang="en">Launch Profiler</source>
+        <target state="translated">啟動分析工具</target>
+      </trans-unit>
+      <trans-unit id="profiler.filter">
+        <source xml:lang="en">Filter…</source>
+        <target state="translated">篩選...</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilter">
+        <source xml:lang="en">Clear Filter</source>
+        <target state="translated">清除篩選</target>
+      </trans-unit>
+      <trans-unit id="profiler.clearFilterPrompt">
+        <source xml:lang="en">Are you sure you want to clear the filters?</source>
+        <target state="translated">確定要清除篩選嗎?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="profiler.viewSelectAccessibleName">
+        <source xml:lang="en">Select View</source>
+        <target state="translated">選取檢視</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectAccessibleName">
+        <source xml:lang="en">Select Session</source>
+        <target state="translated">選取工作階段</target>
+      </trans-unit>
+      <trans-unit id="profiler.sessionSelectLabel">
+        <source xml:lang="en">Select Session:</source>
+        <target state="translated">選取工作階段:</target>
+      </trans-unit>
+      <trans-unit id="profiler.viewSelectLabel">
+        <source xml:lang="en">Select View:</source>
+        <target state="translated">選取檢視:</target>
+      </trans-unit>
+      <trans-unit id="text">
+        <source xml:lang="en">Text</source>
+        <target state="translated">文字</target>
+      </trans-unit>
+      <trans-unit id="label">
+        <source xml:lang="en">Label</source>
+        <target state="translated">標籤</target>
+      </trans-unit>
+      <trans-unit id="profilerEditor.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">詳細資料</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerFindWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="label.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">尋找</target>
+      </trans-unit>
+      <trans-unit id="placeholder.find">
+        <source xml:lang="en">Find</source>
+        <target state="translated">尋找</target>
+      </trans-unit>
+      <trans-unit id="label.previousMatchButton">
+        <source xml:lang="en">Previous match</source>
+        <target state="translated">上一個符合項目</target>
+      </trans-unit>
+      <trans-unit id="label.nextMatchButton">
+        <source xml:lang="en">Next match</source>
+        <target state="translated">下一個符合項目</target>
+      </trans-unit>
+      <trans-unit id="label.closeButton">
+        <source xml:lang="en">Close</source>
+        <target state="translated">關閉</target>
+      </trans-unit>
+      <trans-unit id="title.matchesCountLimit">
+        <source xml:lang="en">Your search returned a large number of results, only the first 999 matches will be highlighted.</source>
+        <target state="translated">您的搜尋傳回了大量結果，只會將前 999 個相符項目醒目提示。</target>
+      </trans-unit>
+      <trans-unit id="label.matchesLocation">
+        <source xml:lang="en">{0} of {1}</source>
+        <target state="translated">{1} 的 {0}</target>
+      </trans-unit>
+      <trans-unit id="label.noResults">
+        <source xml:lang="en">No Results</source>
+        <target state="translated">查無結果</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerResourceEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="profilerTextEditorAriaLabel">
+        <source xml:lang="en">Profiler editor for event text. Readonly</source>
+        <target state="translated">事件文字的分析工具編輯器。唯讀</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/profiler/browser/profilerTableEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="ProfilerTableEditor.eventCountFiltered">
+        <source xml:lang="en">Events (Filtered): {0}/{1}</source>
+        <target state="translated">事件 (已篩選): {0}/{1}</target>
+      </trans-unit>
+      <trans-unit id="ProfilerTableEditor.eventCount">
+        <source xml:lang="en">Events: {0}</source>
+        <target state="translated">事件: {0}</target>
+      </trans-unit>
+      <trans-unit id="status.eventCount">
+        <source xml:lang="en">Event Count</source>
+        <target state="translated">事件計數</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/actions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="saveAsCsv">
+        <source xml:lang="en">Save As CSV</source>
+        <target state="translated">另存為 CSV</target>
+      </trans-unit>
+      <trans-unit id="saveAsJson">
+        <source xml:lang="en">Save As JSON</source>
+        <target state="translated">另存為 JSON</target>
+      </trans-unit>
+      <trans-unit id="saveAsExcel">
+        <source xml:lang="en">Save As Excel</source>
+        <target state="translated">另存為 Excel</target>
+      </trans-unit>
+      <trans-unit id="saveAsXml">
+        <source xml:lang="en">Save As XML</source>
+        <target state="translated">另存為 XML</target>
+      </trans-unit>
+      <trans-unit id="jsonEncoding">
+        <source xml:lang="en">Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created.</source>
+        <target state="translated">匯出至 JSON 時將不會儲存結果編碼，請務必在建立檔案後儲存所需的編碼。</target>
+      </trans-unit>
+      <trans-unit id="saveToFileNotSupported">
+        <source xml:lang="en">Save to file is not supported by the backing data source</source>
+        <target state="translated">回溯資料來源不支援儲存為檔案</target>
+      </trans-unit>
+      <trans-unit id="copySelection">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">複製</target>
+      </trans-unit>
+      <trans-unit id="copyWithHeaders">
+        <source xml:lang="en">Copy With Headers</source>
+        <target state="translated">隨標題一同複製</target>
+      </trans-unit>
+      <trans-unit id="selectAll">
+        <source xml:lang="en">Select All</source>
+        <target state="translated">全選</target>
+      </trans-unit>
+      <trans-unit id="maximize">
+        <source xml:lang="en">Maximize</source>
+        <target state="translated">最大化</target>
+      </trans-unit>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">還原</target>
+      </trans-unit>
+      <trans-unit id="chart">
+        <source xml:lang="en">Chart</source>
+        <target state="translated">圖表</target>
+      </trans-unit>
+      <trans-unit id="visualizer">
+        <source xml:lang="en">Visualizer</source>
+        <target state="translated">視覺化檢視</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/flavorStatus" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="chooseSqlLang">
+        <source xml:lang="en">Choose SQL Language</source>
+        <target state="translated">選擇 SQL 語言 </target>
+      </trans-unit>
+      <trans-unit id="changeProvider">
+        <source xml:lang="en">Change SQL language provider</source>
+        <target state="translated">變更 SQL 語言提供者</target>
+      </trans-unit>
+      <trans-unit id="status.query.flavor">
+        <source xml:lang="en">SQL Language Flavor</source>
+        <target state="translated">SQL 語言的變體</target>
+      </trans-unit>
+      <trans-unit id="changeSqlProvider">
+        <source xml:lang="en">Change SQL Engine Provider</source>
+        <target state="translated">變更 SQL 引擎提供者</target>
+      </trans-unit>
+      <trans-unit id="alreadyConnected">
+        <source xml:lang="en">A connection using engine {0} exists. To change please disconnect or change connection</source>
+        <target state="translated">使用引擎 {0} 的連線已存在。若要變更，請中斷或變更連線</target>
+      </trans-unit>
+      <trans-unit id="noEditor">
+        <source xml:lang="en">No text editor active at this time</source>
+        <target state="translated">目前無使用中的文字編輯器</target>
+      </trans-unit>
+      <trans-unit id="pickSqlProvider">
+        <source xml:lang="en">Select Language Provider</source>
+        <target state="translated">選擇語言提供者</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/gridPanel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="xmlShowplan">
+        <source xml:lang="en">XML Showplan</source>
+        <target state="translated">XML 執行程序表</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid">
+        <source xml:lang="en">Results grid</source>
+        <target state="translated">結果方格</target>
+      </trans-unit>
+      <trans-unit id="resultsGrid.maxRowCountExceeded">
+        <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'</source>
+        <target state="translated">已超過篩選/排序的資料列計數上限。若要更新，您可以前往使用者設定並變更設定: ' queryEditor. inMemoryDataProcessingThreshold '</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/keyboardQueryActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="focusOnCurrentQueryKeyboardAction">
+        <source xml:lang="en">Focus on Current Query</source>
+        <target state="translated">聚焦於目前的查詢</target>
+      </trans-unit>
+      <trans-unit id="runQueryKeyboardAction">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">執行查詢</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryKeyboardAction">
+        <source xml:lang="en">Run Current Query</source>
+        <target state="translated">執行目前查詢</target>
+      </trans-unit>
+      <trans-unit id="copyQueryWithResultsKeyboardAction">
+        <source xml:lang="en">Copy Query With Results</source>
+        <target state="translated">與結果一併複製查詢</target>
+      </trans-unit>
+      <trans-unit id="queryActions.queryResultsCopySuccess">
+        <source xml:lang="en">Successfully copied query and results.</source>
+        <target state="translated">已成功複製查詢與結果。</target>
+      </trans-unit>
+      <trans-unit id="runCurrentQueryWithActualPlanKeyboardAction">
+        <source xml:lang="en">Run Current Query with Actual Plan</source>
+        <target state="translated">使用實際計畫執行目前的查詢</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryKeyboardAction">
+        <source xml:lang="en">Cancel Query</source>
+        <target state="translated">取消查詢</target>
+      </trans-unit>
+      <trans-unit id="refreshIntellisenseKeyboardAction">
+        <source xml:lang="en">Refresh IntelliSense Cache</source>
+        <target state="translated">重新整理 IntelliSense 快取</target>
+      </trans-unit>
+      <trans-unit id="toggleQueryResultsKeyboardAction">
+        <source xml:lang="en">Toggle Query Results</source>
+        <target state="translated">切換查詢結果</target>
+      </trans-unit>
+      <trans-unit id="ToggleFocusBetweenQueryEditorAndResultsAction">
+        <source xml:lang="en">Toggle Focus Between Query And Results</source>
+        <target state="translated">在查詢與結果之間切換焦點</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutNoEditor">
+        <source xml:lang="en">Editor parameter is required for a shortcut to be executed</source>
+        <target state="translated">要執行的捷徑需要編輯器參數</target>
+      </trans-unit>
+      <trans-unit id="parseSyntaxLabel">
+        <source xml:lang="en">Parse Query</source>
+        <target state="translated">剖析查詢</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxSuccess">
+        <source xml:lang="en">Commands completed successfully</source>
+        <target state="translated">已成功完成命令</target>
+      </trans-unit>
+      <trans-unit id="queryActions.parseSyntaxFailure">
+        <source xml:lang="en">Command failed: </source>
+        <target state="translated">命令失敗:</target>
+      </trans-unit>
+      <trans-unit id="queryActions.notConnected">
+        <source xml:lang="en">Please connect to a server</source>
+        <target state="translated">請連線至伺服器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/messagePanel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="messagePanel">
+        <source xml:lang="en">Message Panel</source>
+        <target state="translated">訊息面板</target>
+      </trans-unit>
+      <trans-unit id="copy">
+        <source xml:lang="en">Copy</source>
+        <target state="translated">複製</target>
+      </trans-unit>
+      <trans-unit id="copyAll">
+        <source xml:lang="en">Copy All</source>
+        <target state="translated">全部複製</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/query.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="queryResultsEditor.name">
+        <source xml:lang="en">Query Results</source>
+        <target state="translated">查詢結果</target>
+      </trans-unit>
+      <trans-unit id="newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新增查詢</target>
+      </trans-unit>
+      <trans-unit id="queryEditorConfigurationTitle">
+        <source xml:lang="en">Query Editor</source>
+        <target state="translated">查詢編輯器</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.includeHeaders">
+        <source xml:lang="en">When true, column headers are included when saving results as CSV</source>
+        <target state="translated">若設定為 true，會在將結果另存為 CSV 時包含資料行標題</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.delimiter">
+        <source xml:lang="en">The custom delimiter to use between values when saving as CSV</source>
+        <target state="translated">另存為 CSV 時，用在值之間的自訂分隔符號</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.lineSeperator">
+        <source xml:lang="en">Character(s) used for seperating rows when saving results as CSV</source>
+        <target state="translated">將結果另存為 CSV 時，用於分隔資料列的字元</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.textIdentifier">
+        <source xml:lang="en">Character used for enclosing text fields when saving results as CSV</source>
+        <target state="translated">將結果另存為 CSV 時，用於括住文字欄位的字元</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsCsv.encoding">
+        <source xml:lang="en">File encoding used when saving results as CSV</source>
+        <target state="translated">將結果另存為 CSV 時，要使用的檔案編碼</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.formatted">
+        <source xml:lang="en">When true, XML output will be formatted when saving results as XML</source>
+        <target state="translated">若設定為 true，會在將結果另存為 XML 時將輸出格式化</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.saveAsXml.encoding">
+        <source xml:lang="en">File encoding used when saving results as XML</source>
+        <target state="translated">將結果另存為 XML 時，要使用的檔案編碼</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.streaming">
+        <source xml:lang="en">Enable results streaming; contains few minor visual issues</source>
+        <target state="translated">啟用結果串流；包含些許輕微視覺效果問題</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyIncludeHeaders">
+        <source xml:lang="en">Configuration options for copying results from the Results View</source>
+        <target state="translated">從結果檢視中複製結果的組態選項</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.copyRemoveNewLine">
+        <source xml:lang="en">Configuration options for copying multi-line results from the Results View</source>
+        <target state="translated">從結果檢視中複製多行結果的組態選項</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.optimizedTable">
+        <source xml:lang="en">(Experimental) Use a optimized table in the results out. Some functionality might be missing and in the works.</source>
+        <target state="translated">(實驗性) 在結果中使用最佳化的資料表。可能會缺少某些功能，這些功能仍在開發中。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.inMemoryDataProcessingThreshold">
+        <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
+        <target state="translated">控制允許在記憶體中篩選及排序的資料列數目上限。如果超過此數目，就會停用排序和篩選。警告: 增加此數目可能會影響效能。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.results.openAfterSave">
+        <source xml:lang="en">Whether to open the file in Azure Data Studio after the result is saved.</source>
+        <target state="translated">是否要在儲存結果後在 Azure Data Studio 中開啟檔案。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.showBatchTime">
+        <source xml:lang="en">Should execution time be shown for individual batches</source>
+        <target state="translated">是否顯示個別批次的執行時間</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.messages.wordwrap">
+        <source xml:lang="en">Word wrap messages</source>
+        <target state="translated">自動換行訊息</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.chart.defaultChartType">
+        <source xml:lang="en">The default chart type to use when opening Chart Viewer from a Query Results</source>
+        <target state="translated">從查詢結果開啟圖表檢視器時要使用的預設圖表類型</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.off">
+        <source xml:lang="en">Tab coloring will be disabled</source>
+        <target state="translated">將停用索引標籤著色功能</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.border">
+        <source xml:lang="en">The top border of each editor tab will be colored to match the relevant server group</source>
+        <target state="translated">在每個編輯器索引標籤的上邊框著上符合相關伺服器群組的色彩</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode.fill">
+        <source xml:lang="en">Each editor tab's background color will match the relevant server group</source>
+        <target state="translated">每個編輯器索引標籤的背景色彩將與相關的伺服器群組相符</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.tabColorMode">
+        <source xml:lang="en">Controls how to color tabs based on the server group of their active connection</source>
+        <target state="translated">依據連線的伺服器群組控制索引標籤如何著色</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.showConnectionInfoInTitle">
+        <source xml:lang="en">Controls whether to show the connection info for a tab in the title.</source>
+        <target state="translated">控制是否要在標題中顯示索引標籤的連線資訊。</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.promptToSaveGeneratedFiles">
+        <source xml:lang="en">Prompt to save generated SQL files</source>
+        <target state="translated">提示儲存產生的 SQL 檔案</target>
+      </trans-unit>
+      <trans-unit id="queryShortcutDescription">
+        <source xml:lang="en">Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}</source>
+        <target state="translated">設定按鍵繫結關係 workbench.action.query.shortcut{0} 以執行捷徑文字作為程序呼叫或查詢執行。任何選取的文字在查詢編輯器中會於查詢結尾作為參數傳遞，或您可將它以 {arg} 參考</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="newQueryTask.newQuery">
+        <source xml:lang="en">New Query</source>
+        <target state="translated">新增查詢</target>
+      </trans-unit>
+      <trans-unit id="runQueryLabel">
+        <source xml:lang="en">Run</source>
+        <target state="translated">執行</target>
+      </trans-unit>
+      <trans-unit id="cancelQueryLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="estimatedQueryPlan">
+        <source xml:lang="en">Explain</source>
+        <target state="translated">說明</target>
+      </trans-unit>
+      <trans-unit id="actualQueryPlan">
+        <source xml:lang="en">Actual</source>
+        <target state="translated">實際</target>
+      </trans-unit>
+      <trans-unit id="disconnectDatabaseLabel">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">中斷連線</target>
+      </trans-unit>
+      <trans-unit id="changeConnectionDatabaseLabel">
+        <source xml:lang="en">Change Connection</source>
+        <target state="translated">變更連線</target>
+      </trans-unit>
+      <trans-unit id="connectDatabaseLabel">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">連線</target>
+      </trans-unit>
+      <trans-unit id="enablesqlcmdLabel">
+        <source xml:lang="en">Enable SQLCMD</source>
+        <target state="translated">啟用 SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="disablesqlcmdLabel">
+        <source xml:lang="en">Disable SQLCMD</source>
+        <target state="translated">停用 SQLCMD</target>
+      </trans-unit>
+      <trans-unit id="selectDatabase">
+        <source xml:lang="en">Select Database</source>
+        <target state="translated">選擇資料庫</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failed">
+        <source xml:lang="en">Failed to change database</source>
+        <target state="translated">變更資料庫失敗</target>
+      </trans-unit>
+      <trans-unit id="changeDatabase.failedWithError">
+        <source xml:lang="en">Failed to change database: {0}</source>
+        <target state="translated">無法變更資料庫: {0}</target>
+      </trans-unit>
+      <trans-unit id="queryEditor.exportSqlAsNotebook">
+        <source xml:lang="en">Export as Notebook</source>
+        <target state="translated">匯出為筆記本</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="queryEditor.name">
+        <source xml:lang="en">Query Editor</source>
+        <target state="new">Query Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/queryResultsView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="resultsTabTitle">
+        <source xml:lang="en">Results</source>
+        <target state="translated">結果</target>
+      </trans-unit>
+      <trans-unit id="messagesTabTitle">
+        <source xml:lang="en">Messages</source>
+        <target state="translated">訊息</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/browser/statusBarItems" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="status.query.timeElapsed">
+        <source xml:lang="en">Time Elapsed</source>
+        <target state="translated">已耗用時間</target>
+      </trans-unit>
+      <trans-unit id="status.query.rowCount">
+        <source xml:lang="en">Row Count</source>
+        <target state="translated">資料列計數</target>
+      </trans-unit>
+      <trans-unit id="rowCount">
+        <source xml:lang="en">{0} rows</source>
+        <target state="translated">{0} 個資料列</target>
+      </trans-unit>
+      <trans-unit id="query.status.executing">
+        <source xml:lang="en">Executing query...</source>
+        <target state="translated">執行查詢中...</target>
+      </trans-unit>
+      <trans-unit id="status.query.status">
+        <source xml:lang="en">Execution Status</source>
+        <target state="translated">執行狀態</target>
+      </trans-unit>
+      <trans-unit id="status.query.selection-summary">
+        <source xml:lang="en">Selection Summary</source>
+        <target state="translated">選取摘要</target>
+      </trans-unit>
+      <trans-unit id="status.query.summaryText">
+        <source xml:lang="en">Average: {0}  Count: {1}  Sum: {2}</source>
+        <target state="translated">平均: {0} 計數: {1} 總和: {2}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/query/common/resultsGrid.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="resultsGridConfigurationTitle">
+        <source xml:lang="en">Results Grid and Messages</source>
+        <target state="translated">結果方格與訊息</target>
+      </trans-unit>
+      <trans-unit id="fontFamily">
+        <source xml:lang="en">Controls the font family.</source>
+        <target state="translated">控制字型家族。</target>
+      </trans-unit>
+      <trans-unit id="fontWeight">
+        <source xml:lang="en">Controls the font weight.</source>
+        <target state="translated">控制字型粗細。</target>
+      </trans-unit>
+      <trans-unit id="fontSize">
+        <source xml:lang="en">Controls the font size in pixels.</source>
+        <target state="translated">控制字型大小 (像素)。</target>
+      </trans-unit>
+      <trans-unit id="letterSpacing">
+        <source xml:lang="en">Controls the letter spacing in pixels.</source>
+        <target state="translated">控制字母間距 (像素)。</target>
+      </trans-unit>
+      <trans-unit id="rowHeight">
+        <source xml:lang="en">Controls the row height in pixels</source>
+        <target state="translated">控制列高 (像素)</target>
+      </trans-unit>
+      <trans-unit id="cellPadding">
+        <source xml:lang="en">Controls the cell padding in pixels</source>
+        <target state="translated">控制資料格填補值 (像素)</target>
+      </trans-unit>
+      <trans-unit id="autoSizeColumns">
+        <source xml:lang="en">Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells</source>
+        <target state="translated">自動調整初始結果的欄寬大小。大量欄位或大型資料格可能會造成效能問題</target>
+      </trans-unit>
+      <trans-unit id="maxColumnWidth">
+        <source xml:lang="en">The maximum width in pixels for auto-sized columns</source>
+        <target state="translated">自動調整大小之欄位的寬度上限 (像素)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="toggleQueryHistory">
+        <source xml:lang="en">Toggle Query History</source>
+        <target state="translated">切換查詢歷史記錄</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">刪除</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">清除所有歷史記錄</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.openQuery">
+        <source xml:lang="en">Open Query</source>
+        <target state="translated">開啟查詢</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.runQuery">
+        <source xml:lang="en">Run Query</source>
+        <target state="translated">執行查詢</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.toggleCaptureLabel">
+        <source xml:lang="en">Toggle Query History capture</source>
+        <target state="translated">切換查詢歷史記錄擷取</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">暫停查詢歷史記錄擷取</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">開始查詢歷史記錄擷取</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">成功</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">失敗</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/browser/queryHistoryView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="noQueriesMessage">
+        <source xml:lang="en">No queries to display.</source>
+        <target state="translated">沒有查詢可顯示。</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.regTreeAriaLabel">
+        <source xml:lang="en">Query History</source>
+        <note>QueryHistory</note>
+        <target state="translated">查詢歷史記錄</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryHistory/electron-browser/queryHistory" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="queryHistoryConfigurationTitle">
+        <source xml:lang="en">QueryHistory</source>
+        <target state="translated">查詢歷史記錄</target>
+      </trans-unit>
+      <trans-unit id="queryHistoryCaptureEnabled">
+        <source xml:lang="en">Whether Query History capture is enabled. If false queries executed will not be captured.</source>
+        <target state="translated">是否啟用了查詢歷史記錄擷取。若未啟用，將不會擷取已經執行的查詢。</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.clearLabel">
+        <source xml:lang="en">Clear All History</source>
+        <target state="translated">清除所有歷史記錄</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.disableCapture">
+        <source xml:lang="en">Pause Query History Capture</source>
+        <target state="translated">暫停查詢歷史記錄擷取</target>
+      </trans-unit>
+      <trans-unit id="queryHistory.enableCapture">
+        <source xml:lang="en">Start Query History Capture</source>
+        <target state="translated">開始查詢歷史記錄擷取</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">檢視</target>
+      </trans-unit>
+      <trans-unit id="miViewQueryHistory">
+        <source xml:lang="en">&amp;&amp;Query History</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">查詢歷史記錄(&amp;&amp;Q)</target>
+      </trans-unit>
+      <trans-unit id="queryHistory">
+        <source xml:lang="en">Query History</source>
+        <target state="translated">查詢歷史記錄</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlan" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="queryPlanTitle">
+        <source xml:lang="en">Query Plan</source>
+        <target state="translated">查詢計劃</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="queryPlanEditor">
+        <source xml:lang="en">Query Plan Editor</source>
+        <target state="new">Query Plan Editor</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/queryPlan/browser/topOperations" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="topOperations.operation">
+        <source xml:lang="en">Operation</source>
+        <target state="translated">作業</target>
+      </trans-unit>
+      <trans-unit id="topOperations.object">
+        <source xml:lang="en">Object</source>
+        <target state="translated">物件</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCost">
+        <source xml:lang="en">Est Cost</source>
+        <target state="translated">估計成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estSubtreeCost">
+        <source xml:lang="en">Est Subtree Cost</source>
+        <target state="translated">估計的樹狀子目錄成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRows">
+        <source xml:lang="en">Actual Rows</source>
+        <target state="translated">實際資料列數</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRows">
+        <source xml:lang="en">Est Rows</source>
+        <target state="translated">估計資料列數</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualExecutions">
+        <source xml:lang="en">Actual Executions</source>
+        <target state="translated">實際執行次數</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estCPUCost">
+        <source xml:lang="en">Est CPU Cost</source>
+        <target state="translated">估計 CPU 成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estIOCost">
+        <source xml:lang="en">Est IO Cost</source>
+        <target state="translated">估計 IO 成本</target>
+      </trans-unit>
+      <trans-unit id="topOperations.parallel">
+        <source xml:lang="en">Parallel</source>
+        <target state="translated">平行作業</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRebinds">
+        <source xml:lang="en">Actual Rebinds</source>
+        <target state="translated">實際重新繫結數</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRebinds">
+        <source xml:lang="en">Est Rebinds</source>
+        <target state="translated">估計重新繫結數</target>
+      </trans-unit>
+      <trans-unit id="topOperations.actualRewinds">
+        <source xml:lang="en">Actual Rewinds</source>
+        <target state="translated">實際倒轉數</target>
+      </trans-unit>
+      <trans-unit id="topOperations.estRewinds">
+        <source xml:lang="en">Est Rewinds</source>
+        <target state="translated">估計倒轉數</target>
+      </trans-unit>
+      <trans-unit id="topOperations.partitioned">
+        <source xml:lang="en">Partitioned</source>
+        <target state="translated">已分割</target>
+      </trans-unit>
+      <trans-unit id="topOperationsTitle">
+        <source xml:lang="en">Top Operations</source>
+        <target state="translated">最前幾項操作</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="resourceViewer">
+        <source xml:lang="en">Resource Viewer</source>
+        <target state="translated">資源檢視器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="resourceViewer.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">重新整理</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="resourceViewerTable.openError">
+        <source xml:lang="en">Error opening link : {0}</source>
+        <target state="translated">開啟連結時發生錯誤: {0}</target>
+      </trans-unit>
+      <trans-unit id="resourceViewerTable.commandError">
+        <source xml:lang="en">Error executing command '{0}' : {1}</source>
+        <target state="translated">執行命令 '{0}' 時發生錯誤: {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="resourceViewer.ariaLabel">
+        <source xml:lang="en">Resource Viewer Tree</source>
+        <target state="translated">資源檢視器樹狀結構</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="extension.contributes.resourceView.resource.id">
+        <source xml:lang="en">Identifier of the resource.</source>
+        <target state="translated">資源的識別碼。</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.name">
+        <source xml:lang="en">The human-readable name of the view. Will be shown</source>
+        <target state="translated">使用人性化顯示名稱。會顯示</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceView.resource.icon">
+        <source xml:lang="en">Path to the resource icon.</source>
+        <target state="translated">資源圖示的路徑。</target>
+      </trans-unit>
+      <trans-unit id="extension.contributes.resourceViewResources">
+        <source xml:lang="en">Contributes resource to the resource view</source>
+        <target state="translated">將資源提供給資源檢視</target>
+      </trans-unit>
+      <trans-unit id="requirestring">
+        <source xml:lang="en">property `{0}` is mandatory and must be of type `string`</source>
+        <target state="translated">屬性 '{0}' 為強制項目且必須屬於 `string` 類型</target>
+      </trans-unit>
+      <trans-unit id="optstring">
+        <source xml:lang="en">property `{0}` can be omitted or must be of type `string`</source>
+        <target state="translated">屬性 `{0}` 可以省略或必須屬於 `string` 類型</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restore.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">還原</target>
+      </trans-unit>
+      <trans-unit id="backup">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">還原</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/restore/browser/restoreActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="restore.isPreviewFeature">
+        <source xml:lang="en">You must enable preview features in order to use restore</source>
+        <target state="translated">您必須啟用預覽功能才能使用還原</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupportedOutsideContext">
+        <source xml:lang="en">Restore command is not supported outside of a server context. Please select a server or database and try again.</source>
+        <target state="translated">伺服器內容中不支援還原命令。請選取伺服器或資料庫並再試一次。</target>
+      </trans-unit>
+      <trans-unit id="restore.commandNotSupported">
+        <source xml:lang="en">Restore command is not supported for Azure SQL databases.</source>
+        <target state="translated">Azure SQL 資料庫不支援還原命令。</target>
+      </trans-unit>
+      <trans-unit id="restoreAction.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">還原</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scripting.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="scriptAsCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">建立指令碼</target>
+      </trans-unit>
+      <trans-unit id="scriptAsDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">將指令碼編寫為 Drop</target>
+      </trans-unit>
+      <trans-unit id="scriptAsSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">選取前 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptAsExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">作為指令碼執行</target>
+      </trans-unit>
+      <trans-unit id="scriptAsAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">修改指令碼</target>
+      </trans-unit>
+      <trans-unit id="editData">
+        <source xml:lang="en">Edit Data</source>
+        <target state="translated">編輯資料</target>
+      </trans-unit>
+      <trans-unit id="scriptSelect">
+        <source xml:lang="en">Select Top 1000</source>
+        <target state="translated">選取前 1000</target>
+      </trans-unit>
+      <trans-unit id="scriptKustoSelect">
+        <source xml:lang="en">Take 10</source>
+        <target state="translated">取用 10 筆</target>
+      </trans-unit>
+      <trans-unit id="scriptCreate">
+        <source xml:lang="en">Script as Create</source>
+        <target state="translated">建立指令碼</target>
+      </trans-unit>
+      <trans-unit id="scriptExecute">
+        <source xml:lang="en">Script as Execute</source>
+        <target state="translated">作為指令碼執行</target>
+      </trans-unit>
+      <trans-unit id="scriptAlter">
+        <source xml:lang="en">Script as Alter</source>
+        <target state="translated">修改指令碼</target>
+      </trans-unit>
+      <trans-unit id="scriptDelete">
+        <source xml:lang="en">Script as Drop</source>
+        <target state="translated">將指令碼編寫為 Drop</target>
+      </trans-unit>
+      <trans-unit id="refreshNode">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">重新整理</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/scripting/browser/scriptingActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="refreshError">
+        <source xml:lang="en">An error occurred refreshing node '{0}': {1}</source>
+        <target state="translated">重新整理節點 '{0}' 時發生錯誤: {1}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasks.contribution" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="inProgressTasksChangesBadge">
+        <source xml:lang="en">{0} in progress tasks</source>
+        <target state="translated">{0} 正在執行的工作</target>
+      </trans-unit>
+      <trans-unit id="viewCategory">
+        <source xml:lang="en">View</source>
+        <target state="translated">檢視</target>
+      </trans-unit>
+      <trans-unit id="tasks">
+        <source xml:lang="en">Tasks</source>
+        <target state="translated">工作</target>
+      </trans-unit>
+      <trans-unit id="miViewTasks">
+        <source xml:lang="en">&amp;&amp;Tasks</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">工作(&amp;&amp;T)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="toggleTasks">
+        <source xml:lang="en">Toggle Tasks</source>
+        <target state="translated">切換工作</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="succeeded">
+        <source xml:lang="en">succeeded</source>
+        <target state="translated">成功</target>
+      </trans-unit>
+      <trans-unit id="failed">
+        <source xml:lang="en">failed</source>
+        <target state="translated">失敗</target>
+      </trans-unit>
+      <trans-unit id="inProgress">
+        <source xml:lang="en">in progress</source>
+        <target state="translated">進行中</target>
+      </trans-unit>
+      <trans-unit id="notStarted">
+        <source xml:lang="en">not started</source>
+        <target state="translated">未啟動</target>
+      </trans-unit>
+      <trans-unit id="canceled">
+        <source xml:lang="en">canceled</source>
+        <target state="translated">已取消</target>
+      </trans-unit>
+      <trans-unit id="canceling">
+        <source xml:lang="en">canceling</source>
+        <target state="translated">取消中</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/browser/tasksView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="noTaskMessage">
+        <source xml:lang="en">No task history to display.</source>
+        <target state="translated">沒有工作歷程記錄可顯示。</target>
+      </trans-unit>
+      <trans-unit id="taskHistory.regTreeAriaLabel">
+        <source xml:lang="en">Task history</source>
+        <note>TaskHistory</note>
+        <target state="translated">工作歷程記錄</target>
+      </trans-unit>
+      <trans-unit id="taskError">
+        <source xml:lang="en">Task error</source>
+        <target state="translated">工作錯誤</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/tasks/common/tasksAction" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="cancelTask.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="errorMsgFromCancelTask">
+        <source xml:lang="en">The task failed to cancel.</source>
+        <target state="translated">工作取消失敗。</target>
+      </trans-unit>
+      <trans-unit id="taskAction.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">指令碼</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/views/browser/treeView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="no-dataprovider">
+        <source xml:lang="en">There is no data provider registered that can provide view data.</source>
+        <target state="translated">沒有任何已註冊的資料提供者可提供檢視資料。</target>
+      </trans-unit>
+      <trans-unit id="refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">重新整理</target>
+      </trans-unit>
+      <trans-unit id="collapseAll">
+        <source xml:lang="en">Collapse All</source>
+        <target state="translated">全部摺疊</target>
+      </trans-unit>
+      <trans-unit id="command-error">
+        <source xml:lang="en">Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.</source>
+        <target state="translated">執行命令 {1} 時發生錯誤: {0}。這可能是貢獻 {1} 的延伸模組所引起。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/webview/browser/webViewDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="webViewDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="webViewDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">關閉</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="enablePreviewFeatures.notice">
+        <source xml:lang="en">Preview features enhance your experience in Azure Data Studio by giving you full access to new features and improvements. You can learn more about preview features [here]({0}). Would you like to enable preview features?</source>
+        <target state="translated">預覽功能可讓您完整存取新功能及改善的功能，增強您在 Azure Data Studio 的體驗。您可以參閱[這裡]({0})深入了解預覽功能。是否要啟用預覽功能?</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.yes">
+        <source xml:lang="en">Yes (recommended)</source>
+        <target state="translated">是 (建議)</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="enablePreviewFeatures.never">
+        <source xml:lang="en">No, don't show again</source>
+        <target state="translated">不，不要再顯示</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="welcomePage.previewBody">
+        <source xml:lang="en">This feature page is in preview. Preview features introduce new functionalities that are on track to becoming a permanent part the product. They are stable, but need additional accessibility improvements. We welcome your early feedback while they are under development.</source>
+        <target state="translated">這個功能頁面仍在預覽階段。預覽功能會引進新功能，並逐步成為產品中永久的一部分。這些功能雖然穩定，但在使用上仍需要改善。歡迎您在功能開發期間提供早期的意見反應。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.preview">
+        <source xml:lang="en">Preview</source>
+        <target state="translated">預覽</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnection">
+        <source xml:lang="en">Create a connection</source>
+        <target state="translated">建立連線</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createConnectionBody">
+        <source xml:lang="en">Connect to a database instance through the connection dialog.</source>
+        <target state="translated">透過連線對話方塊連線到資料庫執行個體。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQuery">
+        <source xml:lang="en">Run a query</source>
+        <target state="translated">執行查詢</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.runQueryBody">
+        <source xml:lang="en">Interact with data through a query editor.</source>
+        <target state="translated">透過查詢編輯器與資料互動。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebook">
+        <source xml:lang="en">Create a notebook</source>
+        <target state="translated">建立筆記本</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.createNotebookBody">
+        <source xml:lang="en">Build a new notebook using a native notebook editor.</source>
+        <target state="translated">使用原生筆記本編輯器建置新的筆記本。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">部署伺服器</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServerBody">
+        <source xml:lang="en">Create a new instance of a relational data service on the platform of your choice.</source>
+        <target state="translated">在您選擇的平台上建立關聯式資料服務的新執行個體。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.resources">
+        <source xml:lang="en">Resources</source>
+        <target state="translated">資源</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.history">
+        <source xml:lang="en">History</source>
+        <target state="translated">記錄</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.name">
+        <source xml:lang="en">Name</source>
+        <target state="translated">名稱</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.location">
+        <source xml:lang="en">Location</source>
+        <target state="translated">位置</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">Show more</source>
+        <target state="translated">顯示更多</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">啟動時顯示歡迎頁面</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.usefuLinks">
+        <source xml:lang="en">Useful Links</source>
+        <target state="translated">實用的連結</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting Started</source>
+        <target state="translated">使用者入門</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStartedBody">
+        <source xml:lang="en">Discover the capabilities offered by Azure Data Studio and learn how to make the most of them.</source>
+        <target state="translated">探索 Azure Data Studio 提供的功能，並了解如何充分利用。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">文件</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.documentationBody">
+        <source xml:lang="en">Visit the documentation center for quickstarts, how-to guides, and references for PowerShell, APIs, etc.</source>
+        <target state="translated">如需快速入門、操作指南及 PowerShell、API 等參考，請瀏覽文件中心。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videos">
+        <source xml:lang="en">Videos</source>
+        <target state="translated">影片</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionOverview">
+        <source xml:lang="en">Overview of Azure Data Studio</source>
+        <target state="translated">Azure Data Studio 概觀</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.videoDescriptionIntroduction">
+        <source xml:lang="en">Introduction to Azure Data Studio Notebooks | Data Exposed</source>
+        <target state="translated">Azure Data Studio Notebooks 簡介 | 公開的資料</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">延伸模組</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAll">
+        <source xml:lang="en">Show All</source>
+        <target state="translated">全部顯示</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learnMore">
+        <source xml:lang="en">Learn more </source>
+        <target state="translated">深入了解 </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="GuidedTour.connections">
+        <source xml:lang="en">Connections</source>
+        <target state="translated">連線</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnections">
+        <source xml:lang="en">Connect, query, and manage your connections from SQL Server, Azure, and more.</source>
+        <target state="translated">從 SQL Server、Azure 等處進行連線、查詢及管理您的連線。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.one">
+        <source xml:lang="en">1</source>
+        <target state="translated">1</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.next">
+        <source xml:lang="en">Next</source>
+        <target state="translated">下一個</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.notebooks">
+        <source xml:lang="en">Notebooks</source>
+        <target state="translated">筆記本</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.gettingStartedNotebooks">
+        <source xml:lang="en">Get started creating your own notebook or collection of notebooks in a single place.</source>
+        <target state="translated">開始在單一位置建立您自己的筆記本或筆記本系列。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.two">
+        <source xml:lang="en">2</source>
+        <target state="translated">2</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">延伸模組</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.addExtensions">
+        <source xml:lang="en">Extend the functionality of Azure Data Studio by installing extensions developed by us/Microsoft as well as the third-party community (you!).</source>
+        <target state="translated">安裝由我們 (Microsoft) 及第三方社群 (您!) 所開發的延伸模組，來擴充 Azure Data Studio 的功能。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.three">
+        <source xml:lang="en">3</source>
+        <target state="translated">3</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.settings">
+        <source xml:lang="en">Settings</source>
+        <target state="translated">設定</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.makeConnesetSettings">
+        <source xml:lang="en">Customize Azure Data Studio based on your preferences. You can configure Settings like autosave and tab size, personalize your Keyboard Shortcuts, and switch to a Color Theme of your liking.</source>
+        <target state="translated">根據您的喜好自訂 Azure Data Studio。您可以進行自動儲存及索引標籤大小等 [設定]、將 [鍵盤快速鍵] 個人化，以及切換至您喜歡的 [色彩佈景主題]。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.four">
+        <source xml:lang="en">4</source>
+        <target state="translated">4</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.welcomePage">
+        <source xml:lang="en">Welcome Page</source>
+        <target state="translated">歡迎頁面</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.discoverWelcomePage">
+        <source xml:lang="en">Discover top features, recently opened files, and recommended extensions on the Welcome page. For more information on how to get started in Azure Data Studio, check out our videos and documentation.</source>
+        <target state="translated">在歡迎頁面中探索常用功能、最近開啟的檔案及建議的延伸模組。如需詳細資訊，以了解如何開始使用 Azure Data Studio，請參閱我們的影片及文件。</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.five">
+        <source xml:lang="en">5</source>
+        <target state="translated">5</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.finish">
+        <source xml:lang="en">Finish</source>
+        <target state="translated">完成</target>
+      </trans-unit>
+      <trans-unit id="guidedTour">
+        <source xml:lang="en">User Welcome Tour</source>
+        <target state="translated">使用者歡迎導覽</target>
+      </trans-unit>
+      <trans-unit id="hideGuidedTour">
+        <source xml:lang="en">Hide Welcome Tour</source>
+        <target state="translated">隱藏歡迎導覽</target>
+      </trans-unit>
+      <trans-unit id="GuidedTour.readMore">
+        <source xml:lang="en">Read more</source>
+        <target state="translated">深入了解</target>
+      </trans-unit>
+      <trans-unit id="help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">說明</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome/page/browser/welcomePage" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="welcomePage">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">歡迎使用</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 管理員套件</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showAdminPack">
+        <source xml:lang="en">SQL Admin Pack</source>
+        <target state="translated">SQL 管理員套件</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.adminPackDescription">
+        <source xml:lang="en">Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server</source>
+        <target state="translated">SQL Server 的管理員套件是一套熱門的資料庫管理延伸模組，可協助您管理 SQL Server</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerAgent">
+        <source xml:lang="en">SQL Server Agent</source>
+        <target state="translated">SQL Server Agent</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerProfiler">
+        <source xml:lang="en">SQL Server Profiler</source>
+        <target state="translated">SQL Server Profiler</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerImport">
+        <source xml:lang="en">SQL Server Import</source>
+        <target state="translated">SQL Server 匯入</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.sqlServerDacpac">
+        <source xml:lang="en">SQL Server Dacpac</source>
+        <target state="translated">SQL Server Dacpac</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershell">
+        <source xml:lang="en">Powershell</source>
+        <target state="translated">PowerShell</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.powershellDescription">
+        <source xml:lang="en">Write and execute PowerShell scripts using Azure Data Studio's rich query editor</source>
+        <target state="translated">使用 Azure Data Studio 的豐富查詢編輯器來寫入及執行 PowerShell 指令碼</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualization">
+        <source xml:lang="en">Data Virtualization</source>
+        <target state="translated">資料虛擬化</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.dataVirtualizationDescription">
+        <source xml:lang="en">Virtualize data with SQL Server 2019 and create external tables using interactive wizards</source>
+        <target state="translated">使用 SQL Server 2019 將資料虛擬化，並使用互動式精靈建立外部資料表</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQL">
+        <source xml:lang="en">PostgreSQL</source>
+        <target state="translated">PostgreSQL</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.PostgreSQLDescription">
+        <source xml:lang="en">Connect, query, and manage Postgres databases with Azure Data Studio</source>
+        <target state="translated">使用 Azure Data Studio 進行連線、查詢及管理 Postgres 資料庫</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackAlreadyInstalled">
+        <source xml:lang="en">Support for {0} is already installed.</source>
+        <target state="translated">支援功能{0}已被安裝。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.willReloadAfterInstallingExtensionPack">
+        <source xml:lang="en">The window will reload after installing additional support for {0}.</source>
+        <target state="translated">{0} 的其他支援安裝完成後，將會重新載入此視窗。</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installingExtensionPack">
+        <source xml:lang="en">Installing additional support for {0}...</source>
+        <target state="translated">正在安裝 {0} 的其他支援...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionPackNotFound">
+        <source xml:lang="en">Support for {0} with id {1} could not be found.</source>
+        <target state="translated">找不到ID為{1}的{0}支援功能.</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">新增連線</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">新增查詢</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">新增筆記本</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deployServer">
+        <source xml:lang="en">Deploy a server</source>
+        <target state="translated">部署伺服器</target>
+      </trans-unit>
+      <trans-unit id="welcome.title">
+        <source xml:lang="en">Welcome</source>
+        <target state="translated">歡迎使用</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.new">
+        <source xml:lang="en">New</source>
+        <target state="translated">新增</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.open">
+        <source xml:lang="en">Open…</source>
+        <target state="translated">開啟…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFile">
+        <source xml:lang="en">Open file…</source>
+        <target state="translated">開啟檔案…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolder">
+        <source xml:lang="en">Open folder…</source>
+        <target state="translated">開啟資料夾…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.startTour">
+        <source xml:lang="en">Start Tour</source>
+        <target state="translated">開始導覽</target>
+      </trans-unit>
+      <trans-unit id="closeTourBar">
+        <source xml:lang="en">Close quick tour bar</source>
+        <target state="translated">關閉快速導覽列</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.TakeATour">
+        <source xml:lang="en">Would you like to take a quick tour of Azure Data Studio?</source>
+        <target state="translated">要進行 Azure Data Studio 的快速導覽嗎?</target>
+      </trans-unit>
+      <trans-unit id="WelcomePage.welcome">
+        <source xml:lang="en">Welcome!</source>
+        <target state="translated">歡迎使用!</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFolderWithPath">
+        <source xml:lang="en">Open folder {0} with path {1}</source>
+        <target state="translated">透過路徑 {1} 開啟資料夾 {0}</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.install">
+        <source xml:lang="en">Install</source>
+        <target state="translated">安裝</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installKeymap">
+        <source xml:lang="en">Install {0} keymap</source>
+        <target state="translated">安裝 {0} 鍵盤對應</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installExtensionPack">
+        <source xml:lang="en">Install additional support for {0}</source>
+        <target state="translated">安裝 {0} 的其他支援</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installed">
+        <source xml:lang="en">Installed</source>
+        <target state="translated">已安裝</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedKeymap">
+        <source xml:lang="en">{0} keymap is already installed</source>
+        <target state="translated">已安裝 {0} 按鍵對應</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.installedExtensionPack">
+        <source xml:lang="en">{0} support is already installed</source>
+        <target state="translated">已安裝 {0} 支援</target>
+      </trans-unit>
+      <trans-unit id="ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source xml:lang="en">Details</source>
+        <target state="translated">詳細資料</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.background">
+        <source xml:lang="en">Background color for the Welcome page.</source>
+        <target state="translated">歡迎頁面的背景色彩。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="welcomePage.azdata">
+        <source xml:lang="en">Azure Data Studio</source>
+        <target state="translated">Azure Data Studio</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.start">
+        <source xml:lang="en">Start</source>
+        <target state="translated">開始</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newConnection">
+        <source xml:lang="en">New connection</source>
+        <target state="translated">新增連線</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newQuery">
+        <source xml:lang="en">New query</source>
+        <target state="translated">新增查詢</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newNotebook">
+        <source xml:lang="en">New notebook</source>
+        <target state="translated">新增筆記本</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileMac">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">開啟檔案</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.openFileLinuxPC">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">開啟檔案</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.deploy">
+        <source xml:lang="en">Deploy</source>
+        <target state="translated">部署</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.newDeployment">
+        <source xml:lang="en">New Deployment…</source>
+        <target state="translated">新增部署…</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.recent">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">最近使用</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.moreRecent">
+        <source xml:lang="en">More...</source>
+        <target state="translated">更多...</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.noRecentFolders">
+        <source xml:lang="en">No recent folders</source>
+        <target state="translated">沒有最近使用的資料夾</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.help">
+        <source xml:lang="en">Help</source>
+        <target state="translated">說明</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gettingStarted">
+        <source xml:lang="en">Getting started</source>
+        <target state="translated">使用者入門</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.productDocumentation">
+        <source xml:lang="en">Documentation</source>
+        <target state="translated">文件</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.reportIssue">
+        <source xml:lang="en">Report issue or feature request</source>
+        <target state="translated">回報問題或功能要求</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.gitHubRepository">
+        <source xml:lang="en">GitHub repository</source>
+        <target state="translated">GitHub 存放庫</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.releaseNotes">
+        <source xml:lang="en">Release notes</source>
+        <target state="translated">版本資訊</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showOnStartup">
+        <source xml:lang="en">Show welcome page on startup</source>
+        <target state="translated">啟動時顯示歡迎頁面</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.customize">
+        <source xml:lang="en">Customize</source>
+        <target state="translated">自訂</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensions">
+        <source xml:lang="en">Extensions</source>
+        <target state="translated">延伸模組</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.extensionDescription">
+        <source xml:lang="en">Download extensions that you need, including the SQL Server Admin pack and more</source>
+        <target state="translated">下載所需延伸模組，包括 SQL Server 系統管理員套件等</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcut">
+        <source xml:lang="en">Keyboard Shortcuts</source>
+        <target state="translated">鍵盤快速鍵</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.keyboardShortcutDescription">
+        <source xml:lang="en">Find your favorite commands and customize them</source>
+        <target state="translated">尋找您最愛的命令並予加自訂</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorTheme">
+        <source xml:lang="en">Color theme</source>
+        <target state="translated">色彩佈景主題</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.colorThemeDescription">
+        <source xml:lang="en">Make the editor and your code look the way you love</source>
+        <target state="translated">將編輯器和您的程式碼設定成您喜愛的外觀</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.learn">
+        <source xml:lang="en">Learn</source>
+        <target state="translated">了解</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommands">
+        <source xml:lang="en">Find and run all commands</source>
+        <target state="translated">尋找及執行所有命令</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.showCommandsDescription">
+        <source xml:lang="en">Rapidly access and search commands from the Command Palette ({0})</source>
+        <target state="translated">從命令選擇區快速存取及搜尋命令 ({0})</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlog">
+        <source xml:lang="en">Discover what's new in the latest release</source>
+        <target state="translated">探索最新版本中的新功能</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.azdataBlogDescription">
+        <source xml:lang="en">New monthly blog posts each month showcasing our new features</source>
+        <target state="translated">展示新功能的新每月部落格文章</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitter">
+        <source xml:lang="en">Follow us on Twitter</source>
+        <target state="translated">追蹤我們的 Twitter</target>
+      </trans-unit>
+      <trans-unit id="welcomePage.followTwitterDescription">
+        <source xml:lang="en">Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers.</source>
+        <target state="translated">掌握社群如何使用 Azure Data Studio 的最新消息，並可直接與工程師對話。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="accountExplorer.name">
+        <source xml:lang="en">Accounts</source>
+        <target state="translated">帳戶</target>
+      </trans-unit>
+      <trans-unit id="linkedAccounts">
+        <source xml:lang="en">Linked accounts</source>
+        <target state="translated">連結的帳戶</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">關閉</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noAccountLabel">
+        <source xml:lang="en">There is no linked account. Please add an account.</source>
+        <target state="translated">沒有任何已連結帳戶。請新增帳戶。</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.addConnection">
+        <source xml:lang="en">Add an account</source>
+        <target state="translated">新增帳戶</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.noCloudsRegistered">
+        <source xml:lang="en">You have no clouds enabled. Go to Settings -&gt; Search Azure Account Configuration -&gt; Enable at least one cloud</source>
+        <target state="translated">您未啟用任何雲端。前往 [設定] -&gt; [搜尋 Azure 帳戶組態] -&gt; 啟用至少一個雲端</target>
+      </trans-unit>
+      <trans-unit id="accountDialog.didNotPickAuthProvider">
+        <source xml:lang="en">You didn't select any authentication provider. Please try again.</source>
+        <target state="translated">您未選取任何驗證提供者。請再試一次。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="accountDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">新增帳戶時發生錯誤</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountListRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="refreshCredentials">
+        <source xml:lang="en">You need to refresh the credentials for this account.</source>
+        <target state="translated">您需要重新整理此帳戶的登入資訊。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountManagementService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="accountManagementService.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">關閉</target>
+      </trans-unit>
+      <trans-unit id="loggingIn">
+        <source xml:lang="en">Adding account...</source>
+        <target state="translated">正在新增帳戶...</target>
+      </trans-unit>
+      <trans-unit id="refreshFailed">
+        <source xml:lang="en">Refresh account was canceled by the user</source>
+        <target state="translated">使用者已取消重新整理帳戶</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/accountPickerImpl" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="azureAccount">
+        <source xml:lang="en">Azure account</source>
+        <target state="translated">Azure 帳戶</target>
+      </trans-unit>
+      <trans-unit id="azureTenant">
+        <source xml:lang="en">Azure tenant</source>
+        <target state="translated">Azure 租用戶</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="copyAndOpen">
+        <source xml:lang="en">Copy &amp; Open</source>
+        <target state="translated">複製並開啟</target>
+      </trans-unit>
+      <trans-unit id="oauthDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="userCode">
+        <source xml:lang="en">User code</source>
+        <target state="translated">使用者代碼</target>
+      </trans-unit>
+      <trans-unit id="website">
+        <source xml:lang="en">Website</source>
+        <target state="translated">網站</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/accountManagement/browser/autoOAuthDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="oauthFlyoutIsAlreadyOpen">
+        <source xml:lang="en">Cannot start auto OAuth. An auto OAuth is already in progress.</source>
+        <target state="translated">無法啟動自動 OAuth。自動 OAuth 已在進行中。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/admin/common/adminService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="adminService.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with adminservice</source>
+        <target state="translated">必需連線以便與 adminservice 互動</target>
+      </trans-unit>
+      <trans-unit id="adminService.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">未註冊處理常式</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/assessment/common/assessmentService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="asmt.providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with Assessment Service</source>
+        <target state="translated">需要連線才能與評定服務互動</target>
+      </trans-unit>
+      <trans-unit id="asmt.noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">未註冊任何處理常式</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/advancedPropertiesController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectionAdvancedProperties">
+        <source xml:lang="en">Advanced Properties</source>
+        <target state="translated">進階屬性</target>
+      </trans-unit>
+      <trans-unit id="advancedProperties.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">捨棄</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/cmsConnectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="serverDescription">
+        <source xml:lang="en">Server Description (optional)</source>
+        <target state="translated">伺服器描述 (選用)</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="ClearRecentlyUsedLabel">
+        <source xml:lang="en">Clear List</source>
+        <target state="translated">清除清單</target>
+      </trans-unit>
+      <trans-unit id="ClearedRecentConnections">
+        <source xml:lang="en">Recent connections list cleared</source>
+        <target state="translated">最近的連線清單已清除</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="clearRecentConnectionMessage">
+        <source xml:lang="en">Are you sure you want to delete all the connections from the list?</source>
+        <target state="translated">您確定要刪除清單中的所有連線嗎?</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="delete">
+        <source xml:lang="en">Delete</source>
+        <target state="translated">刪除</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.GetCurrentConnectionString">
+        <source xml:lang="en">Get Current Connection String</source>
+        <target state="translated">取得目前的連接字串</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.connectionString">
+        <source xml:lang="en">Connection string not available</source>
+        <target state="translated">連接字串無法使用</target>
+      </trans-unit>
+      <trans-unit id="connectionAction.noConnection">
+        <source xml:lang="en">No active connection available</source>
+        <target state="translated">沒有可用的有效連線</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionBrowseTab" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectionDialog.browser">
+        <source xml:lang="en">Browse</source>
+        <target state="translated">瀏覽</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterPlaceHolder">
+        <source xml:lang="en">Type here to filter the list</source>
+        <target state="translated">在此鍵入以篩選清單</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterInputTitle">
+        <source xml:lang="en">Filter connections</source>
+        <target state="translated">篩選連線</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.ApplyingFilter">
+        <source xml:lang="en">Applying filter</source>
+        <target state="translated">正在套用篩選</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.RemovingFilter">
+        <source xml:lang="en">Removing filter</source>
+        <target state="translated">正在移除篩選</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterApplied">
+        <source xml:lang="en">Filter applied</source>
+        <target state="translated">已套用篩選</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.FilterRemoved">
+        <source xml:lang="en">Filter removed</source>
+        <target state="translated">已移除篩選</target>
+      </trans-unit>
+      <trans-unit id="savedConnections">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">已儲存的連線</target>
+      </trans-unit>
+      <trans-unit id="savedConnection">
+        <source xml:lang="en">Saved Connections</source>
+        <target state="translated">已儲存的連線</target>
+      </trans-unit>
+      <trans-unit id="connectionBrowserTree">
+        <source xml:lang="en">Connection Browser Tree</source>
+        <target state="translated">連線瀏覽器樹狀結構</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectionError">
+        <source xml:lang="en">Connection error</source>
+        <target state="translated">連線錯誤</target>
+      </trans-unit>
+      <trans-unit id="kerberosErrorStart">
+        <source xml:lang="en">Connection failed due to Kerberos error.</source>
+        <target state="translated">因為 Kerberos 錯誤導致連線失敗。</target>
+      </trans-unit>
+      <trans-unit id="kerberosHelpLink">
+        <source xml:lang="en">Help configuring Kerberos is available at {0}</source>
+        <target state="translated">您可於 {0} 取得設定 Kerberos 的說明</target>
+      </trans-unit>
+      <trans-unit id="kerberosKinit">
+        <source xml:lang="en">If you have previously connected you may need to re-run kinit.</source>
+        <target state="translated">如果您之前曾連線，則可能需要重新執行 kinit。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionDialogWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connection">
+        <source xml:lang="en">Connection</source>
+        <target state="translated">連線</target>
+      </trans-unit>
+      <trans-unit id="connecting">
+        <source xml:lang="en">Connecting</source>
+        <target state="translated">正在連線</target>
+      </trans-unit>
+      <trans-unit id="connectType">
+        <source xml:lang="en">Connection type</source>
+        <target state="translated">連線類型</target>
+      </trans-unit>
+      <trans-unit id="recentConnectionTitle">
+        <source xml:lang="en">Recent</source>
+        <target state="translated">最近</target>
+      </trans-unit>
+      <trans-unit id="connectionDetailsTitle">
+        <source xml:lang="en">Connection Details</source>
+        <target state="translated">連線詳細資料</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.connect">
+        <source xml:lang="en">Connect</source>
+        <target state="translated">連線</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="connectionDialog.recentConnections">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">最近的連線</target>
+      </trans-unit>
+      <trans-unit id="noRecentConnections">
+        <source xml:lang="en">No recent connection</source>
+        <target state="translated">沒有最近使用的連線</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionManagementService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connection.noAzureAccount">
+        <source xml:lang="en">Failed to get Azure account token for connection</source>
+        <target state="translated">無法取得連線的 Azure 帳戶權杖</target>
+      </trans-unit>
+      <trans-unit id="connectionNotAcceptedError">
+        <source xml:lang="en">Connection Not Accepted</source>
+        <target state="translated">連線未被接受</target>
+      </trans-unit>
+      <trans-unit id="connectionService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="connectionService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="cancelConnectionConfirmation">
+        <source xml:lang="en">Are you sure you want to cancel this connection?</source>
+        <target state="translated">您確定要取消此連線嗎?</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/connectionWidget" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectionWidget.AddAzureAccount">
+        <source xml:lang="en">Add an account...</source>
+        <target state="translated">新增帳戶...</target>
+      </trans-unit>
+      <trans-unit id="defaultDatabaseOption">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;預設&gt;</target>
+      </trans-unit>
+      <trans-unit id="loadingDatabaseOption">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">正在載入...</target>
+      </trans-unit>
+      <trans-unit id="serverGroup">
+        <source xml:lang="en">Server group</source>
+        <target state="translated">伺服器群組</target>
+      </trans-unit>
+      <trans-unit id="defaultServerGroup">
+        <source xml:lang="en">&lt;Default&gt;</source>
+        <target state="translated">&lt;預設&gt;</target>
+      </trans-unit>
+      <trans-unit id="addNewServerGroup">
+        <source xml:lang="en">Add new group...</source>
+        <target state="translated">新增群組...</target>
+      </trans-unit>
+      <trans-unit id="noneServerGroup">
+        <source xml:lang="en">&lt;Do not save&gt;</source>
+        <target state="translated">&lt;不要儲存&gt;</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.missingRequireField">
+        <source xml:lang="en">{0} is required.</source>
+        <target state="translated">{0} 為必要項。</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.fieldWillBeTrimmed">
+        <source xml:lang="en">{0} will be trimmed.</source>
+        <target state="translated">{0} 將受到修剪。</target>
+      </trans-unit>
+      <trans-unit id="rememberPassword">
+        <source xml:lang="en">Remember password</source>
+        <target state="translated">記住密碼</target>
+      </trans-unit>
+      <trans-unit id="connection.azureAccountDropdownLabel">
+        <source xml:lang="en">Account</source>
+        <target state="translated">帳戶</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.refreshAzureCredentials">
+        <source xml:lang="en">Refresh account credentials</source>
+        <target state="translated">重新整理帳戶登入資訊</target>
+      </trans-unit>
+      <trans-unit id="connection.azureTenantDropdownLabel">
+        <source xml:lang="en">Azure AD tenant</source>
+        <target state="translated">Azure AD 租用戶</target>
+      </trans-unit>
+      <trans-unit id="connectionName">
+        <source xml:lang="en">Name (optional)</source>
+        <target state="translated">名稱 (選用)</target>
+      </trans-unit>
+      <trans-unit id="advanced">
+        <source xml:lang="en">Advanced...</source>
+        <target state="translated">進階...</target>
+      </trans-unit>
+      <trans-unit id="connectionWidget.invalidAzureAccount">
+        <source xml:lang="en">You must select an account</source>
+        <target state="translated">您必須選取帳戶</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/connection/browser/localizedConstants" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="onDidConnectMessage">
+        <source xml:lang="en">Connected to</source>
+        <target state="translated">已連線到</target>
+      </trans-unit>
+      <trans-unit id="onDidDisconnectMessage">
+        <source xml:lang="en">Disconnected</source>
+        <target state="translated">已中斷連線</target>
+      </trans-unit>
+      <trans-unit id="unsavedGroupLabel">
+        <source xml:lang="en">Unsaved Connections</source>
+        <target state="translated">未儲存的連線</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="newDashboardTab.openDashboardExtensions">
+        <source xml:lang="en">Open dashboard extensions</source>
+        <target state="translated">開啟儀表板延伸模組</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="newDashboardTab.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="newdashboardTabDialog.noExtensionLabel">
+        <source xml:lang="en">No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.</source>
+        <target state="translated">目前沒有安裝任何儀表板延伸模組。請前往延伸模組能管理員探索建議的延伸模組。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/browser/dialogPane" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="wizardPageNumberDisplayText">
+        <source xml:lang="en">Step {0}</source>
+        <target state="translated">步驟 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/dialog/common/dialogTypes" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="dialogModalDoneButtonLabel">
+        <source xml:lang="en">Done</source>
+        <target state="translated">完成</target>
+      </trans-unit>
+      <trans-unit id="dialogModalCancelButtonLabel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/editData/common/editQueryRunner" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="query.initEditExecutionFailed">
+        <source xml:lang="en">Initialize edit data session failed: </source>
+        <target state="translated">初始化編輯資料工作階段失敗:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="errorMessageDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.close">
+        <source xml:lang="en">Close</source>
+        <target state="translated">關閉</target>
+      </trans-unit>
+      <trans-unit id="errorMessageDialog.action">
+        <source xml:lang="en">Action</source>
+        <target state="translated">動作</target>
+      </trans-unit>
+      <trans-unit id="copyDetails">
+        <source xml:lang="en">Copy details</source>
+        <target state="translated">複製詳細資訊</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/errorMessage/browser/errorMessageService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="error">
+        <source xml:lang="en">Error</source>
+        <target state="translated">錯誤</target>
+      </trans-unit>
+      <trans-unit id="warning">
+        <source xml:lang="en">Warning</source>
+        <target state="translated">警告</target>
+      </trans-unit>
+      <trans-unit id="info">
+        <source xml:lang="en">Info</source>
+        <target state="translated">資訊</target>
+      </trans-unit>
+      <trans-unit id="ignore">
+        <source xml:lang="en">Ignore</source>
+        <target state="translated">忽略</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="filebrowser.filepath">
+        <source xml:lang="en">Selected path</source>
+        <target state="translated">選擇的路徑</target>
+      </trans-unit>
+      <trans-unit id="fileFilter">
+        <source xml:lang="en">Files of type</source>
+        <target state="translated">檔案類型</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="fileBrowser.discard">
+        <source xml:lang="en">Discard</source>
+        <target state="translated">捨棄</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="filebrowser.selectFile">
+        <source xml:lang="en">Select a file</source>
+        <target state="translated">選擇檔案</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/browser/fileBrowserTreeView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="fileBrowser.regTreeAriaLabel">
+        <source xml:lang="en">File browser tree</source>
+        <note>FileBrowserTree</note>
+        <target state="translated">樹狀結構檔案瀏覽器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="fileBrowserErrorMessage">
+        <source xml:lang="en">An error occured while loading the file browser.</source>
+        <target state="translated">載入檔案瀏覽器時發生錯誤。</target>
+      </trans-unit>
+      <trans-unit id="fileBrowserErrorDialogTitle">
+        <source xml:lang="en">File browser error</source>
+        <target state="translated">檔案瀏覽器錯誤</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="allFiles">
+        <source xml:lang="en">All files</source>
+        <target state="translated">所有檔案</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightDialogActions" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="workbench.action.insights.copySelection">
+        <source xml:lang="en">Copy Cell</source>
+        <target state="translated">複製資料格</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="insightsInputError">
+        <source xml:lang="en">No Connection Profile was passed to insights flyout</source>
+        <target state="translated">沒有傳遞給見解彈出式視窗的連線設定</target>
+      </trans-unit>
+      <trans-unit id="insightsError">
+        <source xml:lang="en">Insights error</source>
+        <target state="translated">見解錯誤</target>
+      </trans-unit>
+      <trans-unit id="insightsFileError">
+        <source xml:lang="en">There was an error reading the query file: </source>
+        <target state="translated">讀取查詢檔案時發生錯誤:</target>
+      </trans-unit>
+      <trans-unit id="insightsConfigError">
+        <source xml:lang="en">There was an error parsing the insight config; could not find query array/string or queryfile</source>
+        <target state="translated">解析見解設定時發生錯誤。找不到查詢陣列/字串或 queryfile</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/browser/insightsDialogView" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="insights.item">
+        <source xml:lang="en">Item</source>
+        <target state="translated">項目</target>
+      </trans-unit>
+      <trans-unit id="insights.value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="insightsDetailView.name">
+        <source xml:lang="en">Insight Details</source>
+        <target state="translated">見解詳細資料</target>
+      </trans-unit>
+      <trans-unit id="property">
+        <source xml:lang="en">Property</source>
+        <target state="translated">屬性</target>
+      </trans-unit>
+      <trans-unit id="value">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="InsightsDialogTitle">
+        <source xml:lang="en">Insights</source>
+        <target state="translated">見解</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.items">
+        <source xml:lang="en">Items</source>
+        <target state="translated">項目</target>
+      </trans-unit>
+      <trans-unit id="insights.dialog.itemDetails">
+        <source xml:lang="en">Item Details</source>
+        <target state="translated">項目詳細資訊</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/insights/common/insightsUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="insightsDidNotFindResolvedFile">
+        <source xml:lang="en">Could not find query file at any of the following paths :
+ {0}</source>
+        <target state="translated">無法在以下任一路徑找到查詢檔案 :
+ {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/browser/jobManagementUtilities" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="agentUtilities.failed">
+        <source xml:lang="en">Failed</source>
+        <target state="translated">失敗</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.succeeded">
+        <source xml:lang="en">Succeeded</source>
+        <target state="translated">已成功</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.retry">
+        <source xml:lang="en">Retry</source>
+        <target state="translated">重試</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.canceled">
+        <source xml:lang="en">Cancelled</source>
+        <target state="translated">已取消</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.inProgress">
+        <source xml:lang="en">In Progress</source>
+        <target state="translated">正在進行</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.statusUnknown">
+        <source xml:lang="en">Status Unknown</source>
+        <target state="translated">狀態未知</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.executing">
+        <source xml:lang="en">Executing</source>
+        <target state="translated">正在執行</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.waitingForThread">
+        <source xml:lang="en">Waiting for Thread</source>
+        <target state="translated">正在等候執行緒</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.betweenRetries">
+        <source xml:lang="en">Between Retries</source>
+        <target state="translated">正在重試</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.idle">
+        <source xml:lang="en">Idle</source>
+        <target state="translated">閒置</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.suspended">
+        <source xml:lang="en">Suspended</source>
+        <target state="translated">暫止</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.obsolete">
+        <source xml:lang="en">[Obsolete]</source>
+        <target state="translated">[已淘汰]</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.notScheduled">
+        <source xml:lang="en">Not Scheduled</source>
+        <target state="translated">未排程</target>
+      </trans-unit>
+      <trans-unit id="agentUtilities.neverRun">
+        <source xml:lang="en">Never Run</source>
+        <target state="translated">從未執行</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/jobManagement/common/jobManagementService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="providerIdNotValidError">
+        <source xml:lang="en">Connection is required in order to interact with JobManagementService</source>
+        <target state="translated">需要連線才能與 JobManagementService 互動</target>
+      </trans-unit>
+      <trans-unit id="noHandlerRegistered">
+        <source xml:lang="en">No Handler Registered</source>
+        <target state="translated">未註冊任何處理常式</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/interfaces" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="sqlKernel">
+        <source xml:lang="en">SQL</source>
+        <target state="translated">SQL</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/cell" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="runCellCancelled">
@@ -7256,6 +6910,22 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
+  <file original="src/sql/workbench/services/notebook/browser/models/clientSession" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="clientSession.unknownError">
+        <source xml:lang="en">An error occurred while starting the notebook session</source>
+        <target state="translated">啟動筆記本工作階段時發生錯誤</target>
+      </trans-unit>
+      <trans-unit id="ServerNotStarted">
+        <source xml:lang="en">Server did not start for unknown reason</source>
+        <target state="translated">伺服器因為不明原因而未啟動</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Kernel {0} was not found. The default kernel will be used instead.</source>
+        <target state="translated">找不到核心 {0}。會改用預設核心。</target>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/sql/workbench/services/notebook/browser/models/notebookContexts" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
       <trans-unit id="selectConnection">
@@ -7268,11 +6938,738 @@ Error: {1}</source>
       </trans-unit>
     </body>
   </file>
-  <file original="src/sql/workbench/browser/parts/editor/editorStatusModeSelect" source-language="en" datatype="plaintext" target-language="zh-Hant">
+  <file original="src/sql/workbench/services/notebook/browser/models/notebookModel" source-language="en" datatype="plaintext" target-language="zh-Hant">
     <body>
-      <trans-unit id="languageChangeUnsupported">
-        <source xml:lang="en">Changing editor types on unsaved files is unsupported</source>
-        <target state="translated">無法變更尚未儲存之檔案的編輯器類型</target>
+      <trans-unit id="injectedParametersMsg">
+        <source xml:lang="en"># Injected-Parameters
+</source>
+        <target state="translated"># 個插入的參數
+</target>
+      </trans-unit>
+      <trans-unit id="kernelRequiresConnection">
+        <source xml:lang="en">Please select a connection to run cells for this kernel</source>
+        <target state="translated">請選取要為此核心執行資料格的連線</target>
+      </trans-unit>
+      <trans-unit id="deleteCellFailed">
+        <source xml:lang="en">Failed to delete cell.</source>
+        <target state="translated">無法刪除資料格。</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailedRetry">
+        <source xml:lang="en">Failed to change kernel. Kernel {0} will be used. Error was: {1}</source>
+        <target state="translated">無法變更核心。將會使用核心 {0}。錯誤為: {1}</target>
+      </trans-unit>
+      <trans-unit id="changeKernelFailed">
+        <source xml:lang="en">Failed to change kernel due to error: {0}</source>
+        <target state="translated">因為錯誤所以無法變更核心: {0}</target>
+      </trans-unit>
+      <trans-unit id="changeContextFailed">
+        <source xml:lang="en">Changing context failed: {0}</source>
+        <target state="translated">無法變更內容: {0}</target>
+      </trans-unit>
+      <trans-unit id="startSessionFailed">
+        <source xml:lang="en">Could not start session: {0}</source>
+        <target state="translated">無法啟動工作階段: {0}</target>
+      </trans-unit>
+      <trans-unit id="shutdownClientSessionError">
+        <source xml:lang="en">A client session error occurred when closing the notebook: {0}</source>
+        <target state="translated">關閉筆記本時發生用戶端工作階段錯誤: {0}</target>
+      </trans-unit>
+      <trans-unit id="ProviderNoManager">
+        <source xml:lang="en">Can't find notebook manager for provider {0}</source>
+        <target state="translated">找不到提供者 {0} 的筆記本管理員</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookServiceImpl" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebookUriNotDefined">
+        <source xml:lang="en">No URI was passed when creating a notebook manager</source>
+        <target state="translated">建立筆記本管理員時未傳遞任何 URI</target>
+      </trans-unit>
+      <trans-unit id="notebookServiceNoProvider">
+        <source xml:lang="en">Notebook provider does not exist</source>
+        <target state="translated">Notebook 提供者不存在</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/notebookViews/notebookViewModel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebookView.nameTaken">
+        <source xml:lang="en">A view with the name {0} already exists in this notebook.</source>
+        <target state="translated">此筆記本中已有名稱為 {0} 的檢視。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/browser/sql/sqlSessionManager" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="sqlKernelError">
+        <source xml:lang="en">SQL kernel error</source>
+        <target state="translated">SQL 核心錯誤</target>
+      </trans-unit>
+      <trans-unit id="connectionRequired">
+        <source xml:lang="en">A connection must be chosen to run notebook cells</source>
+        <target state="translated">必須選擇連線來執行筆記本資料格</target>
+      </trans-unit>
+      <trans-unit id="sqlMaxRowsDisplayed">
+        <source xml:lang="en">Displaying Top {0} rows.</source>
+        <target state="translated">目前顯示前 {0} 列。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/contracts" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="notebook.richTextEditMode">
+        <source xml:lang="en">Rich Text</source>
+        <target state="translated">RTF 文字</target>
+      </trans-unit>
+      <trans-unit id="notebook.splitViewEditMode">
+        <source xml:lang="en">Split View</source>
+        <target state="translated">分割檢視</target>
+      </trans-unit>
+      <trans-unit id="notebook.markdownEditMode">
+        <source xml:lang="en">Markdown</source>
+        <target state="translated">Markdown</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/localContentManager" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="nbformatNotRecognized">
+        <source xml:lang="en">nbformat v{0}.{1} not recognized</source>
+        <target state="translated">無法識別 nbformat v{0}.{1}</target>
+      </trans-unit>
+      <trans-unit id="nbNotSupported">
+        <source xml:lang="en">This file does not have a valid notebook format</source>
+        <target state="translated">檔案不具備有效的筆記本格式</target>
+      </trans-unit>
+      <trans-unit id="unknownCellType">
+        <source xml:lang="en">Cell type {0} unknown</source>
+        <target state="translated">資料格類型 {0} 不明</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutput">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">無法識別輸出類型 {0}</target>
+      </trans-unit>
+      <trans-unit id="invalidMimeData">
+        <source xml:lang="en">Data for {0} is expected to be a string or an Array of strings</source>
+        <target state="translated">{0} 的資料應為字串或字串的陣列</target>
+      </trans-unit>
+      <trans-unit id="unrecognizedOutputType">
+        <source xml:lang="en">Output type {0} not recognized</source>
+        <target state="translated">無法識別輸出類型 {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/notebook/common/notebookRegistry" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="carbon.extension.contributes.notebook.provider">
+        <source xml:lang="en">Identifier of the notebook provider.</source>
+        <target state="translated">筆記本提供者的識別碼。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.fileExtensions">
+        <source xml:lang="en">What file extensions should be registered to this notebook provider</source>
+        <target state="translated">應向此筆記本提供者註冊的檔案副檔名</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.standardKernels">
+        <source xml:lang="en">What kernels should be standard with this notebook provider</source>
+        <target state="translated">應為此筆記本提供者之標準的核心</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.providers">
+        <source xml:lang="en">Contributes notebook providers.</source>
+        <target state="translated">提供筆記本提供者。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.magic">
+        <source xml:lang="en">Name of the cell magic, such as '%%sql'.</source>
+        <target state="translated">資料格 magic 的名稱，例如 '%%sql'。</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.language">
+        <source xml:lang="en">The cell language to be used if this cell magic is included in the cell</source>
+        <target state="translated">資料格中包含此資料格 magic 時，要使用的資料格語言</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.executionTarget">
+        <source xml:lang="en">Optional execution target this magic indicates, for example Spark vs SQL</source>
+        <target state="translated">這個 magic 指示的選擇性執行目標，例如 Spark vs SQL</target>
+      </trans-unit>
+      <trans-unit id="carbon.extension.contributes.notebook.kernels">
+        <source xml:lang="en">Optional set of kernels this is valid for, e.g. python3, pyspark, sql</source>
+        <target state="translated">適用於像是 python3、pyspark、sql 等等的選擇性核心集</target>
+      </trans-unit>
+      <trans-unit id="vscode.extension.contributes.notebook.languagemagics">
+        <source xml:lang="en">Contributes notebook language.</source>
+        <target state="translated">提供筆記本語言。</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">正在載入...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/connectionTreeAction" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="connectionTree.refresh">
+        <source xml:lang="en">Refresh</source>
+        <target state="translated">重新整理</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editConnection">
+        <source xml:lang="en">Edit Connection</source>
+        <target state="translated">編輯連線</target>
+      </trans-unit>
+      <trans-unit id="DisconnectAction">
+        <source xml:lang="en">Disconnect</source>
+        <target state="translated">中斷連線</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addConnection">
+        <source xml:lang="en">New Connection</source>
+        <target state="translated">新增連線</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.addServerGroup">
+        <source xml:lang="en">New Server Group</source>
+        <target state="translated">新增伺服器群組</target>
+      </trans-unit>
+      <trans-unit id="connectionTree.editServerGroup">
+        <source xml:lang="en">Edit Server Group</source>
+        <target state="translated">編輯伺服器群組</target>
+      </trans-unit>
+      <trans-unit id="activeConnections">
+        <source xml:lang="en">Show Active Connections</source>
+        <target state="translated">顯示使用中的連線</target>
+      </trans-unit>
+      <trans-unit id="showAllConnections">
+        <source xml:lang="en">Show All Connections</source>
+        <target state="translated">顯示所有連線</target>
+      </trans-unit>
+      <trans-unit id="deleteConnection">
+        <source xml:lang="en">Delete Connection</source>
+        <target state="translated">刪除連線</target>
+      </trans-unit>
+      <trans-unit id="deleteConnectionGroup">
+        <source xml:lang="en">Delete Group</source>
+        <target state="translated">刪除群組</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="OeSessionFailedError">
+        <source xml:lang="en">Failed to create Object Explorer session</source>
+        <target state="translated">建立物件總管工作階段失敗</target>
+      </trans-unit>
+      <trans-unit id="nodeExpansionError">
+        <source xml:lang="en">Multiple errors:</source>
+        <target state="translated">多個錯誤:</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="noProviderFound">
+        <source xml:lang="en">Cannot expand as the required connection provider '{0}' was not found</source>
+        <target state="translated">因為找不到必要的連線提供者 ‘{0}’，所以無法展開</target>
+      </trans-unit>
+      <trans-unit id="loginCanceled">
+        <source xml:lang="en">User canceled</source>
+        <target state="translated">已取消使用者</target>
+      </trans-unit>
+      <trans-unit id="firewallCanceled">
+        <source xml:lang="en">Firewall dialog canceled</source>
+        <target state="translated">已取消防火牆對話方塊</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="loading">
+        <source xml:lang="en">Loading...</source>
+        <target state="translated">正在載入...</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/objectExplorer/browser/treeCreationUtils" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="treeAriaLabel">
+        <source xml:lang="en">Recent Connections</source>
+        <target state="translated">最近的連線</target>
+      </trans-unit>
+      <trans-unit id="serversAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">伺服器</target>
+      </trans-unit>
+      <trans-unit id="treeCreation.regTreeAriaLabel">
+        <source xml:lang="en">Servers</source>
+        <target state="translated">伺服器</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerColumnEditorDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="eventSort">
+        <source xml:lang="en">Sort by event</source>
+        <target state="translated">依事件排序</target>
+      </trans-unit>
+      <trans-unit id="nameColumn">
+        <source xml:lang="en">Sort by column</source>
+        <target state="translated">依資料行排序</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.profiler">
+        <source xml:lang="en">Profiler</source>
+        <target state="translated">分析工具</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="profilerColumnDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/profiler/browser/profilerFilterDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="profilerFilterDialog.clear">
+        <source xml:lang="en">Clear all</source>
+        <target state="translated">全部清除</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.apply">
+        <source xml:lang="en">Apply</source>
+        <target state="translated">套用</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.title">
+        <source xml:lang="en">Filters</source>
+        <target state="translated">篩選</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.remove">
+        <source xml:lang="en">Remove this clause</source>
+        <target state="translated">移除此子句</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.saveFilter">
+        <source xml:lang="en">Save Filter</source>
+        <target state="translated">儲存篩選</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.loadFilter">
+        <source xml:lang="en">Load Filter</source>
+        <target state="translated">載入篩選</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.addClauseText">
+        <source xml:lang="en">Add a clause</source>
+        <target state="translated">新增子句</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.fieldColumn">
+        <source xml:lang="en">Field</source>
+        <target state="translated">欄位</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.operatorColumn">
+        <source xml:lang="en">Operator</source>
+        <target state="translated">運算子</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.valueColumn">
+        <source xml:lang="en">Value</source>
+        <target state="translated">值</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNullOperator">
+        <source xml:lang="en">Is Null</source>
+        <target state="translated">為 Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.isNotNullOperator">
+        <source xml:lang="en">Is Not Null</source>
+        <target state="translated">非 Null</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.containsOperator">
+        <source xml:lang="en">Contains</source>
+        <target state="translated">包含</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notContainsOperator">
+        <source xml:lang="en">Not Contains</source>
+        <target state="translated">不包含</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.startsWithOperator">
+        <source xml:lang="en">Starts With</source>
+        <target state="translated">開頭是</target>
+      </trans-unit>
+      <trans-unit id="profilerFilterDialog.notStartsWithOperator">
+        <source xml:lang="en">Not Starts With</source>
+        <target state="translated">開頭不是</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryModelService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="commitEditFailed">
+        <source xml:lang="en">Commit row failed: </source>
+        <target state="translated">認可資料列失敗: </target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartMessage">
+        <source xml:lang="en">Started executing query at </source>
+        <target state="translated">已開始執行以下查詢:</target>
+      </trans-unit>
+      <trans-unit id="runQueryStringBatchStartMessage">
+        <source xml:lang="en">Started executing query "{0}"</source>
+        <target state="translated">已開始執行查詢 "{0}"</target>
+      </trans-unit>
+      <trans-unit id="runQueryBatchStartLine">
+        <source xml:lang="en">Line {0}</source>
+        <target state="translated">第 {0} 行</target>
+      </trans-unit>
+      <trans-unit id="msgCancelQueryFailed">
+        <source xml:lang="en">Canceling the query failed: {0}</source>
+        <target state="translated">取消查詢失敗: {0}</target>
+      </trans-unit>
+      <trans-unit id="updateCellFailed">
+        <source xml:lang="en">Update cell failed: </source>
+        <target state="translated">更新資料格失敗: </target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/queryRunner" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="query.ExecutionFailedError">
+        <source xml:lang="en">Execution failed due to an unexpected error: {0}	{1}</source>
+        <target state="translated">由於意外錯誤導致執行失敗: {0} {1}</target>
+      </trans-unit>
+      <trans-unit id="query.message.executionTime">
+        <source xml:lang="en">Total execution time: {0}</source>
+        <target state="translated">總執行時間: {0}</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQueryWithRange">
+        <source xml:lang="en">Started executing query at Line {0}</source>
+        <target state="translated">已於第 {0} 行開始執行查詢</target>
+      </trans-unit>
+      <trans-unit id="query.message.startQuery">
+        <source xml:lang="en">Started executing batch {0}</source>
+        <target state="translated">已開始執行批次 {0}</target>
+      </trans-unit>
+      <trans-unit id="elapsedBatchTime">
+        <source xml:lang="en">Batch execution time: {0}</source>
+        <target state="translated">批次執行時間: {0}</target>
+      </trans-unit>
+      <trans-unit id="copyFailed">
+        <source xml:lang="en">Copy failed with error {0}</source>
+        <target state="translated">複製失敗。錯誤: {0}</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/query/common/resultSerializer" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="msgSaveFailed">
+        <source xml:lang="en">Failed to save results. </source>
+        <target state="translated">無法儲存結果。</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileTitle">
+        <source xml:lang="en">Choose Results File</source>
+        <target state="translated">選擇結果檔案</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionCSVTitle">
+        <source xml:lang="en">CSV (Comma delimited)</source>
+        <target state="translated">CSV (以逗號分隔)</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionJSONTitle">
+        <source xml:lang="en">JSON</source>
+        <target state="translated">JSON</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionExcelTitle">
+        <source xml:lang="en">Excel Workbook</source>
+        <target state="translated">Excel 活頁簿</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionXMLTitle">
+        <source xml:lang="en">XML</source>
+        <target state="translated">XML</target>
+      </trans-unit>
+      <trans-unit id="resultsSerializer.saveAsFileExtensionTXTTitle">
+        <source xml:lang="en">Plain Text</source>
+        <target state="translated">純文字</target>
+      </trans-unit>
+      <trans-unit id="savingFile">
+        <source xml:lang="en">Saving file...</source>
+        <target state="translated">正在儲存檔案...</target>
+      </trans-unit>
+      <trans-unit id="msgSaveSucceeded">
+        <source xml:lang="en">Successfully saved results to {0}</source>
+        <target state="translated">已成功將結果儲存至 {0}</target>
+      </trans-unit>
+      <trans-unit id="openFile">
+        <source xml:lang="en">Open file</source>
+        <target state="translated">開啟檔案</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="from">
+        <source xml:lang="en">From</source>
+        <target state="translated">從</target>
+      </trans-unit>
+      <trans-unit id="to">
+        <source xml:lang="en">To</source>
+        <target state="translated">至</target>
+      </trans-unit>
+      <trans-unit id="createNewFirewallRule">
+        <source xml:lang="en">Create new firewall rule</source>
+        <target state="translated">建立新的防火牆規則</target>
+      </trans-unit>
+      <trans-unit id="firewall.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="firewall.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleDialogDescription">
+        <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
+        <target state="translated">您的用戶端 IP 位址無法存取伺服器。登錄到 Azure 帳戶並建立新的防火牆規則以啟用存取權限。</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleHelpDescription">
+        <source xml:lang="en">Learn more about firewall settings</source>
+        <target state="translated">深入了解防火牆設定</target>
+      </trans-unit>
+      <trans-unit id="filewallRule">
+        <source xml:lang="en">Firewall rule</source>
+        <target state="translated">防火牆規則</target>
+      </trans-unit>
+      <trans-unit id="addIPAddressLabel">
+        <source xml:lang="en">Add my client IP </source>
+        <target state="translated">新增我的用戶端 IP</target>
+      </trans-unit>
+      <trans-unit id="addIpRangeLabel">
+        <source xml:lang="en">Add my subnet IP range</source>
+        <target state="translated">新增我的子網路 IP 範圍</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/resourceProvider/browser/firewallRuleDialogController" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="firewallDialog.addAccountErrorTitle">
+        <source xml:lang="en">Error adding account</source>
+        <target state="translated">新增帳戶時發生錯誤</target>
+      </trans-unit>
+      <trans-unit id="firewallRuleError">
+        <source xml:lang="en">Firewall rule error</source>
+        <target state="translated">防火牆規則錯誤</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/browser/restoreDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="backupFilePath">
+        <source xml:lang="en">Backup file path</source>
+        <target state="translated">備份檔案路徑</target>
+      </trans-unit>
+      <trans-unit id="targetDatabase">
+        <source xml:lang="en">Target database</source>
+        <target state="translated">目標資料庫</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restore">
+        <source xml:lang="en">Restore</source>
+        <target state="translated">還原</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.restoreTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">還原資料庫</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">資料庫</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.backupFile">
+        <source xml:lang="en">Backup file</source>
+        <target state="translated">備份檔案</target>
+      </trans-unit>
+      <trans-unit id="RestoreDialogTitle">
+        <source xml:lang="en">Restore database</source>
+        <target state="translated">還原資料庫</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="restoreDialog.script">
+        <source xml:lang="en">Script</source>
+        <target state="translated">指令碼</target>
+      </trans-unit>
+      <trans-unit id="source">
+        <source xml:lang="en">Source</source>
+        <target state="translated">來源</target>
+      </trans-unit>
+      <trans-unit id="restoreFrom">
+        <source xml:lang="en">Restore from</source>
+        <target state="translated">還原自</target>
+      </trans-unit>
+      <trans-unit id="missingBackupFilePathError">
+        <source xml:lang="en">Backup file path is required.</source>
+        <target state="translated">需要備份檔案路徑。</target>
+      </trans-unit>
+      <trans-unit id="multipleBackupFilePath">
+        <source xml:lang="en">Please enter one or more file paths separated by commas</source>
+        <target state="translated">請輸入一或多個用逗號分隔的檔案路徑</target>
+      </trans-unit>
+      <trans-unit id="database">
+        <source xml:lang="en">Database</source>
+        <target state="translated">資料庫</target>
+      </trans-unit>
+      <trans-unit id="destination">
+        <source xml:lang="en">Destination</source>
+        <target state="translated">目的地</target>
+      </trans-unit>
+      <trans-unit id="restoreTo">
+        <source xml:lang="en">Restore to</source>
+        <target state="translated">還原到</target>
+      </trans-unit>
+      <trans-unit id="restorePlan">
+        <source xml:lang="en">Restore plan</source>
+        <target state="translated">還原計劃</target>
+      </trans-unit>
+      <trans-unit id="backupSetsToRestore">
+        <source xml:lang="en">Backup sets to restore</source>
+        <target state="translated">要還原的備份組</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileAs">
+        <source xml:lang="en">Restore database files as</source>
+        <target state="translated">將資料庫檔案還原為</target>
+      </trans-unit>
+      <trans-unit id="restoreDatabaseFileDetails">
+        <source xml:lang="en">Restore database file details</source>
+        <target state="translated">還原資料庫檔詳細資訊</target>
+      </trans-unit>
+      <trans-unit id="logicalFileName">
+        <source xml:lang="en">Logical file Name</source>
+        <target state="translated">邏輯檔案名稱</target>
+      </trans-unit>
+      <trans-unit id="fileType">
+        <source xml:lang="en">File type</source>
+        <target state="translated">檔案類型</target>
+      </trans-unit>
+      <trans-unit id="originalFileName">
+        <source xml:lang="en">Original File Name</source>
+        <target state="translated">原始檔案名稱</target>
+      </trans-unit>
+      <trans-unit id="restoreAs">
+        <source xml:lang="en">Restore as</source>
+        <target state="translated">還原為</target>
+      </trans-unit>
+      <trans-unit id="restoreOptions">
+        <source xml:lang="en">Restore options</source>
+        <target state="translated">還原選項</target>
+      </trans-unit>
+      <trans-unit id="taillogBackup">
+        <source xml:lang="en">Tail-Log backup</source>
+        <target state="translated">結尾記錄備份</target>
+      </trans-unit>
+      <trans-unit id="serverConnection">
+        <source xml:lang="en">Server connections</source>
+        <target state="translated">伺服器連線</target>
+      </trans-unit>
+      <trans-unit id="generalTitle">
+        <source xml:lang="en">General</source>
+        <target state="translated">一般</target>
+      </trans-unit>
+      <trans-unit id="filesTitle">
+        <source xml:lang="en">Files</source>
+        <target state="translated">檔案</target>
+      </trans-unit>
+      <trans-unit id="optionsTitle">
+        <source xml:lang="en">Options</source>
+        <target state="translated">選項</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/restore/common/constants" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="backup.filterBackupFiles">
+        <source xml:lang="en">Backup Files</source>
+        <target state="translated">備份檔案</target>
+      </trans-unit>
+      <trans-unit id="backup.allFiles">
+        <source xml:lang="en">All Files</source>
+        <target state="translated">所有檔案</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/browser/serverGroupDialog" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="ServerGroupsDialogTitle">
+        <source xml:lang="en">Server Groups</source>
+        <target state="translated">伺服器群組</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.ok">
+        <source xml:lang="en">OK</source>
+        <target state="translated">確定</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.cancel">
+        <source xml:lang="en">Cancel</source>
+        <target state="translated">取消</target>
+      </trans-unit>
+      <trans-unit id="connectionGroupName">
+        <source xml:lang="en">Server group name</source>
+        <target state="translated">伺服器群組名稱</target>
+      </trans-unit>
+      <trans-unit id="MissingGroupNameError">
+        <source xml:lang="en">Group name is required.</source>
+        <target state="translated">需要群組名稱。</target>
+      </trans-unit>
+      <trans-unit id="groupDescription">
+        <source xml:lang="en">Group description</source>
+        <target state="translated">群組描述</target>
+      </trans-unit>
+      <trans-unit id="groupColor">
+        <source xml:lang="en">Group color</source>
+        <target state="translated">群組色彩</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/serverGroup/common/serverGroupViewModel" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="serverGroup.addServerGroup">
+        <source xml:lang="en">Add server group</source>
+        <target state="translated">新增伺服器群組</target>
+      </trans-unit>
+      <trans-unit id="serverGroup.editServerGroup">
+        <source xml:lang="en">Edit server group</source>
+        <target state="translated">編輯伺服器群組</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/services/tasks/common/tasksService" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="InProgressWarning">
+        <source xml:lang="en">1 or more tasks are in progress. Are you sure you want to quit?</source>
+        <target state="translated">1 個或更多的工作正在進行中。是否確實要退出?</target>
+      </trans-unit>
+      <trans-unit id="taskService.yes">
+        <source xml:lang="en">Yes</source>
+        <target state="translated">是</target>
+      </trans-unit>
+      <trans-unit id="taskService.no">
+        <source xml:lang="en">No</source>
+        <target state="translated">否</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/sql/workbench/update/electron-browser/releaseNotes" source-language="en" datatype="plaintext" target-language="zh-Hant">
+    <body>
+      <trans-unit id="gettingStarted">
+        <source xml:lang="en">Get Started</source>
+        <target state="translated">開始</target>
+      </trans-unit>
+      <trans-unit id="showReleaseNotes">
+        <source xml:lang="en">Show Getting Started</source>
+        <target state="translated">顯示入門指南</target>
+      </trans-unit>
+      <trans-unit id="miGettingStarted">
+        <source xml:lang="en">Getting &amp;&amp;Started</source>
+        <note>&amp;&amp; denotes a mnemonic</note>
+        <target state="translated">開始使用(&amp;&amp;S)</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
This PR adds translated XLF updates to the existing extensions and core SQL strings for our current release's langpacks. This update finally adds working localization to previously non-webpacked extensions that we have aside from import.

There's an issue on the loc team side where LCL files (and therefore localized XLF files) weren't being generated for our new extension English XLF files (the scanning process for detecting file changes was unable to recognize these new files despite the XLF files being recognized as checked in). Additionally the output folder structure changes in LocProject.json is not being recognized as well. This issue has been filed to the developers of the localization tool by @khoiph1 to be looked at.