### PR TITLE
Added replacement for name of Portuguese langpack

### DIFF
--- a/build/lib/locFunc.js
+++ b/build/lib/locFunc.js
@@ -238,7 +238,7 @@ function refreshLangpacks() {
         }
         let packageJSON = JSON.parse(fs.readFileSync(path.join(locExtFolder, 'package.json')).toString());
         //processing extension fields, version and folder name must be changed manually.
-        packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText).replace('pt-BR', 'pt-br');
+        packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText).toLowerCase();
         packageJSON['displayName'] = packageJSON['displayName'].replace('Visual Studio Code', textFields.displayNameText);
         packageJSON['publisher'] = textFields.publisherText;
         packageJSON['license'] = textFields.licenseText;

--- a/build/lib/locFunc.js
+++ b/build/lib/locFunc.js
@@ -238,7 +238,7 @@ function refreshLangpacks() {
         }
         let packageJSON = JSON.parse(fs.readFileSync(path.join(locExtFolder, 'package.json')).toString());
         //processing extension fields, version and folder name must be changed manually.
-        packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText);
+        packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText).replace('pt-BR', 'pt-br');
         packageJSON['displayName'] = packageJSON['displayName'].replace('Visual Studio Code', textFields.displayNameText);
         packageJSON['publisher'] = textFields.publisherText;
         packageJSON['license'] = textFields.licenseText;

--- a/build/lib/locFunc.ts
+++ b/build/lib/locFunc.ts
@@ -256,7 +256,7 @@ export function refreshLangpacks(): Promise<void> {
 		}
 		let packageJSON = JSON.parse(fs.readFileSync(path.join(locExtFolder, 'package.json')).toString());
 		//processing extension fields, version and folder name must be changed manually.
-		packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText).replace('pt-BR', 'pt-br');
+		packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText).toLowerCase();
 		packageJSON['displayName'] = packageJSON['displayName'].replace('Visual Studio Code', textFields.displayNameText);
 		packageJSON['publisher'] = textFields.publisherText;
 		packageJSON['license'] = textFields.licenseText;

--- a/build/lib/locFunc.ts
+++ b/build/lib/locFunc.ts
@@ -256,7 +256,7 @@ export function refreshLangpacks(): Promise<void> {
 		}
 		let packageJSON = JSON.parse(fs.readFileSync(path.join(locExtFolder, 'package.json')).toString());
 		//processing extension fields, version and folder name must be changed manually.
-		packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText);
+		packageJSON['name'] = packageJSON['name'].replace('vscode', textFields.nameText).replace('pt-BR', 'pt-br');
 		packageJSON['displayName'] = packageJSON['displayName'].replace('Visual Studio Code', textFields.displayNameText);
 		packageJSON['publisher'] = textFields.publisherText;
 		packageJSON['license'] = textFields.licenseText;


### PR DESCRIPTION
Turns out vscode langpacks have the name pt-BR instead of pt-br, this generates the wrong id for the langpacks. To fix this from now on, string replacement has been added. 
