### PR TITLE
Add headingLevel to textComponent

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -574,6 +574,14 @@ declare module 'azdata' {
 		onInput: vscode.Event<number>;
 	}
 
+	export interface TextComponentProperties {
+		/**
+		 * The heading level for this component - if set the text component will be created as an h#
+		 * HTML element with this value being the #. 
+		 */
+		headingLevel?: number;
+	}
+
 	export namespace nb {
 		/**
 		 * An event that is emitted when the active Notebook editor is changed.

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -574,12 +574,17 @@ declare module 'azdata' {
 		onInput: vscode.Event<number>;
 	}
 
+	/**
+	 * The heading levels an HTML heading element can be.
+	 */
+	export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
 	export interface TextComponentProperties {
 		/**
 		 * The heading level for this component - if set the text component will be created as an h#
-		 * HTML element with this value being the #. 
+		 * HTML element with this value being the #.
 		 */
-		headingLevel?: number;
+		headingLevel?: HeadingLevel;
 	}
 
 	export namespace nb {

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1371,10 +1371,10 @@ class TextComponentWrapper extends ComponentWrapper implements azdata.TextCompon
 		this.setProperty('requiredIndicator', requiredIndicator);
 	}
 
-	public get headingLevel(): number | undefined {
+	public get headingLevel(): azdata.HeadingLevel | undefined {
 		return this.properties['headingLevel'];
 	}
-	public set headingLevel(headingLevel: number | undefined) {
+	public set headingLevel(headingLevel: azdata.HeadingLevel | undefined) {
 		this.setProperty('headingLevel', headingLevel);
 	}
 }

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1370,6 +1370,13 @@ class TextComponentWrapper extends ComponentWrapper implements azdata.TextCompon
 	public set requiredIndicator(requiredIndicator: boolean) {
 		this.setProperty('requiredIndicator', requiredIndicator);
 	}
+
+	public get headingLevel(): number | undefined {
+		return this.properties['headingLevel'];
+	}
+	public set headingLevel(headingLevel: number | undefined) {
+		this.setProperty('headingLevel', headingLevel);
+	}
 }
 
 class ImageComponentWrapper extends ComponentWithIconWrapper implements azdata.ImageComponentProperties {

--- a/src/sql/workbench/browser/modelComponents/media/text.css
+++ b/src/sql/workbench/browser/modelComponents/media/text.css
@@ -3,6 +3,11 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+modelview-text div#textContainer {
+	margin-block-start: 1em;
+	margin-block-end: 1em;
+}
+
 .modelview-text-tooltip {
 	background-size: 12px 12px;
 	background-repeat: no-repeat;
@@ -41,8 +46,4 @@
 
 .modelview-text-tooltip:focus .modelview-text-tooltip-content, .modelview-text-tooltip:hover .modelview-text-tooltip-content {
 	visibility: visible;
-}
-
-.modelview-text-link {
-	text-decoration: underline !important;
 }

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -95,10 +95,12 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 
 	public set headingLevel(newValue: number | undefined) {
 		this.setPropertyFromUI<number | undefined>((properties, value) => { properties.headingLevel = value; }, newValue);
+		this.validateHeadingLevel();
 	}
 
 	public override setProperties(properties: { [key: string]: any; }): void {
 		super.setProperties(properties);
+		this.validateHeadingLevel();
 		this.updateText();
 		this._changeRef.detectChanges();
 	}
@@ -156,19 +158,26 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		return this.requiredIndicator || !!this.description;
 	}
 
+	private validateHeadingLevel(): void {
+		const headingLevel = this.headingLevel;
+		if (headingLevel < 1) {
+			this.logService.error(`Text component heading level must be a value between 1 and 6 (Actual ${headingLevel})`);
+			this.headingLevel = 1;
+		} else if (headingLevel > 6) {
+			this.logService.error(`Text component heading level must be a value between 1 and 6 (Actual : ${headingLevel})`);
+			this.headingLevel = 6;
+		}
+	}
 	/**
 	 * Creates the appropriate text element based on the type of text component (regular or header) this is
 	 * @returns The text element
 	 */
 	private createTextElement(): HTMLElement {
-		const headingLevel = this.headingLevel;
+		let headingLevel = this.headingLevel;
 		let element: HTMLElement;
-		if (headingLevel === undefined) {
+		if (!headingLevel) { // Undefined or 0
 			element = DOM.$('span');
 		} else {
-			if (headingLevel > 6) {
-				throw new Error('Heading level must be a value between 1 and 6');
-			}
 			element = DOM.$(`h${headingLevel}`);
 		}
 		// Manually set the font-size and font-weight since that is set by the base style sheets which may not be what the user wants

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -166,6 +166,9 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		if (headingLevel === undefined) {
 			element = DOM.$('span');
 		} else {
+			if (headingLevel > 6) {
+				throw new Error('Heading level must be a value between 1 and 6');
+			}
 			element = DOM.$(`h${headingLevel}`);
 		}
 		// Manually set the font-size and font-weight since that is set by the base style sheets which may not be what the user wants

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -168,6 +168,7 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		} else {
 			element = DOM.$(`h${headingLevel}`);
 		}
+		// Manually set the font-size and font-weight since that is set by the base style sheets which may not be what the user wants
 		element.style.fontSize = this.CSSStyles['font-size']?.toString();
 		element.style.fontWeight = this.CSSStyles['font-weight']?.toString();
 		return element;

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -89,18 +89,16 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		return this.getPropertyOrDefault<boolean>((props) => props.requiredIndicator, false);
 	}
 
-	public get headingLevel(): number | undefined {
-		return this.getPropertyOrDefault<number | undefined>(props => props.headingLevel, undefined);
+	public get headingLevel(): azdata.HeadingLevel | undefined {
+		return this.getPropertyOrDefault<azdata.HeadingLevel | undefined>(props => props.headingLevel, undefined);
 	}
 
-	public set headingLevel(newValue: number | undefined) {
-		this.setPropertyFromUI<number | undefined>((properties, value) => { properties.headingLevel = value; }, newValue);
-		this.validateHeadingLevel();
+	public set headingLevel(newValue: azdata.HeadingLevel | undefined) {
+		this.setPropertyFromUI<azdata.HeadingLevel | undefined>((properties, value) => { properties.headingLevel = value; }, newValue);
 	}
 
 	public override setProperties(properties: { [key: string]: any; }): void {
 		super.setProperties(properties);
-		this.validateHeadingLevel();
 		this.updateText();
 		this._changeRef.detectChanges();
 	}
@@ -158,16 +156,6 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		return this.requiredIndicator || !!this.description;
 	}
 
-	private validateHeadingLevel(): void {
-		const headingLevel = this.headingLevel;
-		if (headingLevel < 1) {
-			this.logService.error(`Text component heading level must be a value between 1 and 6 (Actual ${headingLevel})`);
-			this.headingLevel = 1;
-		} else if (headingLevel > 6) {
-			this.logService.error(`Text component heading level must be a value between 1 and 6 (Actual : ${headingLevel})`);
-			this.headingLevel = 6;
-		}
-	}
 	/**
 	 * Creates the appropriate text element based on the type of text component (regular or header) this is
 	 * @returns The text element

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -24,17 +24,15 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 	selector: 'modelview-text',
 	template: `
 	<div *ngIf="showDiv;else noDiv" style="display:flex;flex-flow:row;align-items:center;" [style.width]="getWidth()" [style.height]="getHeight()">
-	<p [title]="title" [ngStyle]="this.CSSStyles" [attr.role]="ariaRole" [attr.aria-hidden]="ariaHidden"></p>
-		<span #textContainer></span>
-		<p *ngIf="requiredIndicator" style="color:red;margin-left:5px;">*</p>
+		<p [title]="title" [ngStyle]="this.CSSStyles" [attr.role]="ariaRole" [attr.aria-hidden]="ariaHidden"></p>
+		<div #textContainer id="textContainer"></div>
+		<span *ngIf="requiredIndicator" style="color:red;margin-left:5px;">*</span>
 		<div *ngIf="description" tabindex="0" class="modelview-text-tooltip" [attr.aria-label]="description" role="img">
 			<div class="modelview-text-tooltip-content" [innerHTML]="description"></div>
 		</div>
 	</div>
 	<ng-template #noDiv>
-	<p [style.display]="display" [style.width]="getWidth()" [style.height]="getHeight()" [title]="title" [attr.role]="ariaRole" [attr.aria-hidden]="ariaHidden" [ngStyle]="this.CSSStyles">
-		<span #textContainer></span>
-	</p>
+		<div #textContainer id="textContainer" [style.display]="display" [style.width]="getWidth()" [style.height]="getHeight()" [title]="title" [attr.role]="ariaRole" [attr.aria-hidden]="ariaHidden" [ngStyle]="this.CSSStyles"></div>
 	</ng-template>`
 })
 export default class TextComponent extends TitledComponent<azdata.TextComponentProperties> implements IComponent, OnDestroy, AfterViewInit {
@@ -91,6 +89,14 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		return this.getPropertyOrDefault<boolean>((props) => props.requiredIndicator, false);
 	}
 
+	public get headingLevel(): number | undefined {
+		return this.getPropertyOrDefault<number | undefined>(props => props.headingLevel, undefined);
+	}
+
+	public set headingLevel(newValue: number | undefined) {
+		this.setPropertyFromUI<number | undefined>((properties, value) => { properties.headingLevel = value; }, newValue);
+	}
+
 	public override setProperties(properties: { [key: string]: any; }): void {
 		super.setProperties(properties);
 		this.updateText();
@@ -113,7 +119,7 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 			// First insert any text from the start of the current string fragment up to the placeholder
 			let curText = text.slice(0, placeholderIndex);
 			if (curText) {
-				const textSpan = DOM.$('span');
+				const textSpan = this.createTextElement();
 				textSpan.innerText = text.slice(0, placeholderIndex);
 				(<HTMLElement>this.textContainer.nativeElement).appendChild(textSpan);
 			}
@@ -140,7 +146,7 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 
 		// If we have any text left over now insert that in directly
 		if (text) {
-			const textSpan = DOM.$('span');
+			const textSpan = this.createTextElement();
 			textSpan.innerText = text;
 			(<HTMLElement>this.textContainer.nativeElement).appendChild(textSpan);
 		}
@@ -148,5 +154,14 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 
 	public get showDiv(): boolean {
 		return this.requiredIndicator || !!this.description;
+	}
+
+	private createTextElement(): HTMLElement {
+		const headingLevel = this.headingLevel;
+		if (headingLevel === undefined) {
+			return DOM.$('span');
+		} else {
+			return DOM.$(`h${headingLevel}`);
+		}
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -119,9 +119,9 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 			// First insert any text from the start of the current string fragment up to the placeholder
 			let curText = text.slice(0, placeholderIndex);
 			if (curText) {
-				const textSpan = this.createTextElement();
-				textSpan.innerText = text.slice(0, placeholderIndex);
-				(<HTMLElement>this.textContainer.nativeElement).appendChild(textSpan);
+				const textElement = this.createTextElement();
+				textElement.innerText = text.slice(0, placeholderIndex);
+				(<HTMLElement>this.textContainer.nativeElement).appendChild(textElement);
 			}
 
 			// Now insert the link element
@@ -146,9 +146,9 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 
 		// If we have any text left over now insert that in directly
 		if (text) {
-			const textSpan = this.createTextElement();
-			textSpan.innerText = text;
-			(<HTMLElement>this.textContainer.nativeElement).appendChild(textSpan);
+			const textElement = this.createTextElement();
+			textElement.innerText = text;
+			(<HTMLElement>this.textContainer.nativeElement).appendChild(textElement);
 		}
 	}
 
@@ -156,12 +156,20 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 		return this.requiredIndicator || !!this.description;
 	}
 
+	/**
+	 * Creates the appropriate text element based on the type of text component (regular or header) this is
+	 * @returns The text element
+	 */
 	private createTextElement(): HTMLElement {
 		const headingLevel = this.headingLevel;
+		let element: HTMLElement;
 		if (headingLevel === undefined) {
-			return DOM.$('span');
+			element = DOM.$('span');
 		} else {
-			return DOM.$(`h${headingLevel}`);
+			element = DOM.$(`h${headingLevel}`);
 		}
+		element.style.fontSize = this.CSSStyles['font-size']?.toString();
+		element.style.fontWeight = this.CSSStyles['font-weight']?.toString();
+		return element;
 	}
 }


### PR DESCRIPTION
Adds headingLevel to textComponent for displaying text as a header.

This required changing up some of the elements that the component used - since we can't nest h#'s inside of a span. The CSS changes were then made so that the elements all lined up as expected again.

Here's what an example text field looks like with headingLevel set to 1

![image](https://user-images.githubusercontent.com/28519865/126213398-0e181102-07e2-4607-b902-cef1b4c5f474.png)

Note that the large text is expected since it picks up the default styles for the appropriate heading level. Callers can specify their own CSS styles if they want to override that. 

Here's some screenshots of current UI vs UI after change for validation that these don't affect anything else. 

Before : 

![image](https://user-images.githubusercontent.com/28519865/126213094-331ddd9e-b72f-4b65-836e-b5031e2fb956.png)


After : 

![image](https://user-images.githubusercontent.com/28519865/126213057-741cc1bb-050f-4735-8fac-acb03497869d.png)

Before :

![image](https://user-images.githubusercontent.com/28519865/126213129-20cd0e2c-1fa6-4e05-bea2-593ca7c600b7.png)

After: 

![image](https://user-images.githubusercontent.com/28519865/126213167-0f4c53cd-a99d-4ae5-b3a6-08aaad187506.png)

Before : 

![image](https://user-images.githubusercontent.com/28519865/126213288-1284a93b-2654-4046-9735-6871c6ed36c5.png)

After: 

![image](https://user-images.githubusercontent.com/28519865/126213327-111c8f26-32d3-471f-8964-2fa9079d519e.png)



