### PR TITLE
add toggle button for properties container

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1003,4 +1003,11 @@ declare module 'azdata' {
 	export interface VisualizationOptions {
 		type: VisualizationType;
 	}
+
+	export interface PropertiesContainerComponentProperties {
+		/**
+		 * Whether to show the button that will hide/show the content of the container. Default value is false.
+		 */
+		showToggleButton?: boolean;
+	}
 }

--- a/src/sql/base/browser/ui/propertiesContainer/media/propertiesContainer.css
+++ b/src/sql/base/browser/ui/propertiesContainer/media/propertiesContainer.css
@@ -61,3 +61,7 @@ properties-container .splitter {
 properties-container .columnLayout .splitter {
 	display: none;
 }
+
+properties-container .actionbar-container {
+	justify-content: center;
+}

--- a/src/sql/base/browser/ui/propertiesContainer/propertiesContainer.component.html
+++ b/src/sql/base/browser/ui/propertiesContainer/propertiesContainer.component.html
@@ -4,7 +4,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 -->
-<div class="grid-container {{gridDisplayLayout}}">
+<div *ngIf="this._togglePropertiesAction.expanded" class="grid-container {{gridDisplayLayout}}">
 	<ng-template ngFor let-item [ngForOf]="propertyItems">
 		<div class="property {{propertyLayout}}">
 			<div class="propertyName">{{item.displayName}}</div>
@@ -13,3 +13,4 @@
 		</div>
 	</ng-template>
 </div>
+<div [style.display]="this.showToggleButton ? 'flex': 'none'"  class="actionbar-container" #actionbar></div>

--- a/src/sql/base/browser/ui/propertiesContainer/togglePropertiesAction.ts
+++ b/src/sql/base/browser/ui/propertiesContainer/togglePropertiesAction.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Action } from 'vs/base/common/actions';
+import * as nls from 'vs/nls';
+
+export class TogglePropertiesAction extends Action {
+	private static readonly ID = 'TogglePropertiesAction';
+	private static readonly COLLPASE_LABEL = nls.localize('hideProperties', "Hide properties");
+	private static readonly EXPAND_LABEL = nls.localize('showProperties', "Show Properties");
+	private static readonly COLLAPSE_ICON = 'codicon-chevron-up';
+	private static readonly EXPAND_ICON = 'codicon-chevron-down';
+
+	constructor(
+	) {
+		super(TogglePropertiesAction.ID, TogglePropertiesAction.COLLPASE_LABEL, TogglePropertiesAction.COLLAPSE_ICON);
+		this.expanded = true;
+	}
+
+	override async run(): Promise<void> {
+		this.expanded = !this.expanded;
+		this.class = this.expanded ? TogglePropertiesAction.COLLAPSE_ICON : TogglePropertiesAction.EXPAND_ICON;
+		this.label = this.expanded ? TogglePropertiesAction.COLLPASE_LABEL : TogglePropertiesAction.EXPAND_LABEL;
+	}
+}

--- a/src/sql/workbench/browser/modelComponents/propertiesContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/propertiesContainer.component.ts
@@ -47,6 +47,7 @@ export default class PropertiesContainerComponent extends ComponentBase<azdata.P
 	public override setProperties(properties: { [key: string]: any; }): void {
 		super.setProperties(properties);
 		this._propertiesContainer.propertyItems = this.propertyItems;
+		this._propertiesContainer.showToggleButton = this.showToggleButton;
 	}
 
 	public get propertyItems(): PropertyItem[] {
@@ -56,6 +57,10 @@ export default class PropertiesContainerComponent extends ComponentBase<azdata.P
 	public set propertyItems(newValue: azdata.PropertiesContainerItem[]) {
 		this.setPropertyFromUI<azdata.PropertiesContainerItem[]>((props, value) => props.propertyItems = value, newValue);
 		this._propertiesContainer.propertyItems = newValue;
+	}
+
+	public get showToggleButton(): boolean {
+		return this.getPropertyOrDefault<boolean>((props) => props.showToggleButton, false);
 	}
 }
 


### PR DESCRIPTION
feature request by a partner team.

this is by default not visible.

usage:

```TypeScript
modelView.modelBuilder.propertiesContainer().withProps({ showToggleButton: true }).component();
```

![image](https://user-images.githubusercontent.com/13777222/126245518-162e5baa-0084-415b-829a-491973eccda8.png)


![image](https://user-images.githubusercontent.com/13777222/126245442-a74181cf-216f-4dd9-81f5-e846d83b1a16.png)


