### PR TITLE
Adding cpu count and ram size properties to getServerInfo API

### DIFF
--- a/extensions/liveshare/src/providers/connectionProvider.ts
+++ b/extensions/liveshare/src/providers/connectionProvider.ts
@@ -128,6 +128,8 @@ export class ConnectionProvider {
 						isCloud: false,
 						azureVersion: 1,
 						osVersion: '1',
+						cpuCount: 1,
+						physicalMemoryInMb: 1,
 						options: connInfo.options
 					}
 				};

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.110",
+	"version": "3.0.0-release.111",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",

--- a/extensions/notebook/src/test/common/utils.test.ts
+++ b/extensions/notebook/src/test/common/utils.test.ts
@@ -317,7 +317,9 @@ describe('Utils Tests', function () {
 			isCloud: false,
 			azureVersion: -1,
 			osVersion: '',
-			options: {}
+			options: {},
+			cpuCount: -1,
+			physicalMemoryInMb: -1
 		};
 		it('empty endpoints does not error', () => {
 			const serverInfo = Object.assign({}, baseServerInfo);

--- a/extensions/notebook/src/test/model/sessionManager.test.ts
+++ b/extensions/notebook/src/test/model/sessionManager.test.ts
@@ -288,6 +288,8 @@ describe('Jupyter Session', function (): void {
 			isCloud: false,
 			azureVersion: 0,
 			osVersion: '',
+			cpuCount: 0,
+			physicalMemoryInMb: -1,
 			options: {
 				isBigDataCluster: true
 			}

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -504,6 +504,14 @@ declare module 'azdata' {
 		 */
 		osVersion: string;
 		/**
+		 * The CPU count of the host running the server.
+		 */
+		cpuCount: number;
+		/**
+		 * The physical memory of the host running the server.
+		 */
+		physicalMemoryInMb: number;
+		/**
 		 * options for all new server properties.
 		 */
 		options: { [key: string]: any };

--- a/src/sql/workbench/contrib/dashboard/test/electron-browser/propertiesWidget.component.test.ts
+++ b/src/sql/workbench/contrib/dashboard/test/electron-browser/propertiesWidget.component.test.ts
@@ -60,6 +60,8 @@ suite('Dashboard Properties Widget Tests', () => {
 			serverEdition: undefined,
 			azureVersion: undefined,
 			osVersion: undefined,
+			cpuCount: undefined,
+			physicalMemoryInMb: undefined,
 			options: {},
 		};
 

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -1332,7 +1332,9 @@ suite('SQL ConnectionManagementService tests', () => {
 			azureVersion: 0,
 			osVersion: 'test_version',
 			options: { isBigDataCluster: 'test' },
-			isCloud: true
+			isCloud: true,
+			cpuCount: 0,
+			physicalMemoryInMb: 0
 		};
 		let uri: string = 'Editor Uri';
 		let options: IConnectionCompletionOptions = {


### PR DESCRIPTION
I have created this PR today but will merge it tomorrow after a new STS build. This PR adds additional server PR properties like cpu count and ram. 
