### PR TITLE
Converting toast to modal dialog to grab focus when cancelling on going migrations.

### DIFF
--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -402,7 +402,7 @@ export class MigrationCutoverDialog {
 		}).component();
 
 		this._cancelButton.onDidClick((e) => {
-			vscode.window.showInformationMessage(loc.CANCEL_MIGRATION_CONFIRMATION, loc.YES, loc.NO).then(async (v) => {
+			vscode.window.showInformationMessage(loc.CANCEL_MIGRATION_CONFIRMATION, { modal: true }, loc.YES, loc.NO).then(async (v) => {
 				if (v === loc.YES) {
 					await this.cancelMigration();
 					await this.refreshStatus();


### PR DESCRIPTION
This PR fixes #15861 

Before: 
![image](https://user-images.githubusercontent.com/6816294/126008106-3136caff-a361-4c65-95fb-20e39a3eeb3b.png)

After: 
![image](https://user-images.githubusercontent.com/6816294/126008227-dad5fd97-c96a-43b7-a47e-5920639784fd.png)
