### PR TITLE
fix keyboard focus issues

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.ts
+++ b/src/sql/base/browser/ui/panel/panel.ts
@@ -33,7 +33,6 @@ export interface IPanelOptions {
 export interface IPanelView {
 	render(container: HTMLElement): void;
 	layout(dimension: DOM.Dimension): void;
-	focus(): void;
 	remove?(): void;
 	onShow?(): void;
 	onHide?(): void;
@@ -183,15 +182,6 @@ export class TabbedPanel extends Disposable {
 			if (event.equals(KeyCode.LeftArrow)) {
 				let currentIndex = this._tabOrder.findIndex(x => x === tab.tab.identifier);
 				this.focusNextTab(currentIndex - 1);
-			}
-			if (event.equals(KeyCode.Tab)) {
-				e.preventDefault();
-				if (this._shownTabId) {
-					const shownTab = this._tabMap.get(this._shownTabId);
-					if (shownTab) {
-						shownTab.tab.view.focus();
-					}
-				}
 			}
 		}));
 
@@ -397,15 +387,6 @@ export class TabbedPanel extends Disposable {
 				tab.body.style.width = dimension.width + 'px';
 				tab.body.style.height = dimension.height + 'px';
 				tab.tab.view.layout(dimension);
-			}
-		}
-	}
-
-	public focus(): void {
-		if (this._shownTabId) {
-			const tab = this._tabMap.get(this._shownTabId);
-			if (tab) {
-				tab.tab.view.focus();
 			}
 		}
 	}

--- a/src/sql/platform/dashboard/browser/interfaces.ts
+++ b/src/sql/platform/dashboard/browser/interfaces.ts
@@ -21,7 +21,8 @@ export enum ComponentEventType {
 	onComponentCreated,
 	onCellAction,
 	onEnterKeyPressed,
-	onInput
+	onInput,
+	onComponentLoaded
 }
 
 /**

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -244,7 +244,8 @@ export enum ComponentEventType {
 	onComponentCreated,
 	onCellAction,
 	onEnterKeyPressed,
-	onInput
+	onInput,
+	onComponentLoaded
 }
 
 export interface IComponentEventArgs {

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -382,12 +382,9 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Set focusable elements in the modal dialog
 	 */
 	public setInitialFocusedElement() {
-		// Try to find focusable element in dialog pane rather than overall container. _modalBodySection contains items in the pane for a wizard.
-		// This ensures that we are setting the focus on a useful element in the form when possible.
-		const focusableElements = getFocusableElements(this._modalBodySection ?? this._bodyContainer!);
-
-		if (focusableElements && focusableElements.length > 0) {
-			(<HTMLElement>focusableElements[0]).focus();
+		const focusableElements = getFocusableElements(this._modalDialog!);
+		if (focusableElements?.length > 0) {
+			focusableElements[0].focus();
 		}
 	}
 

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -56,6 +56,10 @@ export abstract class ComponentBase<TPropertyBag extends azdata.ComponentPropert
 			this.modelStore.registerComponent(this);
 			this._validations.push(() => this.modelStore.validate(this));
 		}
+		this.fireEvent({
+			eventType: ComponentEventType.onComponentLoaded,
+			args: undefined
+		});
 	}
 
 	abstract ngAfterViewInit(): void;

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -206,9 +206,6 @@ export class ChartView extends Disposable implements IPanelView {
 		}
 	}
 
-	focus(): void {
-	}
-
 	public set queryRunner(runner: QueryRunner) {
 		this._queryRunner = runner;
 		this.fetchData();

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -362,8 +362,7 @@ export class ProfilerEditor extends EditorPane {
 			title: nls.localize('text', "Text"),
 			view: {
 				layout: dim => this._editor.layout(dim),
-				render: parent => parent.appendChild(editorContainer),
-				focus: () => this._editor.focus()
+				render: parent => parent.appendChild(editorContainer)
 			},
 			tabSelectedHandler: expandPanel
 		});
@@ -417,8 +416,7 @@ export class ProfilerEditor extends EditorPane {
 			title: nls.localize('details', "Details"),
 			view: {
 				layout: dim => this._detailTable.layout(dim),
-				render: parent => parent.appendChild(detailTableContainer),
-				focus: () => this._detailTable.focus()
+				render: parent => parent.appendChild(detailTableContainer)
 			},
 			tabSelectedHandler: expandPanel
 		});

