### PR TITLE
Fix Windows WYSIWYG linking issue (switching to splitview and resolving links in WYSIWYG) 

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -7,7 +7,7 @@ import TurndownService = require('turndown');
 import { URI } from 'vs/base/common/uri';
 import * as path from 'vs/base/common/path';
 import * as turndownPluginGfm from 'sql/workbench/contrib/notebook/browser/turndownPluginGfm';
-import { invalidRelativePathRegex, replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/test/common/utils';
+import { invalidRelativePathRegex, replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 import { isWindows } from 'vs/base/common/platform';
 
 // These replacements apply only to text. Here's how it's handled from Turndown:
@@ -313,8 +313,8 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			relativePath = relativePath.replace(/\s/g, '%20');
 			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
-				// if relativePath contains improper directory format due to marked js parsing return (ex. ....\) then we need to replace it to ensure the directories are formatted properly (ex. ..\..\)
-			} else if (relativePath.match(invalidRelativePathRegex) && isWindows) {
+				// if relativePath contains improper directory format due to marked js parsing returning an invalid path (ex. ....\) then we need to replace it to ensure the directories are formatted properly (ex. ..\..\)
+			} else if (isWindows && relativePath.match(invalidRelativePathRegex)) {
 				return replaceInvalidLinkPath(relativePath);
 			} else {
 				// if the relative path does not contain ./ at the beginning, we need to add it so it's recognized as a link

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -7,7 +7,7 @@ import TurndownService = require('turndown');
 import { URI } from 'vs/base/common/uri';
 import * as path from 'vs/base/common/path';
 import * as turndownPluginGfm from 'sql/workbench/contrib/notebook/browser/turndownPluginGfm';
-import { invalidRelativePathRegex, replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
+import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 import { isWindows } from 'vs/base/common/platform';
 
 // These replacements apply only to text. Here's how it's handled from Turndown:
@@ -314,7 +314,7 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
 				// if relativePath contains improper directory format due to marked js parsing returning an invalid path (ex. ....\) then we need to replace it to ensure the directories are formatted properly (ex. ..\..\)
-			} else if (isWindows && relativePath.match(invalidRelativePathRegex)) {
+			} else if (isWindows && relativePath.startsWith('...')) {
 				return replaceInvalidLinkPath(relativePath);
 			} else {
 				// if the relative path does not contain ./ at the beginning, we need to add it so it's recognized as a link

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -313,8 +313,8 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
 				// if relativePath contains improper directory format (ex. ....\) then we need to replace it to ensure the directories are formatted properly (ex. ..\..\)
-			} else if (relativePath.match(/^(?!.*\.\\])\.\W/)) {
-				return relativePath.replace(/^(?!.*\.\\])\.\W/, '..\\');
+			} else if (relativePath.match(/\.\.(?=\.\.)/g)) {
+				return relativePath.replace(/\.\.(?=\.\.)/g, '..\\');
 			} else {
 				// if the relative path does not contain ./ at the beginning, we need to add it so it's recognized as a link
 				return `.${path.join(path.sep, relativePath)}`;

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -8,7 +8,6 @@ import { URI } from 'vs/base/common/uri';
 import * as path from 'vs/base/common/path';
 import * as turndownPluginGfm from 'sql/workbench/contrib/notebook/browser/turndownPluginGfm';
 import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
-import { isWindows } from 'vs/base/common/platform';
 
 // These replacements apply only to text. Here's how it's handled from Turndown:
 // if (node.nodeType === 3) {

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -312,6 +312,7 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			relativePath = relativePath.replace(/\s/g, '%20');
 			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
+				// if relativePath contains improper directory format (ex. ....\) then we need to replace it to ensure the directories are formatted properly (ex. ..\..\)
 			} else if (relativePath.match(/^(?!.*\.\\])\.\W/)) {
 				return relativePath.replace(/^(?!.*\.\\])\.\W/, '..\\');
 			} else {

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -312,6 +312,8 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			relativePath = relativePath.replace(/\s/g, '%20');
 			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
+			} else if (relativePath.match(/^(?!.*\.\\])\.\W/)) {
+				return relativePath.replace(/^(?!.*\.\\])\.\W/, '..\\');
 			} else {
 				// if the relative path does not contain ./ at the beginning, we need to add it so it's recognized as a link
 				return `.${path.join(path.sep, relativePath)}`;

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -311,11 +311,10 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			let relativePath = contentPath.fragment ? path.relative(notebookFolder, contentPath.fsPath).concat('#', contentPath.fragment) : path.relative(notebookFolder, contentPath.fsPath);
 			//if path contains whitespaces then it's not identified as a link
 			relativePath = relativePath.replace(/\s/g, '%20');
+			// if relativePath contains improper directory format due to marked js parsing returning an invalid path (ex. ....\) then we need to replace it to ensure the directories are formatted properly (ex. ..\..\)
+			relativePath = replaceInvalidLinkPath(relativePath);
 			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
-				// if relativePath contains improper directory format due to marked js parsing returning an invalid path (ex. ....\) then we need to replace it to ensure the directories are formatted properly (ex. ..\..\)
-			} else if (isWindows && relativePath.startsWith('...')) {
-				return replaceInvalidLinkPath(relativePath);
 			} else {
 				// if the relative path does not contain ./ at the beginning, we need to add it so it's recognized as a link
 				return `.${path.join(path.sep, relativePath)}`;

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -13,7 +13,6 @@ import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { revive } from 'vs/base/common/marshalling';
 import { ImageMimeTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { IMarkdownStringWithCellAttachments, MarkdownRenderOptionsWithCellAttachments } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
-import { isWindows } from 'vs/base/common/platform';
 import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 
 // Based off of HtmlContentRenderer

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -242,7 +242,7 @@ export class NotebookMarkdownRenderer {
 		} else if (href.slice(0, 2) === '..') {
 			if (process.platform === 'win32') {
 				// we need to format invalid href formats (ex. ....\file to ..\..\file)
-				// in order to resolve to absolute link
+				// in order to resolve to an absolute link
 				href = href.replace(/^(?!.*\.\\])\.\W/, '..\\');
 				return path.resolve(base, href);
 			} else {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -14,6 +14,7 @@ import { revive } from 'vs/base/common/marshalling';
 import { ImageMimeTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { IMarkdownStringWithCellAttachments, MarkdownRenderOptionsWithCellAttachments } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
 import { isWindows } from 'vs/base/common/platform';
+import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/test/common/utils';
 
 // Based off of HtmlContentRenderer
 export class NotebookMarkdownRenderer {
@@ -244,9 +245,8 @@ export class NotebookMarkdownRenderer {
 			if (isWindows) {
 				// we need to format invalid href formats (ex. ....\file to ..\..\file)
 				// in order to resolve to an absolute link
-				// Test that documents issue [Follow up]:
-				// 'marked js compiles relative link incorrectly'
-				href = href.replace(/\.\.(?=\.\.)/g, '..\\');
+				// Issue tracked here: https://github.com/markedjs/marked/issues/2135
+				href = replaceInvalidLinkPath(href);
 				return path.resolve(base, href);
 			} else {
 				return path.join(base + href);

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -14,7 +14,7 @@ import { revive } from 'vs/base/common/marshalling';
 import { ImageMimeTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { IMarkdownStringWithCellAttachments, MarkdownRenderOptionsWithCellAttachments } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
 import { isWindows } from 'vs/base/common/platform';
-import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/test/common/utils';
+import { replaceInvalidLinkPath } from 'sql/workbench/contrib/notebook/common/utils';
 
 // Based off of HtmlContentRenderer
 export class NotebookMarkdownRenderer {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -13,6 +13,7 @@ import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { revive } from 'vs/base/common/marshalling';
 import { ImageMimeTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { IMarkdownStringWithCellAttachments, MarkdownRenderOptionsWithCellAttachments } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
+import { isWindows } from 'vs/base/common/platform';
 
 // Based off of HtmlContentRenderer
 export class NotebookMarkdownRenderer {
@@ -240,7 +241,7 @@ export class NotebookMarkdownRenderer {
 		} else if (href.charAt(0) === '/') {
 			return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
 		} else if (href.slice(0, 2) === '..') {
-			if (process.platform === 'win32') {
+			if (isWindows) {
 				// we need to format invalid href formats (ex. ....\file to ..\..\file)
 				// in order to resolve to an absolute link
 				href = href.replace(/^(?!.*\.\\])\.\W/, '..\\');

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -244,7 +244,9 @@ export class NotebookMarkdownRenderer {
 			if (isWindows) {
 				// we need to format invalid href formats (ex. ....\file to ..\..\file)
 				// in order to resolve to an absolute link
-				href = href.replace(/^(?!.*\.\\])\.\W/, '..\\');
+				// Test that documents issue [Follow up]:
+				// 'marked js compiles relative link incorrectly'
+				href = href.replace(/\.\.(?=\.\.)/g, '..\\');
 				return path.resolve(base, href);
 			} else {
 				return path.join(base + href);

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -242,12 +242,12 @@ export class NotebookMarkdownRenderer {
 		} else if (href.charAt(0) === '/') {
 			return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
 		} else if (href.slice(0, 2) === '..') {
-			if (isWindows) {
+			if (isWindows && href.startsWith('...')) {
 				// we need to format invalid href formats (ex. ....\file to ..\..\file)
 				// in order to resolve to an absolute link
 				// Issue tracked here: https://github.com/markedjs/marked/issues/2135
 				href = replaceInvalidLinkPath(href);
-				return path.resolve(base, href);
+				return path.join(base, href);
 			} else {
 				return path.join(base + href);
 			}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -242,15 +242,11 @@ export class NotebookMarkdownRenderer {
 		} else if (href.charAt(0) === '/') {
 			return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
 		} else if (href.slice(0, 2) === '..') {
-			if (isWindows && href.startsWith('...')) {
-				// we need to format invalid href formats (ex. ....\file to ..\..\file)
-				// in order to resolve to an absolute link
-				// Issue tracked here: https://github.com/markedjs/marked/issues/2135
-				href = replaceInvalidLinkPath(href);
-				return path.join(base, href);
-			} else {
-				return path.join(base + href);
-			}
+			// we need to format invalid href formats (ex. ....\file to ..\..\file)
+			// in order to resolve to an absolute link
+			// Issue tracked here: https://github.com/markedjs/marked/issues/2135
+			href = replaceInvalidLinkPath(href);
+			return path.join(base, href);
 		} else {
 			return base + href;
 		}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -235,12 +235,13 @@ export class NotebookMarkdownRenderer {
 		}
 		base = this._baseUrls[' ' + base];
 
+		href = href.replace(/^(?!.*\.\\])\.\W/, '..\\');
 		if (href.slice(0, 2) === '//') {
 			return base.replace(/:[\s\S]*/, ':') + href;
 		} else if (href.charAt(0) === '/') {
 			return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
 		} else if (href.slice(0, 2) === '..') {
-			return path.join(base, href);
+			return path.resolve(base, href);
 		} else {
 			return base + href;
 		}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -235,13 +235,19 @@ export class NotebookMarkdownRenderer {
 		}
 		base = this._baseUrls[' ' + base];
 
-		href = href.replace(/^(?!.*\.\\])\.\W/, '..\\');
 		if (href.slice(0, 2) === '//') {
 			return base.replace(/:[\s\S]*/, ':') + href;
 		} else if (href.charAt(0) === '/') {
 			return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
 		} else if (href.slice(0, 2) === '..') {
-			return path.resolve(base, href);
+			if (process.platform === 'win32') {
+				// we need to format invalid href formats (ex. ....\file to ..\..\file)
+				// in order to resolve to absolute link
+				href = href.replace(/^(?!.*\.\\])\.\W/, '..\\');
+				return path.resolve(base, href);
+			} else {
+				return path.join(base + href);
+			}
 		} else {
 			return base + href;
 		}

--- a/src/sql/workbench/contrib/notebook/common/utils.ts
+++ b/src/sql/workbench/contrib/notebook/common/utils.ts
@@ -9,6 +9,6 @@ export function replaceInvalidLinkPath(href: string): string {
 	// Get first slash of link and use that create relative path format (..\) string
 	// and then concatenate relative path format string to rest of href path after slash
 	let slashIndex = href.indexOf('\\');
-	href = '..\\'.repeat((slashIndex / 2)) + href.substring(slashIndex + 1);
+	href = '..\\'.repeat(slashIndex / 2) + href.substring(slashIndex + 1);
 	return href;
 }

--- a/src/sql/workbench/contrib/notebook/common/utils.ts
+++ b/src/sql/workbench/contrib/notebook/common/utils.ts
@@ -6,6 +6,9 @@
 export const invalidRelativePathRegex = /^\.\.+(?=\.\.)/g;
 
 export function replaceInvalidLinkPath(href: string): string {
-	href = href.replace(invalidRelativePathRegex, '..\\');
+	// Get first slash of link and use that create relative path format (..\) string
+	// and then concatenate relative path format string to rest of href path after slash
+	let slashIndex = href.indexOf('\\');
+	href = '..\\'.repeat((slashIndex / 2)) + href.substring(slashIndex + 1);
 	return href;
 }

--- a/src/sql/workbench/contrib/notebook/common/utils.ts
+++ b/src/sql/workbench/contrib/notebook/common/utils.ts
@@ -3,12 +3,24 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const invalidRelativePathRegex = /^\.\.+(?=\.\.)/g;
+import { isWindows } from 'vs/base/common/platform';
 
+/**
+ * Due to marked js parsing returning an invalid path (ex. ....\) we must format the path to ensure directories are formatted properly (ex. ..\..\).
+ * Issue tracked here: https://github.com/markedjs/marked/issues/2135
+ * The function only formats the path for Windows platform (in which the invalid form occurs) and checks to see if the path is invalid based on the leading periods.
+ * We use the first slash of path and create a relative path format (..\) string based on amount of leading periods
+ * and then concatenate the relative path format string to rest of path after slash
+ * @param href is the relative path
+ * @returns properly formatted relative path
+ */
 export function replaceInvalidLinkPath(href: string): string {
-	// Get first slash of link and use that create relative path format (..\) string
-	// and then concatenate relative path format string to rest of href path after slash
-	let slashIndex = href.indexOf('\\');
-	href = '..\\'.repeat(slashIndex / 2) + href.substring(slashIndex + 1);
-	return href;
+	if (isWindows && href.startsWith('...')) {
+		let slashIndex = href.indexOf('\\');
+		href = '..\\'.repeat(slashIndex / 2) + href.substring(slashIndex + 1);
+		return href;
+	} else {
+		// returns original path since it is valid
+		return href;
+	}
 }

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as marked from 'vs/base/common/marked/marked';
 import { NotebookMarkdownRenderer } from '../../browser/outputs/notebookMarkdown';
 import { URI } from 'vs/base/common/uri';
-import path = require('path');
+import * as path from 'path';
 
 suite('NotebookMarkdownRenderer', () => {
 	let notebookMarkdownRenderer = new NotebookMarkdownRenderer();

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import * as marked from 'vs/base/common/marked/marked';
 import { NotebookMarkdownRenderer } from '../../browser/outputs/notebookMarkdown';
 import { URI } from 'vs/base/common/uri';
+import path = require('path');
 
 suite('NotebookMarkdownRenderer', () => {
 	let notebookMarkdownRenderer = new NotebookMarkdownRenderer();
@@ -56,7 +57,9 @@ suite('NotebookMarkdownRenderer', () => {
 		notebookMarkdownRenderer.setNotebookURI(URI.parse('maddy/temp/file1.txt'));
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](../test/.build/someimageurl)`, isTrusted: true });
 		if (process.platform === 'win32') {
-			assert.strictEqual(result.innerHTML, `<p><a href="C:\\maddy\\test\\.build\\someimageurl" data-href="C:\\maddy\\test\\.build\\someimageurl" title="C:\\maddy\\test\\.build\\someimageurl">Link to relative path</a></p>`);
+			let fullPath = path.resolve('.');
+			let diskDrive = fullPath.substring(0, fullPath.indexOf(':') + 1);
+			assert.strictEqual(result.innerHTML, `<p><a href="${diskDrive}\\maddy\\test\\.build\\someimageurl" data-href="${diskDrive}\\maddy\\test\\.build\\someimageurl" title="${diskDrive}\\maddy\\test\\.build\\someimageurl">Link to relative path</a></p>`);
 		} else {
 			assert.strictEqual(result.innerHTML, `<p><a href="/maddy/test/.build/someimageurl" data-href="/maddy/test/.build/someimageurl" title="/maddy/test/.build/someimageurl">Link to relative path</a></p>`);
 		}

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -56,7 +56,7 @@ suite('NotebookMarkdownRenderer', () => {
 		notebookMarkdownRenderer.setNotebookURI(URI.parse('maddy/temp/file1.txt'));
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](../test/.build/someimageurl)`, isTrusted: true });
 		if (process.platform === 'win32') {
-			assert.strictEqual(result.innerHTML, `<p><a href="\\maddy\\test\\.build\\someimageurl" data-href="\\maddy\\test\\.build\\someimageurl" title="\\maddy\\test\\.build\\someimageurl">Link to relative path</a></p>`);
+			assert.strictEqual(result.innerHTML, `<p><a href="C:\\maddy\\test\\.build\\someimageurl" data-href="C:\\maddy\\test\\.build\\someimageurl" title="C:\\maddy\\test\\.build\\someimageurl">Link to relative path</a></p>`);
 		} else {
 			assert.strictEqual(result.innerHTML, `<p><a href="/maddy/test/.build/someimageurl" data-href="/maddy/test/.build/someimageurl" title="/maddy/test/.build/someimageurl">Link to relative path</a></p>`);
 		}

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -66,6 +66,7 @@ suite('NotebookMarkdownRenderer', () => {
 	});
 
 	// marked js test that alters the relative path requiring regex replace to resolve path properly
+	// Issue tracked here: https://github.com/markedjs/marked/issues/2135
 	test('marked js compiles relative link incorrectly', () => {
 		const markedPath = marked.parse('..\\..\\test.ipynb');
 		assert.strict(markedPath, '<p>....\test.ipynb</p>');

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -54,14 +54,19 @@ suite('NotebookMarkdownRenderer', () => {
 	});
 
 	test('link from relative file path', () => {
-		notebookMarkdownRenderer.setNotebookURI(URI.parse('maddy/temp/file1.txt'));
+		notebookMarkdownRenderer.setNotebookURI(URI.parse('foo/temp/file1.txt'));
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](../test/.build/someimageurl)`, isTrusted: true });
 		if (process.platform === 'win32') {
 			let fullPath = path.resolve('.');
 			let diskDrive = fullPath.substring(0, fullPath.indexOf(':') + 1);
-			assert.strictEqual(result.innerHTML, `<p><a href="${diskDrive}\\maddy\\test\\.build\\someimageurl" data-href="${diskDrive}\\maddy\\test\\.build\\someimageurl" title="${diskDrive}\\maddy\\test\\.build\\someimageurl">Link to relative path</a></p>`);
+			if (diskDrive) {
+				assert.strictEqual(result.innerHTML, `<p><a href="${diskDrive}\\foo\\test\\.build\\someimageurl" data-href="${diskDrive}\\foo\\test\\.build\\someimageurl" title="${diskDrive}\\foo\\test\\.build\\someimageurl">Link to relative path</a></p>`);
+			} else {
+				// network paths
+				assert.strictEqual(result.innerHTML, `<p><a href="${fullPath}\\foo\\test\\.build\\someimageurl" data-href="${fullPath}\\foo\\test\\.build\\someimageurl" title="${fullPath}\\foo\\test\\.build\\someimageurl">Link to relative path</a></p>`);
+			}
 		} else {
-			assert.strictEqual(result.innerHTML, `<p><a href="/maddy/test/.build/someimageurl" data-href="/maddy/test/.build/someimageurl" title="/maddy/test/.build/someimageurl">Link to relative path</a></p>`);
+			assert.strictEqual(result.innerHTML, `<p><a href="/foo/test/.build/someimageurl" data-href="/foo/test/.build/someimageurl" title="/foo/test/.build/someimageurl">Link to relative path</a></p>`);
 		}
 	});
 

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -7,7 +7,6 @@ import * as assert from 'assert';
 import * as marked from 'vs/base/common/marked/marked';
 import { NotebookMarkdownRenderer } from '../../browser/outputs/notebookMarkdown';
 import { URI } from 'vs/base/common/uri';
-import * as path from 'path';
 
 suite('NotebookMarkdownRenderer', () => {
 	let notebookMarkdownRenderer = new NotebookMarkdownRenderer();

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -54,12 +54,10 @@ suite('NotebookMarkdownRenderer', () => {
 	});
 
 	test('link from relative file path', () => {
-		notebookMarkdownRenderer.setNotebookURI(URI.parse('foo/temp/file1.txt'));
+		notebookMarkdownRenderer.setNotebookURI(URI.parse(`foo/temp/file1.txt`));
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](../test/.build/someimageurl)`, isTrusted: true });
 		if (process.platform === 'win32') {
-			let fullPath = path.resolve('.');
-			let diskDrive = fullPath.substring(0, fullPath.indexOf(':') + 1);
-			assert.strictEqual(result.innerHTML, `<p><a href="${diskDrive}\\foo\\test\\.build\\someimageurl" data-href="${diskDrive}\\foo\\test\\.build\\someimageurl" title="${diskDrive}\\foo\\test\\.build\\someimageurl">Link to relative path</a></p>`);
+			assert.strictEqual(result.innerHTML, `<p><a href="\\foo\\test\\.build\\someimageurl" data-href="\\foo\\test\\.build\\someimageurl" title="\\foo\\test\\.build\\someimageurl">Link to relative path</a></p>`);
 		} else {
 			assert.strictEqual(result.innerHTML, `<p><a href="/foo/test/.build/someimageurl" data-href="/foo/test/.build/someimageurl" title="/foo/test/.build/someimageurl">Link to relative path</a></p>`);
 		}

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -59,15 +59,16 @@ suite('NotebookMarkdownRenderer', () => {
 		if (process.platform === 'win32') {
 			let fullPath = path.resolve('.');
 			let diskDrive = fullPath.substring(0, fullPath.indexOf(':') + 1);
-			if (diskDrive) {
-				assert.strictEqual(result.innerHTML, `<p><a href="${diskDrive}\\foo\\test\\.build\\someimageurl" data-href="${diskDrive}\\foo\\test\\.build\\someimageurl" title="${diskDrive}\\foo\\test\\.build\\someimageurl">Link to relative path</a></p>`);
-			} else {
-				// network paths
-				assert.strictEqual(result.innerHTML, `<p><a href="${fullPath}\\foo\\test\\.build\\someimageurl" data-href="${fullPath}\\foo\\test\\.build\\someimageurl" title="${fullPath}\\foo\\test\\.build\\someimageurl">Link to relative path</a></p>`);
-			}
+			assert.strictEqual(result.innerHTML, `<p><a href="${diskDrive}\\foo\\test\\.build\\someimageurl" data-href="${diskDrive}\\foo\\test\\.build\\someimageurl" title="${diskDrive}\\foo\\test\\.build\\someimageurl">Link to relative path</a></p>`);
 		} else {
 			assert.strictEqual(result.innerHTML, `<p><a href="/foo/test/.build/someimageurl" data-href="/foo/test/.build/someimageurl" title="/foo/test/.build/someimageurl">Link to relative path</a></p>`);
 		}
+	});
+
+	// marked js test that alters the relative path requiring regex replace to resolve path properly
+	test('marked js compiles relative link incorrectly', () => {
+		const markedPath = marked.parse('..\\..\\test.ipynb');
+		assert.strict(markedPath, '<p>....\test.ipynb</p>');
 	});
 
 	test('cell attachment image', () => {

--- a/src/sql/workbench/contrib/notebook/test/common/utils.ts
+++ b/src/sql/workbench/contrib/notebook/test/common/utils.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const invalidRelativePathRegex = /^\.\.+(?=\.\.)/g;
+
+export function replaceInvalidLinkPath(href: string): string {
+	href = href.replace(invalidRelativePathRegex, '..\\');
+	return href;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #15942. PR is a targeted fix for Windows WYSIWYG issues, as the issue was not reproable on Mac. 

This PR fixes two distinct issues: 
1. Relative Path is incorrectly formatted (fixed using a regex to edit the 
- User inserts an absolute link in WYSIWYG
- exits the cell 
- goes back into the cell and edits the cell (insert a new link)
- switch to split view the link is incorrectly formatted (.\\....\\relativePath) should be (..\\..\\relativePath) - fix shown below.

![parentFolder](https://user-images.githubusercontent.com/23587151/125543932-572d1f20-9eea-4404-8600-c547c3e18c8e.gif)

- Another issue fixed in this PR is that the link resolves incorrectly after exiting the WYSIWYG cell and therefore returns an error message below upon clicking the link: 
![image](https://user-images.githubusercontent.com/23587151/125681360-c5eb73c7-675d-4a2a-b086-49a8ba616d07.png)

I found instead of joining the paths (base notebook folder and target href) incorrectly together we should be resolving it to get the absolute path. This would then fix the entire working scenario so that linking works no matter if WYSIWYG cell gets updated.