### PR TITLE
use modal confirmation dialog

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerActions.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerActions.ts
@@ -16,7 +16,7 @@ import * as nls from 'vs/nls';
 import { IEditorAction } from 'vs/editor/common/editorCommon';
 import { IEditorService, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 
 export class ProfilerConnect extends Action {
 	private static readonly ConnectText = nls.localize('profilerAction.connect', "Connect");
@@ -150,22 +150,18 @@ export class ProfilerClear extends Action {
 
 	constructor(id: string,
 		label: string,
-		@INotificationService private _notificationService: INotificationService) {
+		@IDialogService private _dialogService: IDialogService) {
 		super(id, label, 'clear-results');
 	}
 
 	override async run(input: ProfilerInput): Promise<void> {
-		this._notificationService.prompt(Severity.Warning, nls.localize('profiler.clearDataPrompt', "Are you sure you want to clear the data?"), [
-			{
-				label: nls.localize('profiler.yes', "Yes"),
-				run: () => {
-					input.data.clear();
-				}
-			}, {
-				label: nls.localize('profiler.no', "No"),
-				run: () => { }
-			}
-		]);
+		const result = await this._dialogService.confirm({
+			type: 'question',
+			message: nls.localize('profiler.clearDataPrompt', "Are you sure you want to clear the data?")
+		});
+		if (result.confirmed) {
+			input.data.clear();
+		}
 	}
 }
 
@@ -315,22 +311,18 @@ export class ProfilerClearSessionFilter extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@INotificationService private _notificationService: INotificationService
+		@IDialogService private _dialogService: IDialogService
 	) {
 		super(id, label, 'clear-filter');
 	}
 
 	public override async run(input: ProfilerInput): Promise<void> {
-		this._notificationService.prompt(Severity.Warning, nls.localize('profiler.clearFilterPrompt', "Are you sure you want to clear the filters?"), [
-			{
-				label: nls.localize('profiler.yes', "Yes"),
-				run: () => {
-					input.clearFilter();
-				}
-			}, {
-				label: nls.localize('profiler.no', "No"),
-				run: () => { }
-			}
-		]);
+		const result = await this._dialogService.confirm({
+			type: 'question',
+			message: nls.localize('profiler.clearFilterPrompt', "Are you sure you want to clear the filters?")
+		});
+		if (result.confirmed) {
+			input.clearFilter();
+		}
 	}
 }


### PR DESCRIPTION
While helping @aasimkhan30 looking into another issue, I realized I should also be using modal prompt here when we need user confirmation.

before:
![image](https://user-images.githubusercontent.com/13777222/126014324-8a2d340b-e1c9-4127-ad91-b62cf3ec83a2.png)


after:
![image](https://user-images.githubusercontent.com/13777222/126014061-8c5605e3-929d-41c8-82e1-d98cfcf813e6.png)




