### PR TITLE
Handle if no extensions listed in PG spec

### DIFF
--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -44,6 +44,7 @@ export const discardText = localize('arc.discard', "Discard");
 export const resetPassword = localize('arc.resetPassword', "Reset Password");
 export const addExtensions = localize('arc.addExtensions', "Add extensions");
 export const dropExtensions = localize('arc.dropExtensions', "Drop extensions");
+export const noExtensions = localize('arc.noExtensions', "No extensions listed in configuration.");
 export const openInAzurePortal = localize('arc.openInAzurePortal', "Open in Azure Portal");
 export const resourceGroup = localize('arc.resourceGroup', "Resource Group");
 export const region = localize('arc.region', "Region");

--- a/extensions/arc/src/ui/dashboards/postgres/postgresExtensionsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresExtensionsPage.ts
@@ -202,12 +202,18 @@ export class PostgresExtensionsPage extends DashboardPage {
 
 	private refreshExtensionsTable(): void {
 		let extensions = this._postgresModel.config!.spec.engine.extensions;
-		let extensionBasicData = extensions.map(e => {
-			this.extensionNames.push(e.name);
-			return [this.createDropCheckBox(e.name), e.name];
-		});
-
 		let extenesionFinalData: azdata.DeclarativeTableCellValue[][] = [];
+		let extensionBasicData: (string | azdata.CheckBoxComponent | azdata.ImageComponent)[][] = [];
+
+		if (extensions) {
+			extensionBasicData = extensions.map(e => {
+				this.extensionNames.push(e.name);
+				return [this.createDropCheckBox(e.name), e.name];
+			});
+		} else {
+			extensionBasicData = [[this.modelView.modelBuilder.image().component(), loc.noExtensions]];
+		}
+
 		extenesionFinalData = extensionBasicData.map(e => {
 			return e.map((value): azdata.DeclarativeTableCellValue => {
 				return { value: value };
@@ -233,6 +239,7 @@ export class PostgresExtensionsPage extends DashboardPage {
 			checkBox.onChanged(() => {
 				if (checkBox.checked) {
 					this.droppedExtensions.push(name);
+					this.dropExtensionsButton.focus();
 				} else {
 					let index = this.droppedExtensions.indexOf(name, 0);
 					this.droppedExtensions.splice(index, 1);
@@ -277,6 +284,7 @@ export class PostgresExtensionsPage extends DashboardPage {
 			this.extensionsLink.url = `https://www.postgresql.org/docs/${this._postgresModel.engineVersion}/external-extensions.html`;
 			this.extensionNames = [];
 			this.refreshExtensionsTable();
+			this.addExtensionsButton.focus();
 		}
 	}
 }

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -188,7 +188,7 @@ declare module 'azdata-ext' {
 				extensions?: {
 					name: string // "citus"
 				}[],
-				settings: {
+				settings?: {
 					default: { [key: string]: string }, // { "max_connections": "101", "work_mem": "4MB" }
 					roles: {
 						coordinator: { [key: string]: string },
@@ -208,7 +208,7 @@ declare module 'azdata-ext' {
 						limits: SchedulingOptions
 					}
 				},
-				roles: {
+				roles?: {
 					coordinator: {
 						resources: {
 							requests: SchedulingOptions,

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -185,7 +185,7 @@ declare module 'azdata-ext' {
 		},
 		spec: {
 			engine: {
-				extensions: {
+				extensions?: {
 					name: string // "citus"
 				}[],
 				settings: {


### PR DESCRIPTION
States no extensions are listed without adding a checkbox component. 
![image](https://user-images.githubusercontent.com/69922333/125857754-26ca5880-f3d3-4dc0-9c94-d0ce5bdc29f1.png)

Added focus to buttons: Drop button gets focused after checkbox is checked, Add button gets focused once table has refreshed

This PR fixes #16181 
