### PR TITLE
Fix for Portuguese

### DIFF
--- a/i18n/ads-language-pack-pt-BR/package.json
+++ b/i18n/ads-language-pack-pt-BR/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ads-language-pack-pt-BR",
+	"name": "ads-language-pack-pt-br",
 	"displayName": "Portuguese (Brazil) Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Portuguese (Brazil)",
 	"version": "1.31.0",


### PR DESCRIPTION
This is a small fix for the portuguese language id, this is required to make my langpacks fully work with ADS.

This is to address this: https://github.com/microsoft/azuredatastudio/issues/16359

This is basically a port of #15665