### PR TITLE
added updates to extensionsGallery for RC1

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1780,7 +1780,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -1845,7 +1845,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -1910,7 +1910,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -1975,7 +1975,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2040,7 +2040,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2105,7 +2105,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2170,7 +2170,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2235,7 +2235,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2300,7 +2300,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2365,7 +2365,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1779,14 +1779,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-de-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-de-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1816,7 +1816,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1844,14 +1844,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-es-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-es-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1881,7 +1881,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1909,14 +1909,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-fr-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-fr-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1946,7 +1946,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1974,14 +1974,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-it-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-it-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2011,7 +2011,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2039,14 +2039,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-ko-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-ko-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2076,7 +2076,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2104,14 +2104,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-pt-br-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-pt-br-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2141,7 +2141,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2169,14 +2169,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-ru-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-ru-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2206,7 +2206,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2234,14 +2234,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-zh-hans-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-zh-hans-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2271,7 +2271,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2299,14 +2299,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-zh-hant-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-zh-hant-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2336,7 +2336,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2364,14 +2364,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-ja-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-ja-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2401,7 +2401,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1780,7 +1780,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -1845,7 +1845,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -1910,7 +1910,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -1975,7 +1975,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2040,7 +2040,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2105,7 +2105,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2170,7 +2170,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2235,7 +2235,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2300,7 +2300,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -2365,7 +2365,7 @@
 					"versions": [
 						{
 							"version": "1.31.0",
-							"lastUpdated": "5/24/2021",
+							"lastUpdated": "7/19/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1779,14 +1779,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-de-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-de-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1816,7 +1816,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1844,14 +1844,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-es-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-es-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1881,7 +1881,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1909,14 +1909,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-fr-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-fr-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1946,7 +1946,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1974,14 +1974,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-it-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-it-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2011,7 +2011,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2039,14 +2039,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-ko-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-ko-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2076,7 +2076,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2104,14 +2104,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-pt-br-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-pt-br-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2141,7 +2141,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2169,14 +2169,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-ru-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-ru-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2206,7 +2206,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2234,14 +2234,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-zh-hans-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-zh-hans-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2271,7 +2271,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2299,14 +2299,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-zh-hant-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-zh-hant-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2336,7 +2336,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -2364,14 +2364,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.29.0",
+							"version": "1.31.0",
 							"lastUpdated": "5/24/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-ja-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.31.0/ads-language-pack-ja-1.31.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -2401,7 +2401,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.29.0"
+									"value": ">=1.31.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",


### PR DESCRIPTION
Now targeting extensions/rc1

This is an update to the RC1 extensions gallery with newly updated langpacks, the build to get the vsixes from is located here (currently compiling): https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=111847&view=results

I have tested the langpacks locally (via an adhoc-build identical to that of release/1.31) and they fix the core strings that were previously missing from vscode edits. The extensions so far are not fully translated as they are still the old version. They will be bumped to the new webpacked versions for the August release.