### PR TITLE
fix the icon size issue of info button

### DIFF
--- a/src/sql/base/browser/ui/infoButton/infoButton.css
+++ b/src/sql/base/browser/ui/infoButton/infoButton.css
@@ -17,6 +17,10 @@
 	flex-flow: column;
 	padding-right: 10px;
 }
+.info-button .info-icon .icon {
+	background-size: cover;
+	background-repeat: no-repeat;
+}
 .info-button .info-text {
 	display: flex;
 	flex-flow: column;


### PR DESCRIPTION
a partner is using the info button component and noticed this issue. (I am using migration extension to repro the issue and take screenshots)

before:
![image](https://user-images.githubusercontent.com/13777222/126208947-2444b428-86ef-4e76-a525-e80d99c772d4.png)

after:
![image](https://user-images.githubusercontent.com/13777222/126209337-4a7205fb-a00f-46ea-99f8-4af47fb7755e.png)
