### PR TITLE
Add openQueryDocument API

### DIFF
--- a/extensions/machine-learning/src/prediction/predictService.ts
+++ b/extensions/machine-learning/src/prediction/predictService.ts
@@ -80,10 +80,7 @@ export class PredictService {
 				predictParams.outputColumns || [],
 				predictParams);
 		}
-		let document = await this._apiWrapper.openTextDocument({
-			language: 'sql',
-			content: query
-		});
+		const document = await azdata.queryeditor.openQueryDocument({ content: query });
 		await this._apiWrapper.executeCommand('vscode.open', document.uri);
 		await this._apiWrapper.connect(document.uri.toString(), connection.connectionId);
 		this._apiWrapper.runQuery(document.uri.toString(), undefined, false);

--- a/extensions/machine-learning/src/prediction/predictService.ts
+++ b/extensions/machine-learning/src/prediction/predictService.ts
@@ -81,7 +81,6 @@ export class PredictService {
 				predictParams);
 		}
 		const document = await azdata.queryeditor.openQueryDocument({ content: query });
-		await this._apiWrapper.executeCommand('vscode.open', document.uri);
 		await this._apiWrapper.connect(document.uri.toString(), connection.connectionId);
 		this._apiWrapper.runQuery(document.uri.toString(), undefined, false);
 		return query;

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -98,9 +98,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 			// (they're left out for perf purposes)
 			const doc = vscode.workspace.textDocuments.find(doc => doc.uri.toString() === uri.toString());
 			const result = await appContext.getService<INotebookConvertService>(Constants.NotebookConvertService).convertNotebookToSql(doc.getText());
