### PR TITLE
make button not focusable when disabled

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -294,7 +294,7 @@ export class Button extends Disposable implements IButton {
 		} else {
 			this._element.classList.add('disabled');
 			this._element.setAttribute('aria-disabled', String(true));
-			removeTabIndexAndUpdateFocus(this._element); // {{SQL CARBON EDIT}} - remove tabindex when the disabled otherwise disabled control is still keyboard focusable
+			removeTabIndexAndUpdateFocus(this._element); // {{SQL CARBON EDIT}} - remove tabindex when disabled otherwise disabled control is still keyboard focusable.
 		}
 		this.applyStyles(); // {{SQL CARBON EDIT}}
 	}

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -12,7 +12,7 @@ import { Event as BaseEvent, Emitter } from 'vs/base/common/event';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { Gesture, EventType as TouchEventType } from 'vs/base/browser/touch';
 import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
-import { addDisposableListener, IFocusTracker, EventType, EventHelper, trackFocus, reset } from 'vs/base/browser/dom';
+import { addDisposableListener, IFocusTracker, EventType, EventHelper, trackFocus, reset, removeTabIndexAndUpdateFocus } from 'vs/base/browser/dom';
 import { IContextMenuProvider } from 'vs/base/browser/contextmenu';
 import { Action, IAction, IActionRunner } from 'vs/base/common/actions';
 import { CSSIcon, Codicon } from 'vs/base/common/codicons';
@@ -294,6 +294,7 @@ export class Button extends Disposable implements IButton {
 		} else {
 			this._element.classList.add('disabled');
 			this._element.setAttribute('aria-disabled', String(true));
+			removeTabIndexAndUpdateFocus(this._element); // {{SQL CARBON EDIT}} - remove tabindex when the disabled otherwise disabled control is still keyboard focusable
 		}
 		this.applyStyles(); // {{SQL CARBON EDIT}}
 	}

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -12,7 +12,7 @@ import { Event as BaseEvent, Emitter } from 'vs/base/common/event';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { Gesture, EventType as TouchEventType } from 'vs/base/browser/touch';
 import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
-import { addDisposableListener, IFocusTracker, EventType, EventHelper, trackFocus, reset, removeTabIndexAndUpdateFocus } from 'vs/base/browser/dom';
+import { addDisposableListener, IFocusTracker, EventType, EventHelper, trackFocus, reset, removeTabIndexAndUpdateFocus } from 'vs/base/browser/dom'; // {{SQL CARBON EDIT}}
 import { IContextMenuProvider } from 'vs/base/browser/contextmenu';
 import { Action, IAction, IActionRunner } from 'vs/base/common/actions';
 import { CSSIcon, Codicon } from 'vs/base/common/codicons';


### PR DESCRIPTION
for #16142

in this VSCode commit: https://github.com/microsoft/vscode/commit/3479bb35904eb046c0974090794cac9c76173796, the logic of removing the tabindex when disabled is deleted, and caused the disabled buttons to be still keyboard focusable. I've emailed the committer for the context since there is no description in the commit.  I only added the logic back for button component since checkbox and menu don't really need this because tabindex=0 were never set on those elements to begin with, but for button, we are using html A tag, without href attribute, the element is not keyboard focusable unless we set tabindex=0. 
