### PR TITLE
List databases for publish quickpick

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -79,7 +79,7 @@ export async function launchPublishDatabaseQuickpick(project: Project): Promise<
 		if (!connectionProfile) {
 			return;
 		}
-		// Get the list of databases now to validate that the connection is valid and re-prompt them if it is
+		// Get the list of databases now to validate that the connection is valid and re-prompt them if it isn't
 		try {
 			dbs = await vscodeMssqlApi.listDatabases(connectionProfile);
 		} catch (err) {

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -69,14 +69,26 @@ export async function launchPublishDatabaseQuickpick(project: Project): Promise<
 		// so exit the flow.
 		return;
 	}
+	quickPick.hide(); // Hide the quickpick immediately so it isn't showing while the API loads
 
 	// 2. Select connection
-	const api = await getVscodeMssqlApi();
-	const connectionProfile = await api.promptForConnection();
-	if (!connectionProfile) {
-		return;
+	const vscodeMssqlApi = await getVscodeMssqlApi();
+	let dbs: string[] | undefined = undefined;
+	while (!dbs) {
+		const connectionProfile = await vscodeMssqlApi.promptForConnection(true);
+		if (!connectionProfile) {
+			return;
+		}
+		// Get the list of databases now to validate that the connection is valid and re-prompt them if it is
+		try {
+			dbs = await vscodeMssqlApi.listDatabases(connectionProfile);
+		} catch (err) {
+			// no-op, the mssql extension handles showing the error to the user. We'll just go
+			// back and prompt the user for a connection again
+		}
 	}
-	const dbs = ['db1', 'db2'];
+
+	// 3. Select database
 	const dbQuickpicks = dbs.map(db => {
 		return {
 			label: db,
@@ -93,10 +105,9 @@ export async function launchPublishDatabaseQuickpick(project: Project): Promise<
 	}
 
 	dbQuickpicks.push({ label: constants.createNew, dbName: '', isCreateNew: true });
-	// 3. Select database
-	// TODO@chgagnon: Hook up to MSSQL
-	let databaseName = '';
-	while (databaseName === '') {
+
+	let databaseName: string | undefined = undefined;
+	while (!databaseName) {
 		const selectedDatabase = await vscode.window.showQuickPick(
 			dbQuickpicks,
 			{ title: constants.selectDatabase, ignoreFocusOut: true });
@@ -116,7 +127,6 @@ export async function launchPublishDatabaseQuickpick(project: Project): Promise<
 			// If user cancels out of this just return them to the db select quickpick in case they changed their mind
 		}
 	}
-
 
 	// 4. Modify sqlcmd vars
 	// If a publish profile is provided then the values from there will overwrite the ones in the

--- a/extensions/sql-database-projects/src/typings/vscode-mssql.d.ts
+++ b/extensions/sql-database-projects/src/typings/vscode-mssql.d.ts
@@ -28,8 +28,16 @@ declare module 'vscode-mssql' {
 
         /**
          * Prompts the user to select an existing connection or create a new one, and then returns the result
+         * @param ignoreFocusOut Whether the quickpick prompt ignores focus out (default false)
          */
-        promptForConnection(): Promise<IConnectionInfo | undefined>
+        promptForConnection(ignoreFocusOut?: boolean): Promise<IConnectionInfo | undefined>;
+
+        /**
+         * Lists the databases for a given connection. An error is thrown and displayed to the user if an
+         * error occurs while connecting
+         * @param connection The connection to list the databases for
+         */
+        listDatabases(connection: IConnectionInfo): Promise<string[]>;
     }
 
     /**


### PR DESCRIPTION
Hooking up to the changes made in the VS Code MSSQL extension.

Also two minor fixes : 

1. ignoreFocusOut on prompt for connection
2. Hide the profile prompt right after selecting an option. If the MS SQL extension takes a while to respond (usually because it needs to be activated) then we don't want to have it waiting since it seems like it's hung then. 

(I plan on making the sql-database-projects extension actual have a dependency on the mssql extension so that it is already activated before getting to this dialog in the future though, so this shouldn't be needed at that point. But it's still good to have)

![ListDatabases](https://user-images.githubusercontent.com/28519865/126407690-f812efec-34ac-480f-8acf-86255f1302d1.gif)
