### PR TITLE
Allow action bar to be hidden on Plotly tables

### DIFF
--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -325,9 +325,16 @@ export interface IDataSet {
 
 export interface IGridTableOptions {
 	actionOrientation: ActionsOrientation;
+	displayActions?: boolean;
 	inMemoryDataProcessing: boolean;
 	inMemoryDataCountThreshold?: number;
 }
+
+const defaultGridTableOptions: IGridTableOptions = {
+	displayActions: true,
+	inMemoryDataProcessing: false,
+	actionOrientation: ActionsOrientation.VERTICAL
+};
 
 export abstract class GridTableBase<T> extends Disposable implements IView {
 	private table: Table<T>;
@@ -375,10 +382,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	constructor(
 		state: GridTableState,
 		protected _resultSet: ResultSetSummary,
-		private readonly options: IGridTableOptions = {
-			inMemoryDataProcessing: false,
-			actionOrientation: ActionsOrientation.VERTICAL
-		},
+		private readonly options: IGridTableOptions,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
 		@IEditorService private readonly editorService: IEditorService,
@@ -390,6 +394,9 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		@INotificationService private readonly notificationService: INotificationService
 	) {
 		super();
+
+		this.options = { ...defaultGridTableOptions, ...options };
+
 		let config = this.configurationService.getValue<{ rowHeight: number }>('resultsGrid');
 		this.rowHeight = config && config.rowHeight ? config.rowHeight : ROW_HEIGHT;
 		this.state = state;
@@ -559,7 +566,6 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			this.actionBar.context = this.generateContext();
 		});
 		this.rebuildActionBar();
-
 		this.selectionModel.onSelectedRangesChanged.subscribe(async e => {
 			if (this.state) {
 				this.state.selection = this.selectionModel.getSelectedRanges();
@@ -736,7 +742,14 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	private rebuildActionBar() {
 		let actions = this.getCurrentActions();
 		this.actionBar.clear();
-		this.actionBar.push(actions, { icon: true, label: false });
+		if (this.options.displayActions) {
+			this.actionBar.push(actions, { icon: true, label: false });
+		}
+	}
+
+	public showActionBar(display: boolean) {
+		this.options.displayActions = display;
+		this.rebuildActionBar();
 	}
 
 	protected abstract getCurrentActions(): IAction[];
@@ -884,6 +897,7 @@ class GridTable<T> extends GridTableBase<T> {
 		super(state, resultSet, {
 			actionOrientation: ActionsOrientation.VERTICAL,
 			inMemoryDataProcessing: true,
+			displayActions: true,
 			inMemoryDataCountThreshold: configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.inMemoryDataProcessingThreshold,
 		}, contextMenuService, instantiationService, editorService, untitledEditorService, configurationService, queryModelService, themeService, contextViewService, notificationService);
 		this._gridDataProvider = this.instantiationService.createInstance(QueryGridDataProvider, this._runner, resultSet.batchId, resultSet.id);

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -325,13 +325,13 @@ export interface IDataSet {
 
 export interface IGridTableOptions {
 	actionOrientation: ActionsOrientation;
-	displayActions?: boolean;
+	showActionBar?: boolean;
 	inMemoryDataProcessing: boolean;
 	inMemoryDataCountThreshold?: number;
 }
 
 const defaultGridTableOptions: IGridTableOptions = {
-	displayActions: true,
+	showActionBar: true,
 	inMemoryDataProcessing: false,
 	actionOrientation: ActionsOrientation.VERTICAL
 };
@@ -742,14 +742,20 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	private rebuildActionBar() {
 		let actions = this.getCurrentActions();
 		this.actionBar.clear();
-		if (this.options.displayActions) {
+		if (this.options.showActionBar) {
 			this.actionBar.push(actions, { icon: true, label: false });
 		}
 	}
 
-	public showActionBar(display: boolean) {
-		this.options.displayActions = display;
-		this.rebuildActionBar();
+	public get showActionBar(): boolean {
+		return this.options.showActionBar;
+	}
+
+	public set showActionBar(v: boolean) {
+		if (this.options.showActionBar !== v) {
+			this.options.showActionBar = v;
+			this.rebuildActionBar();
+		}
 	}
 
 	protected abstract getCurrentActions(): IAction[];
@@ -897,7 +903,7 @@ class GridTable<T> extends GridTableBase<T> {
 		super(state, resultSet, {
 			actionOrientation: ActionsOrientation.VERTICAL,
 			inMemoryDataProcessing: true,
-			displayActions: true,
+			showActionBar: true,
 			inMemoryDataCountThreshold: configurationService.getValue<IQueryEditorConfiguration>('queryEditor').results.inMemoryDataProcessingThreshold,
 		}, contextMenuService, instantiationService, editorService, untitledEditorService, configurationService, queryModelService, themeService, contextViewService, notificationService);
 		this._gridDataProvider = this.instantiationService.createInstance(QueryGridDataProvider, this._runner, resultSet.batchId, resultSet.id);


### PR DESCRIPTION
This option allows hiding the action bar on Plotly tables. This allows tables Notebook Views to look a little more clean when the bar is not needed.

**Normal table layout**
![hide-toolbar-hidden](https://user-images.githubusercontent.com/8183814/126230689-7e4b8364-4208-4f5b-a0b7-d3c219829a8d.JPG)

**Table layout with actionbar hidden**
![hide-toolbar-showing](https://user-images.githubusercontent.com/8183814/126230699-7c611244-3998-4424-aa81-0bec2bda1423.JPG)
