### PR TITLE
Fixed tabs in locProject

### DIFF
--- a/resources/xlf/LocProject.json
+++ b/resources/xlf/LocProject.json
@@ -15,19 +15,19 @@
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\arc.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\arc.xlf.lcl",
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\asde-deployment.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\asde-deployment.xlf.lcl",
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\azdata.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\azdata.xlf.lcl",
           "CopyOption": "LangIDOnPath",
@@ -39,7 +39,7 @@
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\azurehybridtoolkit.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\azurehybridtoolkit.xlf.lcl",
           "CopyOption": "LangIDOnPath",
@@ -63,7 +63,7 @@
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\data-workspace.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\data-workspace.xlf.lcl",
           "CopyOption": "LangIDOnPath",
@@ -75,13 +75,13 @@
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\kusto.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\kusto.xlf.lcl",
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\machine-learning.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\machine-learning.xlf.lcl",
           "CopyOption": "LangIDOnPath",
@@ -111,7 +111,7 @@
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\query-history.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\query-history.xlf.lcl",
           "CopyOption": "LangIDOnPath",
@@ -129,19 +129,19 @@
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\sql-assessment.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\sql-assessment.xlf.lcl",
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\sql-database-projects.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\sql-database-projects.xlf.lcl",
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\sql-migration.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\sql-migration.xlf.lcl",
           "CopyOption": "LangIDOnPath",
@@ -153,7 +153,7 @@
           "CopyOption": "LangIDOnPath",
           "OutputPath": "resources\\xlf"
         },
-    {
+		{
           "SourceFile": "resources\\xlf\\en\\xml-language-features.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\xml-language-features.xlf.lcl",
           "CopyOption": "LangIDOnPath",


### PR DESCRIPTION
There was an inconsistency in the tab spacing between new extensions that were added to locproject and the older ones, this PR fixes this issue (This may or may not be related to the issue of why these extensions aren't being recognized by the localization tool)