-
-			const sqlDoc = await vscode.workspace.openTextDocument({ language: 'sql', content: result.content });
-			await vscode.commands.executeCommand('vscode.open', sqlDoc.uri);
+			await azdata.queryeditor.openQueryDocument({ content: result.content });
 		} catch (err) {
 			vscode.window.showErrorMessage(localize('mssql.errorConvertingToSQL', "An error occurred converting the Notebook document to SQL. Error : {0}", err.toString()));
 		}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -9,6 +9,19 @@ import * as vscode from 'vscode';
 
 declare module 'azdata' {
 
+	export namespace queryeditor {
+		/**
+		 * Opens an untitled text document. The editor will prompt the user for a file
+		 * path when the document is to be saved. The `options` parameter allows to
+		 * specify the *content* of the document.
+		 *
+		 * @param options Options to control how the document will be created.
+		 * @param providerId Optional provider ID this editor will be associated with. Defaults to MSSQL.
+		 * @return A promise that resolves to a [document](#QueryDocument).
+		 */
+		export function openQueryDocument(options?: { content?: string; }, providerId?: string): Thenable<QueryDocument>;
+	}
+
 	export namespace nb {
 		export interface NotebookDocument {
 			/**

--- a/src/sql/workbench/api/browser/mainThreadQueryEditor.ts
+++ b/src/sql/workbench/api/browser/mainThreadQueryEditor.ts
@@ -16,6 +16,8 @@ import { IQueryManagementService } from 'sql/workbench/services/query/common/que
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ILogService } from 'vs/platform/log/common/log';
+import { URI } from 'vs/base/common/uri';
+import { IQueryEditorService } from 'sql/workbench/services/queryEditor/common/queryEditorService';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadQueryEditor)
 export class MainThreadQueryEditor extends Disposable implements MainThreadQueryEditorShape {
@@ -29,7 +31,8 @@ export class MainThreadQueryEditor extends Disposable implements MainThreadQuery
 		@IQueryModelService private _queryModelService: IQueryModelService,
 		@IEditorService private _editorService: IEditorService,
 		@IQueryManagementService private _queryManagementService: IQueryManagementService,
-		@ILogService private _logService: ILogService
+		@ILogService private _logService: ILogService,
+		@IQueryEditorService private _queryEditorService: IQueryEditorService
 	) {
 		super();
 		if (extHostContext) {
@@ -144,5 +147,10 @@ export class MainThreadQueryEditor extends Disposable implements MainThreadQuery
 
 	public $setQueryExecutionOptions(fileUri: string, options: azdata.QueryExecutionOptions): Thenable<void> {
 		return this._queryManagementService.setQueryExecutionOptions(fileUri, options);
+	}
+
+	public async $tryCreateQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI> {
+		const queryInput = await this._queryEditorService.newSqlEditor({ initalContent: options.content }, providerId);
+		return queryInput.resource;
 	}
 }

--- a/src/sql/workbench/api/browser/mainThreadQueryEditor.ts
+++ b/src/sql/workbench/api/browser/mainThreadQueryEditor.ts
@@ -149,7 +149,7 @@ export class MainThreadQueryEditor extends Disposable implements MainThreadQuery
 		return this._queryManagementService.setQueryExecutionOptions(fileUri, options);
 	}
 
-	public async $tryCreateQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI> {
+	public async $createQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI> {
 		const queryInput = await this._queryEditorService.newSqlEditor({ initalContent: options.content }, providerId);
 		return queryInput.resource;
 	}

--- a/src/sql/workbench/api/common/extHostQueryEditor.ts
+++ b/src/sql/workbench/api/common/extHostQueryEditor.ts
@@ -79,6 +79,6 @@ export class ExtHostQueryEditor implements ExtHostQueryEditorShape {
 	}
 
 	public createQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI> {
-		return this._proxy.$tryCreateQueryDocument(options, providerId).then(data => URI.revive(data));
+		return this._proxy.$createQueryDocument(options, providerId).then(data => URI.revive(data));
 	}
 }

--- a/src/sql/workbench/api/common/extHostQueryEditor.ts
+++ b/src/sql/workbench/api/common/extHostQueryEditor.ts
@@ -9,6 +9,7 @@ import * as azdata from 'azdata';
 import { IQueryEvent } from 'sql/workbench/services/query/common/queryModel';
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { Disposable } from 'vs/workbench/api/common/extHostTypes';
+import { URI } from 'vs/base/common/uri';
 
 class ExtHostQueryDocument implements azdata.queryeditor.QueryDocument {
 	constructor(
@@ -77,4 +78,7 @@ export class ExtHostQueryEditor implements ExtHostQueryEditorShape {
 		});
 	}
 
+	public createQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI> {
+		return this._proxy.$tryCreateQueryDocument(options, providerId).then(data => URI.revive(data));
+	}
 }

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -35,6 +35,7 @@ import { IExtensionApiFactory as vsIApiFactory, createApiFactoryAndRegisterActor
 import { IExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 import { ExtHostWorkspace } from 'sql/workbench/api/common/extHostWorkspace';
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
+import { URI } from 'vs/base/common/uri';
 
 export interface IAzdataExtensionApiFactory {
 	(extension: IExtensionDescription): typeof azdata;
@@ -96,7 +97,6 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 	const extHostNotebookDocumentsAndEditors = rpcProtocol.set(SqlExtHostContext.ExtHostNotebookDocumentsAndEditors, new ExtHostNotebookDocumentsAndEditors(rpcProtocol));
 	const extHostExtensionManagement = rpcProtocol.set(SqlExtHostContext.ExtHostExtensionManagement, new ExtHostExtensionManagement(rpcProtocol));
 	const extHostWorkspace = rpcProtocol.set(SqlExtHostContext.ExtHostWorkspace, new ExtHostWorkspace(rpcProtocol));
-
 	return {
 		azdata: function (extension: IExtensionDescription): typeof azdata {
 			// namespace: connection
@@ -506,6 +506,15 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 
 				getQueryDocument(fileUri: string): Thenable<azdata.queryeditor.QueryDocument> {
 					return extHostQueryEditor.$getQueryDocument(fileUri);
+				},
+
+				openQueryDocument(options?: { content?: string; }, providerId?: string): Thenable<azdata.queryeditor.QueryDocument> {
+					let uriPromise: Thenable<URI>;
+
+					uriPromise = extHostQueryEditor.createQueryDocument(options, providerId);
+					return uriPromise.then(uri => {
+						return extHostQueryEditor.$getQueryDocument(uri.toString());
+					});
 				}
 			};
 

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -847,7 +847,7 @@ export interface MainThreadQueryEditorShape extends IDisposable {
 	$setQueryExecutionOptions(fileUri: string, options: azdata.QueryExecutionOptions): Thenable<void>;
 	$registerQueryInfoListener(handle: number): void;
 	$unregisterQueryInfoListener(handle: number): void;
-	$tryCreateQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI>;
+	$createQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI>;
 }
 
 export interface ExtHostNotebookShape {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -7,7 +7,7 @@ import {
 	createMainContextProxyIdentifier as createMainId,
 	createExtHostContextProxyIdentifier as createExtId
 } from 'vs/workbench/services/extensions/common/proxyIdentifier';
-import { UriComponents } from 'vs/base/common/uri';
+import { URI, UriComponents } from 'vs/base/common/uri';
 
 import { IDisposable } from 'vs/base/common/lifecycle';
 
@@ -847,6 +847,7 @@ export interface MainThreadQueryEditorShape extends IDisposable {
 	$setQueryExecutionOptions(fileUri: string, options: azdata.QueryExecutionOptions): Thenable<void>;
 	$registerQueryInfoListener(handle: number): void;
 	$unregisterQueryInfoListener(handle: number): void;
+	$tryCreateQueryDocument(options?: { content?: string }, providerId?: string): Promise<URI>;
 }
 
 export interface ExtHostNotebookShape {


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/16108

This should also fix https://github.com/microsoft/azuredatastudio/issues/13250

This is the same issue as the other query editor problems - setting the mode is no longer enough to result in a query editor to be opened. So to get around this I'm adding an API similar to vscode.workspace.openTextDocument to open a new query editor.

