### PR TITLE
Azure Monitor Logs hide database option 2

### DIFF
--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -109,20 +109,6 @@
           "categoryValues": null,
           "isRequired": true,
           "isArray": false
-        },
-        {
-          "specialValueType": "databaseName",
-          "isIdentity": true,
-          "name": "database",
-          "displayName": "%azuremonitor.connectionOptions.databaseName.displayName%",
-          "description": "%azuremonitor.connectionOptions.databaseName.description%",
-          "groupName": "Source",
-          "valueType": "string",
-          "defaultValue": null,
-          "objectType": null,
-          "categoryValues": null,
-          "isRequired": false,
-          "isArray": false
         }
       ]
     },

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -730,7 +730,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 		if (uri) {
 			let profile = this.connectionManagementService.getConnectionProfile(uri);
 			if (profile) {
-				return profile.databaseName;
+				return profile.databaseName ? profile.databaseName : profile.serverName;
 			}
 		}
 		return undefined;
@@ -759,7 +759,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 			return;
 		}
 
-		this.updateConnection(connParams.connectionProfile.databaseName);
+		this.updateConnection(connParams.connectionProfile.databaseName ? connParams.connectionProfile.databaseName : connParams.connectionProfile.serverName);
 	}
 
 	private onDropdownFocus(): void {


### PR DESCRIPTION
ADS requires multiple connection options to be declared to properly function including username, password, and databaseName. Azure Monitor Logs connects directly to a database equivalent so it has no use for a database. This is an alternative to hiding the database option.

Issue:
If the databaseName is not declared in the package.json then the query window is never able to select a database.

Preposed Solution
To resolve this, I removed all declarations of the database within the extension and ToolsService. In this case, ADS will query / show whatever it's given by the ToolsService.

This PR fixes #