### PR TITLE
Removed async copy in rename function

### DIFF
--- a/build/lib/locFunc.js
+++ b/build/lib/locFunc.js
@@ -266,18 +266,6 @@ function refreshLangpacks() {
             if (languageId === "zh-tw") {
                 languageId = "zh-hant";
             }
-            //remove extensions not part of ADS.
-            if (fs.existsSync(translationDataFolder)) {
-                let totalExtensions = fs.readdirSync(path.join(translationDataFolder, 'extensions'));
-                for (let extensionTag in totalExtensions) {
-                    let extensionFileName = totalExtensions[extensionTag];
-                    let xlfPath = path.join(location, `${languageId}`, extensionFileName.replace('.i18n.json', '.xlf'));
-                    if (!(fs.existsSync(xlfPath) || VSCODEExtensions.indexOf(extensionFileName.replace('.i18n.json', '')) !== -1)) {
-                        let filePath = path.join(translationDataFolder, 'extensions', extensionFileName);
-                        rimraf.sync(filePath);
-                    }
-                }
-            }
             console.log(`Importing translations for ${languageId} from '${location}' to '${translationDataFolder}' ...`);
             let translationPaths = [];
             gulp.src(path.join(location, languageId, '**', '*.xlf'))
@@ -344,7 +332,7 @@ exports.refreshLangpacks = refreshLangpacks;
  * Function for adding replacing ads language packs with vscode ones.
  * For new languages, remember to add to i18n.extraLanguages so that it will be recognized by ADS.
 */
-function renameVscodeLangpacks() {
+async function renameVscodeLangpacks() {
     let supportedLocations = [...i18n.defaultLanguages, ...i18n.extraLanguages];
     for (let i = 0; i < supportedLocations.length; i++) {
         let langId = supportedLocations[i].id;
@@ -356,6 +344,8 @@ function renameVscodeLangpacks() {
         }
         let locADSFolder = path.join('.', 'i18n', `ads-language-pack-${langId}`);
         let locVSCODEFolder = path.join('.', 'i18n', `vscode-language-pack-${langId}`);
+        let translationDataFolder = path.join(locVSCODEFolder, 'translations');
+        let location = path.join('.', 'resources', 'xlf');
         try {
             fs.statSync(locVSCODEFolder);
         }
@@ -363,13 +353,24 @@ function renameVscodeLangpacks() {
             console.log('vscode pack is not in ADS yet: ' + langId);
             continue;
         }
-        gulp.src(path.join(locADSFolder, '*.md'))
-            .pipe(rename(filepath => filepath.dirname = ''))
-            .pipe(gulp.dest(locVSCODEFolder))
-            .on('end', () => {
-            rimraf.sync(locADSFolder);
-            fs.renameSync(locVSCODEFolder, locADSFolder);
+        // Delete extension files in vscode language pack that are not in ADS.
+        if (fs.existsSync(translationDataFolder)) {
+            let totalExtensions = fs.readdirSync(path.join(translationDataFolder, 'extensions'));
+            for (let extensionTag in totalExtensions) {
+                let extensionFileName = totalExtensions[extensionTag];
+                let xlfPath = path.join(location, `${langId}`, extensionFileName.replace('.i18n.json', '.xlf'));
+                if (!(fs.existsSync(xlfPath) || VSCODEExtensions.indexOf(extensionFileName.replace('.i18n.json', '')) !== -1)) {
+                    let filePath = path.join(translationDataFolder, 'extensions', extensionFileName);
+                    rimraf.sync(filePath);
+                }
+            }
+        }
+        let globArray = glob.sync(path.join(locADSFolder, '*.md'));
+        globArray.forEach(element => {
+            fs.copyFileSync(element, path.join(locVSCODEFolder, path.parse(element).base));
         });
+        rimraf.sync(locADSFolder);
+        fs.renameSync(locVSCODEFolder, locADSFolder);
     }
     console.log("Langpack Rename Completed.");
     return Promise.resolve();

--- a/build/lib/locFunc.js
+++ b/build/lib/locFunc.js
@@ -332,7 +332,7 @@ exports.refreshLangpacks = refreshLangpacks;
  * Function for adding replacing ads language packs with vscode ones.
  * For new languages, remember to add to i18n.extraLanguages so that it will be recognized by ADS.
 */
-async function renameVscodeLangpacks() {
+function renameVscodeLangpacks() {
     let supportedLocations = [...i18n.defaultLanguages, ...i18n.extraLanguages];
     for (let i = 0; i < supportedLocations.length; i++) {
         let langId = supportedLocations[i].id;
@@ -345,7 +345,7 @@ async function renameVscodeLangpacks() {
         let locADSFolder = path.join('.', 'i18n', `ads-language-pack-${langId}`);
         let locVSCODEFolder = path.join('.', 'i18n', `vscode-language-pack-${langId}`);
         let translationDataFolder = path.join(locVSCODEFolder, 'translations');
-        let location = path.join('.', 'resources', 'xlf');
+        let xlfFolder = path.join('.', 'resources', 'xlf');
         try {
             fs.statSync(locVSCODEFolder);
         }
@@ -358,14 +358,16 @@ async function renameVscodeLangpacks() {
             let totalExtensions = fs.readdirSync(path.join(translationDataFolder, 'extensions'));
             for (let extensionTag in totalExtensions) {
                 let extensionFileName = totalExtensions[extensionTag];
-                let xlfPath = path.join(location, `${langId}`, extensionFileName.replace('.i18n.json', '.xlf'));
+                let xlfPath = path.join(xlfFolder, `${langId}`, extensionFileName.replace('.i18n.json', '.xlf'));
                 if (!(fs.existsSync(xlfPath) || VSCODEExtensions.indexOf(extensionFileName.replace('.i18n.json', '')) !== -1)) {
                     let filePath = path.join(translationDataFolder, 'extensions', extensionFileName);
                     rimraf.sync(filePath);
                 }
             }
         }
+        //Get list of md files in ADS langpack, to copy to vscode langpack prior to renaming.
         let globArray = glob.sync(path.join(locADSFolder, '*.md'));
+        //Copy files to vscode langpack, then remove the ADS langpack, and finally rename the vscode langpack to match the ADS one.
         globArray.forEach(element => {
             fs.copyFileSync(element, path.join(locVSCODEFolder, path.parse(element).base));
         });

--- a/build/lib/locFunc.ts
+++ b/build/lib/locFunc.ts
@@ -352,7 +352,7 @@ export function refreshLangpacks(): Promise<void> {
  * Function for adding replacing ads language packs with vscode ones.
  * For new languages, remember to add to i18n.extraLanguages so that it will be recognized by ADS.
 */
-export async function renameVscodeLangpacks(): Promise<void> {
+export function renameVscodeLangpacks(): Promise<void> {
 	let supportedLocations = [...i18n.defaultLanguages, ...i18n.extraLanguages];
 
 
@@ -367,7 +367,7 @@ export async function renameVscodeLangpacks(): Promise<void> {
 		let locADSFolder = path.join('.', 'i18n', `ads-language-pack-${langId}`);
 		let locVSCODEFolder = path.join('.', 'i18n', `vscode-language-pack-${langId}`);
 		let translationDataFolder = path.join(locVSCODEFolder, 'translations');
-		let location = path.join('.', 'resources', 'xlf');
+		let xlfFolder = path.join('.', 'resources', 'xlf');
 		try {
 			fs.statSync(locVSCODEFolder);
 		}
@@ -380,15 +380,18 @@ export async function renameVscodeLangpacks(): Promise<void> {
 			let totalExtensions = fs.readdirSync(path.join(translationDataFolder, 'extensions'));
 			for (let extensionTag in totalExtensions) {
 				let extensionFileName = totalExtensions[extensionTag];
-				let xlfPath = path.join(location, `${langId}`, extensionFileName.replace('.i18n.json', '.xlf'))
+				let xlfPath = path.join(xlfFolder, `${langId}`, extensionFileName.replace('.i18n.json', '.xlf'))
 				if (!(fs.existsSync(xlfPath) || VSCODEExtensions.indexOf(extensionFileName.replace('.i18n.json', '')) !== -1)) {
 					let filePath = path.join(translationDataFolder, 'extensions', extensionFileName);
 					rimraf.sync(filePath);
 				}
 			}
 		}
+
+		//Get list of md files in ADS langpack, to copy to vscode langpack prior to renaming.
 		let globArray = glob.sync(path.join(locADSFolder, '*.md'));
 
+		//Copy files to vscode langpack, then remove the ADS langpack, and finally rename the vscode langpack to match the ADS one.
 		globArray.forEach(element => {
 			fs.copyFileSync(element, path.join(locVSCODEFolder,path.parse(element).base));
 		});


### PR DESCRIPTION
This PR fixes a bug where the non ADS extensions delete happens BEFORE the vscode langpack folder is renamed to ADS folder, (basically starting the langpack refresh task before the vscode rename task was not completed). Using a synchronous file copy fixes this issue. 

There is a minor issue (due to the asynchronous design of gulp.src) where the message for refresh pops up saying its "completed" when it still has to process the "on-end" part of the pipe stream, but its at the very end and does not affect the resulting json files.