### PR TITLE
Combine project deploy settings into one

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -10,7 +10,7 @@ import * as utils from '../common/utils';
 
 import { Project } from '../models/project';
 import { SqlConnectionDataSource } from '../models/dataSources/sqlConnectionStringSource';
-import { IPublishSettings, IGenerateScriptSettings } from '../models/IPublishSettings';
+import { IDeploySettings } from '../models/IDeploySettings';
 import { DeploymentOptions, SchemaObjectType } from '../../../mssql/src/mssql';
 import { IconPathHelper } from '../common/iconHelper';
 import { cssStyles } from '../common/uiConstants';
@@ -46,8 +46,8 @@ export class PublishDatabaseDialog {
 
 	private toDispose: vscode.Disposable[] = [];
 
-	public publish: ((proj: Project, profile: IPublishSettings) => any) | undefined;
-	public generateScript: ((proj: Project, profile: IGenerateScriptSettings) => any) | undefined;
+	public publish: ((proj: Project, profile: IDeploySettings) => any) | undefined;
+	public generateScript: ((proj: Project, profile: IDeploySettings) => any) | undefined;
 	public readPublishProfile: ((profileUri: vscode.Uri) => any) | undefined;
 
 	constructor(private project: Project) {
@@ -182,10 +182,9 @@ export class PublishDatabaseDialog {
 	}
 
 	public async publishClick(): Promise<void> {
-		const settings: IPublishSettings = {
+		const settings: IDeploySettings = {
 			databaseName: this.getTargetDatabaseName(),
 			serverName: this.getServerName(),
-			upgradeExisting: true,
 			connectionUri: await this.getConnectionUri(),
 			sqlCmdVariables: this.getSqlCmdVariablesForPublish(),
 			deploymentOptions: await this.getDeploymentOptions(),
@@ -202,7 +201,7 @@ export class PublishDatabaseDialog {
 		TelemetryReporter.sendActionEvent(TelemetryViews.SqlProjectPublishDialog, TelemetryActions.generateScriptClicked);
 
 		const sqlCmdVars = this.getSqlCmdVariablesForPublish();
-		const settings: IGenerateScriptSettings = {
+		const settings: IDeploySettings = {
 			databaseName: this.getTargetDatabaseName(),
 			serverName: this.getServerName(),
 			connectionUri: await this.getConnectionUri(),
@@ -213,9 +212,7 @@ export class PublishDatabaseDialog {
 
 		utils.getAzdataApi()!.window.closeDialog(this.dialog);
 
-		if (this.generateScript) {
-			await this.generateScript!(this.project, settings);
-		}
+		await this.generateScript?.(this.project, settings);
 
 		this.dispose();
 	}

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import * as constants from '../common/constants';
-import { IGenerateScriptSettings, IPublishSettings } from '../models/IPublishSettings';
 import { Project } from '../models/project';
 import { PublishProfile, readPublishProfile } from '../models/publishProfile/publishProfile';
 import { promptForPublishProfile } from './publishDatabaseDialog';
@@ -188,17 +187,12 @@ export async function launchPublishDatabaseQuickpick(project: Project): Promise<
 
 	// TODO@chgagnon: Get deployment options
 	// 6. Generate script/publish
-	let settings: IPublishSettings | IGenerateScriptSettings = {
-		databaseName: databaseName,
-		serverName: '', // TODO@chgagnon: Get from connection profile
-		connectionUri: '', // TODO@chgagnon: Get from connection profile
-		sqlCmdVariables: undefined, // this.getSqlCmdVariablesForPublish(),
-		deploymentOptions: undefined, // await this.getDeploymentOptions(),
-		profileUsed: true, // this.profileUsed,
-	};
-
-	// TODO@chgagnon Consolidate creation of the settings into one place
-	if (action === constants.publish) {
-		(settings as IPublishSettings).upgradeExisting = true;
-	}
+	// let settings: IDeploySettings | IGenerateScriptSettings = {
+	// 	databaseName: databaseName,
+	// 	serverName: connectionProfile!.server,
+	// 	connectionUri: '', // TODO@chgagnon: Get from connection profile
+	// 	sqlCmdVariables: sqlCmdVariables,
+	// 	deploymentOptions: undefined, // await this.getDeploymentOptions(),
+	// 	profileUsed: !!publishProfile
+	// };
 }

--- a/extensions/sql-database-projects/src/models/IDeploySettings.ts
+++ b/extensions/sql-database-projects/src/models/IDeploySettings.ts
@@ -5,17 +5,7 @@
 
 import { DeploymentOptions } from '../../../mssql/src/mssql';
 
-export interface IPublishSettings {
-	databaseName: string;
-	serverName: string;
-	connectionUri: string;
-	upgradeExisting: boolean;
-	sqlCmdVariables?: Record<string, string>;
-	deploymentOptions?: DeploymentOptions;
-	profileUsed?: boolean;
-}
-
-export interface IGenerateScriptSettings {
+export interface IDeploySettings {
 	databaseName: string;
 	serverName: string;
 	connectionUri: string;

--- a/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
@@ -15,7 +15,7 @@ import * as TypeMoq from 'typemoq';
 import { PublishDatabaseDialog } from '../../dialogs/publishDatabaseDialog';
 import { Project } from '../../models/project';
 import { ProjectsController } from '../../controllers/projectController';
-import { IPublishSettings, IGenerateScriptSettings } from '../../models/IPublishSettings';
+import { IDeploySettings } from '../../models/IDeploySettings';
 import { emptySqlDatabaseProjectTypeId } from '../../common/constants';
 import { mockDacFxOptionsResult } from '../testContext';
 
@@ -70,13 +70,12 @@ describe('Publish Database Dialog', () => {
 		dialog.setup(x => x.getServerName()).returns(() => 'MockServer');
 		dialog.callBase = true;
 
-		let profile: IPublishSettings | IGenerateScriptSettings | undefined;
+		let profile: IDeploySettings | undefined;
 
-		const expectedPublish: IPublishSettings = {
+		const expectedPublish: IDeploySettings = {
 			databaseName: 'MockDatabaseName',
 			serverName: 'MockServer',
 			connectionUri: 'Mock|Connection|Uri',
-			upgradeExisting: true,
 			sqlCmdVariables: {
 				'ProdDatabaseName': 'MyProdDatabase',
 				'BackupDatabaseName': 'MyBackupDatabase'
@@ -90,7 +89,7 @@ describe('Publish Database Dialog', () => {
 
 		should(profile).deepEqual(expectedPublish);
 
-		const expectedGenScript: IGenerateScriptSettings = {
+		const expectedGenScript: IDeploySettings = {
 			databaseName: 'MockDatabaseName',
 			serverName: 'MockServer',
 			connectionUri: 'Mock|Connection|Uri',

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -23,7 +23,6 @@ import { promises as fs } from 'fs';
 import { createContext, TestContext, mockDacFxResult, mockConnectionProfile } from './testContext';
 import { Project, reservedProjectFolders, SystemDatabase, FileProjectEntry, SystemDatabaseReferenceProjectEntry } from '../models/project';
 import { PublishDatabaseDialog } from '../dialogs/publishDatabaseDialog';
-import { IPublishSettings, IGenerateScriptSettings } from '../models/IPublishSettings';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { FolderNode, FileNode } from '../models/tree/fileFolderTreeItem';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
@@ -386,12 +385,12 @@ describe('ProjectsController', function (): void {
 				let projController = TypeMoq.Mock.ofType(ProjectsController);
 				projController.callBase = true;
 				projController.setup(x => x.getPublishDialog(TypeMoq.It.isAny())).returns(() => publishDialog.object);
-				projController.setup(x => x.publishProjectCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IPublishSettings => true))).returns(() => {
+				projController.setup(x => x.publishOrScriptProject(TypeMoq.It.isAny(), TypeMoq.It.isAny(), true)).returns(() => {
 					holler = publishHoller;
 					return Promise.resolve(undefined);
 				});
 
-				projController.setup(x => x.publishProjectCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IGenerateScriptSettings => true))).returns(() => {
+				projController.setup(x => x.publishOrScriptProject(TypeMoq.It.isAny(), TypeMoq.It.isAny(), false)).returns(() => {
 					holler = generateHoller;
 					return Promise.resolve(undefined);
 				});
@@ -430,7 +429,7 @@ describe('ProjectsController', function (): void {
 
 				const proj = await testUtils.createTestProject(baselines.openProjectFileBaseline);
 
-				await projController.object.publishProjectCallback(proj, { connectionUri: '', databaseName: '' , serverName: ''});
+				await projController.object.publishOrScriptProject(proj, { connectionUri: '', databaseName: '' , serverName: ''}, false);
 
 				should(builtDacpacPath).not.equal('', 'built dacpac path should be set');
 				should(publishedDacpacPath).not.equal('', 'published dacpac path should be set');


### PR DESCRIPTION
The only difference is the upgradeExisting setting which currently isn't even being used (publish always has upgradeExisting set to true). So to simplify things I combined them into a single IDeploySettings and just had the callback be told specifically whether to deploy or generate a script. 