--- a/src/sql/workbench/contrib/query/browser/modelViewTab/queryModelViewTab.ts
+++ b/src/sql/workbench/contrib/query/browser/modelViewTab/queryModelViewTab.ts
@@ -63,9 +63,6 @@ export class QueryModelViewTabView implements IPanelView {
 	public layout(dimension: Dimension): void {
 	}
 
-	public focus(): void {
-	}
-
 	public get componentId(): string {
 		return this.state.componentId;
 	}

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -44,10 +44,6 @@ class MessagesView extends Disposable implements IPanelView {
 		this.messagePanel.layout(dimension);
 	}
 
-	focus(): void {
-		this.messagePanel.focus();
-	}
-
 	public clear() {
 		this.messagePanel.clear();
 	}
@@ -81,10 +77,6 @@ class ResultsView extends Disposable implements IPanelView {
 		this.container.style.width = `${dimension.width}px`;
 		this.container.style.height = `${dimension.height}px`;
 		this.gridPanel.layout(dimension);
-	}
-
-	focus(): void {
-		this.gridPanel.focus();
 	}
 
 	public clear() {

--- a/src/sql/workbench/contrib/queryPlan/browser/queryPlan.ts
+++ b/src/sql/workbench/contrib/queryPlan/browser/queryPlan.ts
@@ -58,10 +58,6 @@ export class QueryPlanView implements IPanelView {
 		this.container.style.height = dimension.height + 'px';
 	}
 
-	public focus() {
-		this.container.focus();
-	}
-
 	public clear() {
 		if (this.qp) {
 			this.qp.xml = undefined;

--- a/src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor.ts
+++ b/src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor.ts
@@ -48,13 +48,6 @@ export class QueryPlanEditor extends EditorPane {
 	}
 
 	/**
-	 * Sets focus on this editor. Specifically, it sets the focus on the hosted text editor.
-	 */
-	public override focus(): void {
-		this.view.focus();
-	}
-
-	/**
 	 * Updates the internal variable keeping track of the editor's size, and re-calculates the sash position.
 	 * To be called when the container of this editor changes size.
 	 */

--- a/src/sql/workbench/contrib/queryPlan/browser/topOperations.ts
+++ b/src/sql/workbench/contrib/queryPlan/browser/topOperations.ts
@@ -77,10 +77,6 @@ export class TopOperationsView extends Disposable implements IPanelView {
 		this.table.layout(dimension);
 	}
 
-	public focus(): void {
-		this.table.focus();
-	}
-
 	public clear() {
 		this.dataView.clear();
 	}

--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -281,10 +281,6 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 		this.treeContainer.style.height = `${treeHeight}px`;
 		this.tree.layout(treeHeight, dimension.width);
 	}
-
-	focus(): void {
-		this.filterInput.focus();
-	}
 }
 
 export interface ITreeItemFromProvider {

--- a/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
@@ -191,9 +191,6 @@ export class ConnectionDialogWidget extends Modal {
 				},
 				layout: (dimension: DOM.Dimension) => {
 					this._recentConnectionTree.layout(dimension.height - DOM.getTotalHeight(this._recentConnectionActionBarContainer));
-				},
-				focus: () => {
-					this._actionbar.focus();
 				}
 			}
 		});

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -133,8 +133,8 @@ export class WizardModal extends Modal {
 		this._mpContainer = append(this._body, $('div.dialog-message-and-page-container'));
 		this._pageContainer = append(this._mpContainer, $('div.dialogModal-page-container'));
 
-		this._wizard.pages.forEach(page => {
-			this.registerPage(page);
+		this._wizard.pages.forEach((page, index) => {
+			this.registerPage(page, index === 0); // only do auto-focus for the first page.
 		});
 		this._wizard.onPageAdded(page => {
 			this.registerPage(page);
@@ -167,8 +167,8 @@ export class WizardModal extends Modal {
 		});
 	}
 
-	private registerPage(page: WizardPage): void {
-		let dialogPane = new DialogPane(page.title, page.content, valid => page.notifyValidityChanged(valid), this._instantiationService, this._themeService, this._wizard.displayPageTitles, page.description);
+	private registerPage(page: WizardPage, setInitialFocus: boolean = false): void {
+		let dialogPane = new DialogPane(page.title, page.content, valid => page.notifyValidityChanged(valid), this._instantiationService, this._themeService, this._wizard.displayPageTitles, page.description, setInitialFocus);
 		dialogPane.createBody(this._pageContainer);
 		this._dialogPanes.set(page, dialogPane);
 		page.onUpdate(() => this.setButtonsForPage(this._wizard.currentPage));

--- a/src/sql/workbench/services/restore/browser/restoreDialog.ts
+++ b/src/sql/workbench/services/restore/browser/restoreDialog.ts
@@ -334,8 +334,7 @@ export class RestoreDialog extends Modal {
 				render: c => {
 					DOM.append(c, generalTab);
 				},
-				layout: () => { },
-				focus: () => this._restoreFromSelectBox ? this._restoreFromSelectBox.focus() : generalTab.focus()
+				layout: () => { }
 			}
 		});
 
@@ -346,8 +345,7 @@ export class RestoreDialog extends Modal {
 				layout: () => { },
 				render: c => {
 					c.appendChild(fileContentElement);
-				},
-				focus: () => this._optionsMap[this._relocateDatabaseFilesOption] ? this._optionsMap[this._relocateDatabaseFilesOption].focus() : fileContentElement.focus()
+				}
 			}
 		});
 
@@ -358,8 +356,7 @@ export class RestoreDialog extends Modal {
 				layout: () => { },
 				render: c => {
 					c.appendChild(optionsContentElement);
-				},
-				focus: () => this._optionsMap[this._withReplaceDatabaseOption] ? this._optionsMap[this._withReplaceDatabaseOption].focus() : optionsContentElement.focus()
+				}
 			}
 		});
 


### PR DESCRIPTION
This PR fixes #15740

1. when model view dialog/wizard is launched and loaded, the focus will be set to the first focusable element in the content area when available. if the content is loaded async, this code change will at least make sure the focus is in side the dialog/wizard.
2. while testing I observed a bunch of keyboard navigation issues and turns out they are all related to the way the tabbed panel is designed, it is asking content providers to provide a focus method, as you can see in the deleted code, a lot of them don't have a proper implementation, and caused keyboard focus trapped in the tab header. and some scenarios, it is causing incorrect focus order because of this.
3. also fixed a long standing issue with table keyboard focus management, previously tables are not focusable until you manually  or programmatically select a cell. with this pr, the focus will go in and out of the table naturally.
