### PR TITLE
Fix for rename vscode langpack gulp function

### DIFF
--- a/build/lib/locFunc.js
+++ b/build/lib/locFunc.js
@@ -363,9 +363,10 @@ function renameVscodeLangpacks() {
             console.log('vscode pack is not in ADS yet: ' + langId);
             continue;
         }
-        gulp.src(`i18n/ads-language-pack-${langId}/*.md`)
-            .pipe(vfs.dest(locVSCODEFolder, { overwrite: true }))
-            .end(function () {
+        gulp.src(path.join(locADSFolder, '*.md'))
+            .pipe(rename(filepath => filepath.dirname = ''))
+            .pipe(gulp.dest(locVSCODEFolder))
+            .on('end', () => {
             rimraf.sync(locADSFolder);
             fs.renameSync(locVSCODEFolder, locADSFolder);
         });

--- a/build/lib/locFunc.ts
+++ b/build/lib/locFunc.ts
@@ -387,9 +387,10 @@ export function renameVscodeLangpacks(): Promise<void> {
 			console.log('vscode pack is not in ADS yet: ' + langId);
 			continue;
 		}
-		gulp.src(`i18n/ads-language-pack-${langId}/*.md`)
-			.pipe(vfs.dest(locVSCODEFolder, {overwrite: true}))
-			.end(function () {
+		gulp.src(path.join(locADSFolder, '*.md'))
+			.pipe(rename(filepath => filepath.dirname = ''))
+			.pipe(gulp.dest(locVSCODEFolder))
+			.on('end', () => {
 				rimraf.sync(locADSFolder);
 				fs.renameSync(locVSCODEFolder, locADSFolder);
 			});


### PR DESCRIPTION
replaces 'end' with on('end' as 'end' prematurely closes the stream before files could be added.