### PR TITLE
Fix component unregistering from parent

### DIFF
--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -132,23 +132,13 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 
 	removeFromContainer(containerId: string, itemConfig: IItemConfig): void {
 		this.logService.debug(`Queueing action to remove component ${itemConfig.componentShape.id} from container ${containerId}`);
-		const childDescriptor = this.modelStore.getComponentDescriptor(itemConfig.componentShape.id);
-		if (!childDescriptor) {
-			// This should ideally never happen but it's possible for a race condition to happen when adding/removing components quickly where
-			// the child component is unregistered after it is defined because a component is only unregistered when it's destroyed by Angular
-			// which can take a while and we don't wait on that to happen currently.
-			// While this happening isn't desirable there isn't much we can do here currently until that's fixed so for now just continue on since
-			// it doesn't typically seem to have any huge impacts when this does happen (which is generally rare)
-			this.logService.warn(`Could not find descriptor for child component ${itemConfig.componentShape.id} when removing from container ${containerId}`);
-			return;
-		}
 		this.queueAction(containerId, (component) => {
 			if (!component.removeFromContainer) {
 				this.logService.warn(`Container ${containerId} is trying to remove component ${itemConfig.componentShape.id} but does not implement removeFromContainer!`);
 				return;
 			}
 			this.logService.debug(`Removing component ${itemConfig.componentShape.id} from container ${containerId}`);
-			component.removeFromContainer(childDescriptor);
+			component.removeFromContainer({ id: itemConfig.componentShape.id, type: componentRegistry.getIdForTypeMapping(itemConfig.componentShape.type) });
 			this.removeComponent(itemConfig.componentShape);
 		});
 	}


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/16131

This was broken by https://github.com/microsoft/azuredatastudio/pull/15988 (specifically the addition of the new validation on the dropdown component. Commenting that out makes it so this issue doesn't occur)

But as far as I can tell that was mostly just coincident that made the race condition described in the comment be an actual issue.

Description of the issue happening here : 

On the schema compare dialog it starts off with the file picker (...) button for the target section. When that's changed from DACPAC to database the button (and other components) are removed and new ones added in their place. 

But due to the race condition described the component itself was removed from the DOM and then unregistering itself from the modelstore BEFORE its parent container had removeFromContainer called. Then when that was eventually called the child button component was already removed from the modelstore so it would just give the warning and exit - leaving the component in the list of children for the container.

Once that was done then we were left with an invalid child component - which meant that when the parent container ran its validations it would try to validate that component as well and end up with "undefined" for its validity which caused the whole form to be considered invalid - thus blocking the OK button from being enabled.

So the fix here is to make it so that when removeFromContainer is called we no longer care about whether it's still in the model store - since that isn't actually required to remove something from a container (we only need the ID and type). This gets rid of the race condition and now all components that are removed from the containers should actually be removed, preventing other issues similar to this one. 