### PR TITLE
Fix #15854 refresh button role

### DIFF
--- a/extensions/integration-tests/src/onboarding/developers.ts
+++ b/extensions/integration-tests/src/onboarding/developers.ts
@@ -10,6 +10,7 @@ export const developers: string[] = [
 	'abist',
 	'alanrenmsft',
 	'anjalia',
+	'anjaligoyal',
 	'anthonydresser',
 	'bnhoule',
 	'caohai',

--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -566,6 +566,7 @@ export class DashboardWidget {
 		const refreshButton = view.modelBuilder.hyperlink().withProps({
 			label: loc.REFRESH,
 			url: '',
+			ariaRole: 'button',
 			CSSStyles: {
 				'text-align': 'right',
 				'font-size': '13px'


### PR DESCRIPTION
This PR fixes #15854 A11y_AzureDataStudioSQLMigration_AzureSQLMigration_DeveloperTool:The role for refresh button is defined as a link.
