### PR TITLE
Add conditional operator before checking length

### DIFF
--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -30,7 +30,7 @@ export interface quickPickResults {
 const allowedFileExtensions: string[] = [FileExtension.Markdown, FileExtension.Notebook];
 
 export function hasSections(node: JupyterBookSection): boolean {
-	return node.sections !== undefined && node.sections?.length > 0;
+	return node.sections?.length > 0;
 }
 
 export class BookTocManager implements IBookTocManager {

--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -30,7 +30,7 @@ export interface quickPickResults {
 const allowedFileExtensions: string[] = [FileExtension.Markdown, FileExtension.Notebook];
 
 export function hasSections(node: JupyterBookSection): boolean {
-	return node.sections !== undefined && node.sections.length > 0;
+	return node.sections !== undefined && node.sections?.length > 0;
 }
 
 export class BookTocManager implements IBookTocManager {


### PR DESCRIPTION
This PR is for #15690

One of the entries of the toc had a definition of sections, but didn't have any file entries below it.
So sections were not undefined, but when we tried to check the length then it'll throw an error.
Adding an conditional operator so none of the editing operations fail.