### PR TITLE
Reduce the number of onUpdate events fired for dialog buttons

### DIFF
--- a/src/sql/workbench/api/browser/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/browser/mainThreadModelViewDialog.ts
@@ -161,19 +161,10 @@ export class MainThreadModelViewDialog extends Disposable implements MainThreadM
 		let button = this._buttons.get(handle);
 		if (!button) {
 			button = new DialogButton(details.label, details.enabled);
-			button.position = details.position;
-			button.hidden = details.hidden;
-			button.secondary = details.secondary;
 			button.onClick(() => this.onButtonClick(handle));
 			this._buttons.set(handle, button);
-		} else {
-			button.label = details.label;
-			button.enabled = details.enabled;
-			button.hidden = details.hidden;
-			button.focused = details.focused;
-			button.position = details.position;
-			button.secondary = details.secondary;
 		}
+		button.setProperties(details);
 
 		return Promise.resolve();
 	}

--- a/src/sql/workbench/services/dialog/common/dialogTypes.ts
+++ b/src/sql/workbench/services/dialog/common/dialogTypes.ts
@@ -100,22 +100,42 @@ export class Dialog extends ModelViewPane {
 	}
 }
 
+export interface DialogButtonProperties {
+	label: string;
+	enabled: boolean;
+	hidden: boolean;
+	focused?: boolean;
+	position?: azdata.window.DialogButtonPosition;
+	secondary?: boolean;
+}
+
 export class DialogButton implements azdata.window.Button {
-	private _label: string;
-	private _enabled: boolean;
-	private _hidden: boolean;
-	private _focused: boolean | undefined;
+	private _hidden: boolean = false;
+	private _focused?: boolean;
 	private _position?: azdata.window.DialogButtonPosition;
-	private _secondary: boolean | undefined;
+	private _secondary?: boolean;
 	private _onClick: Emitter<void> = new Emitter<void>();
 	public readonly onClick: Event<void> = this._onClick.event;
 	private _onUpdate: Emitter<void> = new Emitter<void>();
 	public readonly onUpdate: Event<void> = this._onUpdate.event;
 
-	constructor(label: string, enabled: boolean) {
-		this._label = label;
-		this._enabled = enabled;
-		this._hidden = false;
+	constructor(private _label: string, private _enabled: boolean) { }
+
+	/**
+	 * Sets all the values for the dialog button and then fires the onUpdate event once - this should be
+	 * preferred to be used when setting multiple properties to reduce overhead of event listeners having
+	 * to process multiple events.
+	 * Note that all current values are overwritten with the ones passed in.
+	 * @param properties The property values to set for this dialog button
+	 */
+	public setProperties(properties: DialogButtonProperties) {
+		this._enabled = properties.enabled;
+		this._focused = properties.focused;
+		this._hidden = properties.hidden;
+		this._label = properties.label;
+		this._position = properties.position;
+		this._secondary = properties.secondary;
+		this._onUpdate.fire();
 	}
 
 	public get label(): string {


### PR DESCRIPTION
Noticed this while investigating the issue with the model view validation affecting dialog buttons - the code that sets the properties for a dialog button fires the onUpdate event every time a property is changed. This is fine by itself - but the only place we're currently doing that has us always setting all 5 properties and so the event would be fired 5 times and end up going through a whole bunch of extra calls (including telling angular to redraw the UI) which was a huge amount of unnecessary overhead. 

So here I'm just adding a helper function to set all properties and fire the event just once at the end. 

Tested this with a couple of dialogs (including ones that set the button values manually after initial rendering) and things work as expected. 

We could get fancier with the setProperties and have it take in a Partial of the properties or something so as to not require setting ALL of the properties. But given how this function is called currently it didn't seem to be a huge deal to have it left simpler like this (a tiny bit of extra overhead from setting label/enabled twice). 