### PR TITLE
Mark unstable book test as unstable

### DIFF
--- a/extensions/notebook/src/test/book/bookTrustManager.test.ts
+++ b/extensions/notebook/src/test/book/bookTrustManager.test.ts
@@ -353,7 +353,7 @@ describe('BookTrustManagerTests', function () {
 					should(isNotebookTrusted).be.false('Notebook not should be trusted');
 				});
 
-				it('should trust notebook after book has been added to a folder', async () => {
+				it('should trust notebook after book has been added to a folder @UNSTABLE@', async () => {
 					let notebookUri = run.book2.notebook1;
 					let isNotebookTrustedBeforeChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 


### PR DESCRIPTION
This particular test has been failing intermittently in canary, so marking as unstable as a first step.

Will ensure that we review unstable tests weekly for notebooks.