### PR TITLE
Plotly output resize

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -738,6 +738,7 @@
 					"rxjs/**",
 					"ng2-charts",
 					"chart.js",
+					"plotly.js",
 					"plotly.js-dist-min",
 					"angular2-grid",
 					"html-query-plan",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -739,7 +739,6 @@
 					"ng2-charts",
 					"chart.js",
 					"plotly.js",
-					"plotly.js-dist-min",
 					"angular2-grid",
 					"html-query-plan",
 					"turndown",

--- a/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
@@ -13,7 +13,7 @@ import { ICellModel } from 'sql/workbench/services/notebook/browser/models/model
 import { MimeModel } from 'sql/workbench/services/notebook/browser/outputs/mimemodel';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { getResizesObserver } from 'vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets';
-
+import * as Plotly from 'plotly.js';
 type ObjectType = object;
 
 interface FigureLayout extends ObjectType {
@@ -27,12 +27,6 @@ interface Figure extends ObjectType {
 	layout: Partial<FigureLayout>;
 }
 
-declare class PlotlyHTMLElement extends HTMLDivElement {
-	data: object;
-	layout: object;
-	newPlot: () => void;
-	redraw: () => void;
-}
 
 @Component({
 	selector: PlotlyOutputComponent.SELECTOR,
@@ -43,7 +37,7 @@ declare class PlotlyHTMLElement extends HTMLDivElement {
 export class PlotlyOutputComponent extends AngularDisposable implements IMimeComponent, OnInit {
 	public static readonly SELECTOR: string = 'plotly-output';
 
-	private static Plotly?: Promise<typeof import('plotly.js-dist-min')>;
+	private static Plotly?: Promise<typeof Plotly>;
 
 	@ViewChild('output', { read: ElementRef }) private output: ElementRef;
 
@@ -51,8 +45,8 @@ export class PlotlyOutputComponent extends AngularDisposable implements IMimeCom
 	private _rendered: boolean = false;
 	private _cellModel: ICellModel;
 	private _bundleOptions: MimeModel.IOptions;
-	private _plotDiv: PlotlyHTMLElement;
-	private _plotly: any;
+	private _plotDiv: Plotly.PlotlyHTMLElement;
+	private _plotly: typeof Plotly;
 	public errorText: string;
 
 	constructor() {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
@@ -140,9 +140,7 @@ export class PlotlyOutputComponent extends AngularDisposable implements IMimeCom
 	}
 
 	private resize() {
-		if (this._initialized) {
-			this._plotly.Plots.resize(this._plotDiv);
-		}
+		this._plotly.Plots.resize(this._plotDiv);
 	}
 
 	public hasError(): boolean {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/plotlyOutput.component.ts
@@ -12,6 +12,7 @@ import { IMimeComponent } from 'sql/workbench/contrib/notebook/browser/outputs/m
 import { ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { MimeModel } from 'sql/workbench/services/notebook/browser/outputs/mimemodel';
 import { getErrorMessage } from 'vs/base/common/errors';
+import { getResizesObserver } from 'vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets';
 
 type ObjectType = object;
 
@@ -51,6 +52,7 @@ export class PlotlyOutputComponent extends AngularDisposable implements IMimeCom
 	private _cellModel: ICellModel;
 	private _bundleOptions: MimeModel.IOptions;
 	private _plotDiv: PlotlyHTMLElement;
+	private _plotly: any;
 	public errorText: string;
 
 	constructor() {
@@ -83,8 +85,13 @@ export class PlotlyOutputComponent extends AngularDisposable implements IMimeCom
 		}
 		this._plotDiv = this.output.nativeElement;
 		this._plotDiv.style.maxWidth = '700px';
+		this._plotDiv.style.width = '100%';
 		this.renderPlotly();
 		this._initialized = true;
+
+		this._register(getResizesObserver(this._plotDiv, undefined, () => {
+			this.resize();
+		})).startObserving();
 	}
 
 	renderPlotly(): void {
@@ -106,6 +113,7 @@ export class PlotlyOutputComponent extends AngularDisposable implements IMimeCom
 		if (figure) {
 			let config = { responsive: true };
 			PlotlyOutputComponent.Plotly.then(plotly => {
+				this._plotly = plotly;
 				return plotly.newPlot(this._plotDiv, figure.data, figure.layout, config);
 			}).catch(e => this.displayError(e));
 		}
@@ -135,6 +143,12 @@ export class PlotlyOutputComponent extends AngularDisposable implements IMimeCom
 
 	layout(): void {
 		// No need to re-layout for now as Plotly is doing its own resize handling.
+	}
+
+	private resize() {
+		if (this._initialized) {
+			this._plotly.Plots.resize(this._plotDiv);
+		}
 	}
 
 	public hasError(): boolean {


### PR DESCRIPTION
Allow Plotly graphs to resize based on the size of the output container itself, not only when the window is resized. This allows graphs contained within cells of the Notebook Views grid to adapt to the size of their container whenever the cell is resized.

**Before**
![plotly-resize-before](https://user-images.githubusercontent.com/8183814/126212719-6f53da91-d4a3-42c6-ad90-def287a2fcb7.gif)

**After**
![plotly-resize-after](https://user-images.githubusercontent.com/8183814/126212759-81f92e59-21b7-47b2-83fd-b104532a4fbb.gif)
