### PR TITLE
Azure Monitor Logs hide database option

### DIFF
--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -122,7 +122,8 @@
           "objectType": null,
           "categoryValues": null,
           "isRequired": false,
-          "isArray": false
+          "isArray": false,
+          "hide": true
         }
       ]
     },

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -282,7 +282,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 	private addDatabaseOption(): void {
 		// Database
 		let databaseOption = this._optionsMaps[ConnectionOptionSpecialType.databaseName];
-		if (databaseOption) {
+		if (databaseOption && !databaseOption.hide) {
 			let databaseName = DialogHelper.appendRow(this._tableContainer, databaseOption.displayName, 'connection-label', 'connection-input');
 			this._databaseNameInputBox = new Dropdown(databaseName, this._contextViewService, {
 				values: [this._defaultDatabaseName, this._loadingDatabaseName],


### PR DESCRIPTION
ADS requires multiple connection options to be declared to properly function including username, password, and databaseName. Azure Monitor Logs connects directly to a database equivalent so it has no use for a database.  To resolve this, I added a 'hide' flag to the `package.json` and used it in the connection widget.

If the databaseName is not declared in the package.json then the query window is never able to select a database. (see screenshot).

![image](https://user-images.githubusercontent.com/63619224/125980938-1c31f452-2c69-4809-b93b-335007615845.png)


Added hide flag to database in `package.json`. Added check in `connectionwidget.ts` to not show database option if the hide flag is true.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
