### PR TITLE
Dev/brih/hotfix status page

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -422,7 +422,7 @@ export interface DatabaseMigration {
 export interface DatabaseMigrationProperties {
 	scope: string;
 	provisioningState: 'Succeeded' | 'Failed' | 'Creating';
-	migrationStatus: 'InProgress' | 'Failed' | 'Succeeded' | 'Creating' | 'Completing' | 'Cancelling';
+	migrationStatus: 'InProgress' | 'Failed' | 'Succeeded' | 'Creating' | 'Completing' | 'Canceling';
 	migrationStatusDetails?: MigrationStatusDetails;
 	startedOn: string;
 	endedOn: string;

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -395,10 +395,10 @@ export const FINISH_TIME = localize('sql.migration.finish.time', "Finish Time");
 
 export function STATUS_VALUE(status: string, count: number): string {
 	if (count > 0) {
-		return localize('sql.migration.status.error.count.some', "{0} (", StatusLookup[status]);
+		return localize('sql.migration.status.error.count.some', "{0} (", StatusLookup[status] ?? status);
 	}
 
-	return localize('sql.migration.status.error.count.none', "{0}", StatusLookup[status]);
+	return localize('sql.migration.status.error.count.none', "{0}", StatusLookup[status] ?? status);
 }
 
 export interface LookupTable<T> {
@@ -410,7 +410,7 @@ export const StatusLookup: LookupTable<string | undefined> = {
 	['Succeeded']: localize('sql.migration.status.succeeded', 'Succeeded'),
 	['Creating']: localize('sql.migration.status.creating', 'Creating'),
 	['Completing']: localize('sql.migration.status.completing', 'Completing'),
-	['Cancelling']: localize('sql.migration.status.cancelling', 'Cancelling'),
+	['Canceling']: localize('sql.migration.status.canceling', 'Canceling'),
 	['Failed']: localize('sql.migration.status.failed', 'Failed'),
 	default: undefined,
 };

--- a/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
+++ b/extensions/sql-migration/src/dashboard/sqlServerDashboard.ts
@@ -37,7 +37,6 @@ export class DashboardWidget {
 	private _migrationStatusCardLoadingContainer!: azdata.LoadingComponent;
 	private _view!: azdata.ModelView;
 
-
 	private _inProgressMigrationButton!: StatusCard;
 	private _inProgressWarningMigrationButton!: StatusCard;
 	private _successfulMigrationButton!: StatusCard;
@@ -48,6 +47,7 @@ export class DashboardWidget {
 	private _viewAllMigrationsButton!: azdata.ButtonComponent;
 
 	private _autoRefreshHandle!: NodeJS.Timeout;
+	private _disposables: vscode.Disposable[] = [];
 
 	constructor() {
 	}
@@ -94,10 +94,13 @@ export class DashboardWidget {
 					'margin-top': '20px'
 				}
 			});
-			await view.initializeModel(container);
-			this._view.onClosed((e) => {
+			this._disposables.push(this._view.onClosed(e => {
 				clearInterval(this._autoRefreshHandle);
-			});
+				this._disposables.forEach(
+					d => { try { d.dispose(); } catch { } });
+			}));
+
+			await view.initializeModel(container);
 			this.refreshMigrations();
 		});
 	}
@@ -184,9 +187,9 @@ export class DashboardWidget {
 			}
 		}).component();
 
-		preRequisiteLearnMoreLink.onDidClick((value) => {
+		this._disposables.push(preRequisiteLearnMoreLink.onDidClick((value) => {
 			vscode.window.showInformationMessage(loc.COMING_SOON);
-		});
+		}));
 
 		const preReqContainer = view.modelBuilder.flexContainer().withItems([
 			preRequisiteListTitle,
@@ -233,11 +236,11 @@ export class DashboardWidget {
 				'border': '1px solid'
 			}
 		}).component();
-		buttonContainer.onDidClick(async () => {
+		this._disposables.push(buttonContainer.onDidClick(async () => {
 			if (taskMetaData.command) {
 				await vscode.commands.executeCommand(taskMetaData.command);
 			}
-		});
+		}));
 		return view.modelBuilder.divContainer().withItems([buttonContainer]).component();
 	}
 
@@ -558,10 +561,10 @@ export class DashboardWidget {
 			}
 		}).component();
 
-		this._viewAllMigrationsButton.onDidClick(async (e) => {
+		this._disposables.push(this._viewAllMigrationsButton.onDidClick(async (e) => {
 			const migrationStatus = await this.getCurrentMigrations();
 			new MigrationStatusDialog(migrationStatus ? migrationStatus : await this.getMigrations(), AdsMigrationStatus.ALL).initialize();
-		});
+		}));
 
 		const refreshButton = view.modelBuilder.hyperlink().withProps({
 			label: loc.REFRESH,
@@ -573,11 +576,11 @@ export class DashboardWidget {
 			}
 		}).component();
 
-		refreshButton.onDidClick(async (e) => {
+		this._disposables.push(refreshButton.onDidClick(async (e) => {
 			refreshButton.enabled = false;
 			await this.refreshMigrations();
 			refreshButton.enabled = true;
-		});
+		}));
 
 		const buttonContainer = view.modelBuilder.flexContainer().withLayout({
 			justifyContent: 'flex-end',
@@ -614,10 +617,10 @@ export class DashboardWidget {
 			IconPathHelper.inProgressMigration,
 			loc.MIGRATION_IN_PROGRESS
 		);
-		this._inProgressMigrationButton.container.onDidClick(async (e) => {
+		this._disposables.push(this._inProgressMigrationButton.container.onDidClick(async (e) => {
 			const dialog = new MigrationStatusDialog(await this.getCurrentMigrations(), AdsMigrationStatus.ONGOING);
 			dialog.initialize();
-		});
+		}));
 
 		this._migrationStatusCardsContainer.addItem(
 			this._inProgressMigrationButton.container
@@ -628,10 +631,10 @@ export class DashboardWidget {
 			loc.MIGRATION_IN_PROGRESS,
 			''
 		);
-		this._inProgressWarningMigrationButton.container.onDidClick(async (e) => {
+		this._disposables.push(this._inProgressWarningMigrationButton.container.onDidClick(async (e) => {
 			const dialog = new MigrationStatusDialog(await this.getCurrentMigrations(), AdsMigrationStatus.ONGOING);
 			dialog.initialize();
-		});
+		}));
 
 		this._migrationStatusCardsContainer.addItem(
 			this._inProgressWarningMigrationButton.container
@@ -641,10 +644,10 @@ export class DashboardWidget {
 			IconPathHelper.completedMigration,
 			loc.MIGRATION_COMPLETED
 		);
-		this._successfulMigrationButton.container.onDidClick(async (e) => {
+		this._disposables.push(this._successfulMigrationButton.container.onDidClick(async (e) => {
 			const dialog = new MigrationStatusDialog(await this.getCurrentMigrations(), AdsMigrationStatus.SUCCEEDED);
 			dialog.initialize();
-		});
+		}));
 		this._migrationStatusCardsContainer.addItem(
 			this._successfulMigrationButton.container
 		);
@@ -654,10 +657,10 @@ export class DashboardWidget {
 			IconPathHelper.completingCutover,
 			loc.MIGRATION_CUTOVER_CARD
 		);
-		this._completingMigrationButton.container.onDidClick(async (e) => {
+		this._disposables.push(this._completingMigrationButton.container.onDidClick(async (e) => {
 			const dialog = new MigrationStatusDialog(await this.getCurrentMigrations(), AdsMigrationStatus.COMPLETING);
 			dialog.initialize();
-		});
+		}));
 		this._migrationStatusCardsContainer.addItem(
 			this._completingMigrationButton.container
 		);
@@ -666,10 +669,10 @@ export class DashboardWidget {
 			IconPathHelper.error,
 			loc.MIGRATION_FAILED
 		);
-		this._failedMigrationButton.container.onDidClick(async (e) => {
+		this._disposables.push(this._failedMigrationButton.container.onDidClick(async (e) => {
 			const dialog = new MigrationStatusDialog(await this.getCurrentMigrations(), AdsMigrationStatus.FAILED);
 			dialog.initialize();
-		});
+		}));
 		this._migrationStatusCardsContainer.addItem(
 			this._failedMigrationButton.container
 		);
@@ -678,9 +681,9 @@ export class DashboardWidget {
 			IconPathHelper.notStartedMigration,
 			loc.MIGRATION_NOT_STARTED
 		);
-		this._notStartedMigrationCard.container.onDidClick((e) => {
+		this._disposables.push(this._notStartedMigrationCard.container.onDidClick((e) => {
 			vscode.window.showInformationMessage('Feature coming soon');
-		});
+		}));
 
 		this._migrationStatusCardLoadingContainer = view.modelBuilder.loadingComponent().withItem(this._migrationStatusCardsContainer).component();
 
@@ -843,11 +846,11 @@ export class DashboardWidget {
 				'margin': '0px'
 			}
 		}).component();
-		video1Container.onDidClick(async () => {
+		this._disposables.push(video1Container.onDidClick(async () => {
 			if (linkMetaData.link) {
 				await vscode.env.openExternal(vscode.Uri.parse(linkMetaData.link));
 			}
-		});
+		}));
 		videosContainer.addItem(video1Container, {
 			CSSStyles: {
 				'background-image': `url(${vscode.Uri.file(<string>linkMetaData.iconPath?.light)})`,

--- a/extensions/sql-migration/src/main.ts
+++ b/extensions/sql-migration/src/main.ts
@@ -36,7 +36,7 @@ class SQLMigration {
 
 				input.items = NotebookPathHelper.getAllMigrationNotebooks();
 
-				input.onDidAccept(async (e) => {
+				this.context.subscriptions.push(input.onDidAccept(async (e) => {
 					const selectedNotebook = input.selectedItems[0];
 					if (selectedNotebook) {
 						try {
@@ -50,7 +50,7 @@ class SQLMigration {
 						}
 						input.hide();
 					}
-				});
+				}));
 
 				input.show();
 			}),

--- a/extensions/sql-migration/src/wizard/accountsSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/accountsSelectionPage.ts
@@ -16,6 +16,7 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 	private _azureAccountsDropdown!: azdata.DropDownComponent;
 	private _accountTenantDropdown!: azdata.DropDownComponent;
 	private _accountTenantFlexContainer!: azdata.FlexContainer;
+	private _disposables: vscode.Disposable[] = [];
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel) {
 		super(wizard, azdata.window.createWizardPage(constants.ACCOUNTS_SELECTION_PAGE_TITLE), migrationStateModel);
@@ -32,6 +33,9 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 			);
 		await view.initializeModel(form.component());
 		await this.populateAzureAccountsDropdown();
+		this._disposables.push(view.onClosed(e =>
+			this._disposables.forEach(
+				d => { try { d.dispose(); } catch { } })));
 	}
 
 	private createAzureAccountsDropdown(view: azdata.ModelView): azdata.FormComponent {
@@ -74,7 +78,7 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 				return false;
 			}).component();
 
-		this._azureAccountsDropdown.onValueChanged(async (value) => {
+		this._disposables.push(this._azureAccountsDropdown.onValueChanged(async (value) => {
 			const selectedIndex = findDropDownItemIndex(this._azureAccountsDropdown, value);
 			if (selectedIndex > -1) {
 				const selectedAzureAccount = this.migrationStateModel.getAccount(selectedIndex);
@@ -97,7 +101,7 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 				this.migrationStateModel._databaseBackup.subscription = undefined!;
 				await this._azureAccountsDropdown.validate();
 			}
-		});
+		}));
 
 		const linkAccountButton = view.modelBuilder.hyperlink()
 			.withProps({
@@ -109,14 +113,14 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 			})
 			.component();
 
-		linkAccountButton.onDidClick(async (event) => {
+		this._disposables.push(linkAccountButton.onDidClick(async (event) => {
 			await vscode.commands.executeCommand('workbench.actions.modal.linkedAccount');
 			await this.populateAzureAccountsDropdown();
 			this.wizard.message = {
 				text: ''
 			};
 			this._azureAccountsDropdown.validate();
-		});
+		}));
 
 		const flexContainer = view.modelBuilder.flexContainer()
 			.withLayout({
@@ -152,7 +156,7 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 			fireOnTextChange: true,
 		}).component();
 
-		this._accountTenantDropdown.onValueChanged(value => {
+		this._disposables.push(this._accountTenantDropdown.onValueChanged(value => {
 			/**
 			 * Replacing all the tenants in azure account with the tenant user has selected.
 			 * All azure requests will only run on this tenant from now on
@@ -164,7 +168,7 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 				this.migrationStateModel._targetSubscription = undefined!;
 				this.migrationStateModel._databaseBackup.subscription = undefined!;
 			}
-		});
+		}));
 
 		this._accountTenantFlexContainer = view.modelBuilder.flexContainer()
 			.withLayout({

--- a/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 import { MigrationWizardPage } from '../models/migrationWizardPage';
 import { MigrationStateModel, StateChangeEvent } from '../models/stateMachine';
 import * as constants from '../constants/strings';
-import { IconPath, IconPathHelper } from '../constants/iconPathHelper';
+// import { IconPath, IconPathHelper } from '../constants/iconPathHelper';
 import { debounce } from '../api/utils';
 
 const headerLeft: azdata.CssStyles = {
@@ -41,6 +42,7 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 	private _dbNames!: string[];
 	private _dbCount!: azdata.TextComponent;
 	private _databaseTableValues!: azdata.DeclarativeTableCellValue[][];
+	private _disposables: vscode.Disposable[] = [];
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel) {
 		super(wizard, azdata.window.createWizardPage(constants.SOURCE_CONFIGURATION, 'MigrationModePage'), migrationStateModel);
@@ -55,6 +57,11 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 			width: '100%'
 		}).component();
 		flex.addItem(await this.createRootContainer(view), { flex: '1 1 auto' });
+
+		this._disposables.push(this._view.onClosed(e => {
+			this._disposables.forEach(
+				d => { try { d.dispose(); } catch { } });
+		}));
 
 		await view.initializeModel(flex);
 	}
@@ -82,7 +89,7 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 			width: 200
 		}).component();
 
-		resourceSearchBox.onTextChanged(value => this._filterTableList(value));
+		this._disposables.push(resourceSearchBox.onTextChanged(value => this._filterTableList(value)));
 
 		const searchContainer = this._view.modelBuilder.divContainer().withItems([resourceSearchBox]).withProps({
 			CSSStyles: {
@@ -142,7 +149,8 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 					enabled: selectable
 				},
 				{
-					value: this.createIconTextCell(IconPathHelper.sqlDatabaseLogo, finalResult[index].options.name),
+					// value: this.createIconTextCell(IconPathHelper.sqlDatabaseLogo, finalResult[index].options.name),
+					value: finalResult[index].options.name,
 					style: styleLeft
 				},
 				{
@@ -207,7 +215,8 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 					},
 					{
 						displayName: constants.DATABASE,
-						valueType: azdata.DeclarativeDataType.component,
+						// valueType: azdata.DeclarativeDataType.component,
+						valueType: azdata.DeclarativeDataType.string,
 						width: 100,
 						isReadOnly: true,
 						headerCssStyles: headerLeft
@@ -238,11 +247,11 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 		).component();
 
 		await this._databaseSelectorTable.setDataValues(this._databaseTableValues);
-		this._databaseSelectorTable.onDataChanged(() => {
+		this._disposables.push(this._databaseSelectorTable.onDataChanged(() => {
 			this._dbCount.updateProperties({
 				'value': constants.DATABASES_SELECTED(this.selectedDbs().length, this._databaseTableValues.length)
 			});
-		});
+		}));
 		const flex = view.modelBuilder.flexContainer().withLayout({
 			flexFlow: 'column',
 			height: '100%',
@@ -271,42 +280,41 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 		return result;
 	}
 
-	private createIconTextCell(icon: IconPath, text: string): azdata.FlexContainer {
+	// private createIconTextCell(icon: IconPath, text: string): azdata.FlexContainer {
+	// const iconComponent = this._view.modelBuilder.image().withProps({
+	// 		iconPath: icon,
+	// 		iconWidth: '16px',
+	// 		iconHeight: '16px',
+	// 		width: '20px',
+	// 		height: '20px'
+	// 	}).component();
+	// 	const textComponent = this._view.modelBuilder.text().withProps({
+	// 		value: text,
+	// 		title: text,
+	// 		CSSStyles: {
+	// 			'margin': '0px',
+	// 			'width': '110px'
+	// 		}
+	// 	}).component();
 
-		const iconComponent = this._view.modelBuilder.image().withProps({
-			iconPath: icon,
-			iconWidth: '16px',
-			iconHeight: '16px',
-			width: '20px',
-			height: '20px'
-		}).component();
-		const textComponent = this._view.modelBuilder.text().withProps({
-			value: text,
-			title: text,
-			CSSStyles: {
-				'margin': '0px',
-				'width': '110px'
-			}
-		}).component();
+	// 	const cellContainer = this._view.modelBuilder.flexContainer().withProps({
+	// 		CSSStyles: {
+	// 			'justify-content': 'left'
+	// 		}
+	// 	}).component();
+	// 	cellContainer.addItem(iconComponent, {
+	// 		flex: '0',
+	// 		CSSStyles: {
+	// 			'width': '32px'
+	// 		}
+	// 	});
+	// 	cellContainer.addItem(textComponent, {
+	// 		CSSStyles: {
+	// 			'width': 'auto'
+	// 		}
+	// 	});
 
-		const cellContainer = this._view.modelBuilder.flexContainer().withProps({
-			CSSStyles: {
-				'justify-content': 'left'
-			}
-		}).component();
-		cellContainer.addItem(iconComponent, {
-			flex: '0',
-			CSSStyles: {
-				'width': '32px'
-			}
-		});
-		cellContainer.addItem(textComponent, {
-			CSSStyles: {
-				'width': 'auto'
-			}
-		});
-
-		return cellContainer;
-	}
+	// 	return cellContainer;
+	// }
 
 }

--- a/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
+++ b/extensions/sql-migration/src/wizard/integrationRuntimePage.ts
@@ -34,6 +34,7 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 	private _copy2!: azdata.ButtonComponent;
 	private _refresh1!: azdata.ButtonComponent;
 	private _refresh2!: azdata.ButtonComponent;
+	private _disposables: vscode.Disposable[] = [];
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel) {
 		super(wizard, azdata.window.createWizardPage(constants.IR_PAGE_TITLE), migrationStateModel);
@@ -50,14 +51,14 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			}
 		}).component();
 
-		createNewMigrationService.onDidClick(async (e) => {
+		this._disposables.push(createNewMigrationService.onDidClick(async (e) => {
 			const dialog = new CreateSqlMigrationServiceDialog();
 			const createdDmsResult = await dialog.createNewDms(this.migrationStateModel, (<azdata.CategoryValue>this._resourceGroupDropdown.value).displayName);
 			this.migrationStateModel._sqlMigrationServiceResourceGroup = createdDmsResult.resourceGroup;
 			this.migrationStateModel._sqlMigrationService = createdDmsResult.service;
 			await this.loadResourceGroupDropdown();
 			await this.populateDms(createdDmsResult.resourceGroup);
-		});
+		}));
 
 		this._statusLoadingComponent = view.modelBuilder.loadingComponent().withItem(this.createDMSDetailsContainer()).component();
 
@@ -91,6 +92,12 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 
 				]
 			);
+
+		this._disposables.push(this._view.onClosed(e => {
+			this._disposables.forEach(
+				d => { try { d.dispose(); } catch { } });
+		}));
+
 		await view.initializeModel(this._form.component());
 	}
 
@@ -187,12 +194,12 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			fireOnTextChange: true,
 		}).component();
 
-		this._resourceGroupDropdown.onValueChanged(async (value) => {
+		this._disposables.push(this._resourceGroupDropdown.onValueChanged(async (value) => {
 			const selectedIndex = findDropDownItemIndex(this._resourceGroupDropdown, value);
 			if (selectedIndex > -1) {
 				await this.populateDms(value);
 			}
-		});
+		}));
 
 		const migrationServcieDropdownLabel = this._view.modelBuilder.text().withProps({
 			value: constants.IR_PAGE_TITLE,
@@ -209,7 +216,7 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			fireOnTextChange: true,
 		}).component();
 
-		this._dmsDropdown.onValueChanged(async (value) => {
+		this._disposables.push(this._dmsDropdown.onValueChanged(async (value) => {
 			if (value && value !== constants.SQL_MIGRATION_SERVICE_NOT_FOUND_ERROR) {
 				if (this.migrationStateModel._databaseBackup.networkContainerType === NetworkContainerType.NETWORK_SHARE) {
 					this._dmsInfoContainer.display = 'inline';
@@ -225,7 +232,7 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			} else {
 				this._dmsInfoContainer.display = 'none';
 			}
-		});
+		}));
 
 		const flexContainer = this._view.modelBuilder.flexContainer().withItems([
 			descriptionText,
@@ -267,14 +274,14 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			ariaLabel: constants.REFRESH,
 		}).component();
 
-		this._refreshButton.onDidClick(async (e) => {
+		this._disposables.push(this._refreshButton.onDidClick(async (e) => {
 			this._connectionStatusLoader.loading = true;
 			try {
 				await this.loadStatus();
 			} finally {
 				this._connectionStatusLoader.loading = false;
 			}
-		});
+		}));
 
 		const connectionLabelContainer = this._view.modelBuilder.flexContainer().withProps({
 			CSSStyles: {
@@ -318,10 +325,10 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			ariaLabel: constants.COPY_KEY1,
 		}).component();
 
-		this._copy1.onDidClick(async (e) => {
+		this._disposables.push(this._copy1.onDidClick(async (e) => {
 			await vscode.env.clipboard.writeText(<string>this._authKeyTable.dataValues![0][1].value);
 			vscode.window.showInformationMessage(constants.SERVICE_KEY1_COPIED_HELP);
-		});
+		}));
 
 		this._copy2 = this._view.modelBuilder.button().withProps({
 			title: constants.COPY_KEY2,
@@ -329,10 +336,10 @@ export class IntergrationRuntimePage extends MigrationWizardPage {
 			ariaLabel: constants.COPY_KEY2,
 		}).component();
 
-		this._copy2.onDidClick(async (e) => {
+		this._disposables.push(this._copy2.onDidClick(async (e) => {
 			await vscode.env.clipboard.writeText(<string>this._authKeyTable.dataValues![1][1].value);
 			vscode.window.showInformationMessage(constants.SERVICE_KEY2_COPIED_HELP);
-		});
+		}));
 
 		this._refresh1 = this._view.modelBuilder.button().withProps({
 			title: constants.REFRESH_KEY1,

--- a/extensions/sql-migration/src/wizard/migrationModePage.ts
+++ b/extensions/sql-migration/src/wizard/migrationModePage.ts
@@ -11,6 +11,7 @@ import * as constants from '../constants/strings';
 
 export class MigrationModePage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;
+	private _disposables: vscode.Disposable[] = [];
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel) {
 		super(wizard, azdata.window.createWizardPage(constants.DATABASE_BACKUP_MIGRATION_MODE_LABEL, 'MigrationModePage'), migrationStateModel);
@@ -25,6 +26,11 @@ export class MigrationModePage extends MigrationWizardPage {
 					this.migrationModeContainer(),
 				]
 			);
+
+		this._disposables.push(this._view.onClosed(e => {
+			this._disposables.forEach(
+				d => { try { d.dispose(); } catch { } });
+		}));
 		await view.initializeModel(form.component());
 	}
 
@@ -64,11 +70,11 @@ export class MigrationModePage extends MigrationWizardPage {
 
 		this.migrationStateModel._databaseBackup.migrationMode = MigrationMode.ONLINE;
 
-		onlineButton.onDidChangeCheckedState((e) => {
+		this._disposables.push(onlineButton.onDidChangeCheckedState((e) => {
 			if (e) {
 				this.migrationStateModel._databaseBackup.migrationMode = MigrationMode.ONLINE;
 			}
-		});
+		}));
 
 		const offlineButton = this._view.modelBuilder.radioButton().withProps({
 			label: constants.DATABASE_BACKUP_MIGRATION_MODE_OFFLINE_LABEL,
@@ -88,13 +94,13 @@ export class MigrationModePage extends MigrationWizardPage {
 		}).component();
 
 
-		offlineButton.onDidChangeCheckedState((e) => {
+		this._disposables.push(offlineButton.onDidChangeCheckedState((e) => {
 			if (e) {
 				vscode.window.showInformationMessage('Feature coming soon');
 				onlineButton.checked = true;
 				//this.migrationStateModel._databaseBackup.migrationCutover = MigrationCutover.OFFLINE; TODO: Enable when offline mode is supported.
 			}
-		});
+		}));
 
 		const flexContainer = this._view.modelBuilder.flexContainer().withItems(
 			[

--- a/extensions/sql-migration/src/wizard/sqlSourceConfigurationPage.ts
+++ b/extensions/sql-migration/src/wizard/sqlSourceConfigurationPage.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 import { MigrationWizardPage } from '../models/migrationWizardPage';
 import { MigrationSourceAuthenticationType, MigrationStateModel, StateChangeEvent } from '../models/stateMachine';
 import * as constants from '../constants/strings';
@@ -13,6 +14,7 @@ export class SqlSourceConfigurationPage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;
 	private _usernameInput!: azdata.InputBoxComponent;
 	private _password!: azdata.InputBoxComponent;
+	private _disposables: vscode.Disposable[] = [];
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel) {
 		super(wizard, azdata.window.createWizardPage(constants.SOURCE_CONFIGURATION, 'MigrationModePage'), migrationStateModel);
@@ -26,6 +28,12 @@ export class SqlSourceConfigurationPage extends MigrationWizardPage {
 					await this.createSourceCredentialContainer(),
 				]
 			);
+
+		this._disposables.push(this._view.onClosed(e => {
+			this._disposables.forEach(
+				d => { try { d.dispose(); } catch { } });
+		}));
+
 		await view.initializeModel(form.component());
 	}
 
@@ -107,9 +115,9 @@ export class SqlSourceConfigurationPage extends MigrationWizardPage {
 			enabled: false,
 			width: WIZARD_INPUT_COMPONENT_WIDTH
 		}).component();
-		this._usernameInput.onTextChanged(value => {
+		this._disposables.push(this._usernameInput.onTextChanged(value => {
 			this.migrationStateModel._sqlServerUsername = value;
-		});
+		}));
 
 		const passwordLabel = this._view.modelBuilder.text().withProps({
 			value: constants.DATABASE_BACKUP_NETWORK_SHARE_PASSWORD_LABEL,
@@ -125,9 +133,9 @@ export class SqlSourceConfigurationPage extends MigrationWizardPage {
 			inputType: 'password',
 			width: WIZARD_INPUT_COMPONENT_WIDTH
 		}).component();
-		this._password.onTextChanged(value => {
+		this._disposables.push(this._password.onTextChanged(value => {
 			this.migrationStateModel._sqlServerPassword = value;
-		});
+		}));
 
 		const container = this._view.modelBuilder.flexContainer().withItems(
 			[

--- a/extensions/sql-migration/src/wizard/subscriptionSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/subscriptionSelectionPage.ts
@@ -179,7 +179,7 @@ export class SubscriptionSelectionPage extends MigrationWizardPage {
 	}
 
 	public async onPageLeave(): Promise<void> {
-		this.disposables.forEach(d => d.dispose());
+		this.disposables.forEach(d => { try { d.dispose(); } catch { } });
 	}
 
 	protected async handleStateChange(e: StateChangeEvent): Promise<void> {

--- a/extensions/sql-migration/src/wizard/summaryPage.ts
+++ b/extensions/sql-migration/src/wizard/summaryPage.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 import { MigrationWizardPage } from '../models/migrationWizardPage';
 import { MigrationMode, MigrationStateModel, MigrationTargetType, NetworkContainerType, StateChangeEvent } from '../models/stateMachine';
 import * as constants from '../constants/strings';
@@ -14,6 +15,7 @@ import { TargetDatabaseSummaryDialog } from '../dialog/targetDatabaseSummary/tar
 export class SummaryPage extends MigrationWizardPage {
 	private _view!: azdata.ModelView;
 	private _flexContainer!: azdata.FlexContainer;
+	private _disposables: vscode.Disposable[] = [];
 
 	constructor(wizard: azdata.window.Wizard, migrationStateModel: MigrationStateModel) {
 		super(wizard, azdata.window.createWizardPage(constants.SUMMARY_PAGE_TITLE), migrationStateModel);
@@ -32,6 +34,12 @@ export class SummaryPage extends MigrationWizardPage {
 					}
 				]
 			);
+
+		this._disposables.push(this._view.onClosed(e => {
+			this._disposables.forEach(
+				d => { try { d.dispose(); } catch { } });
+		}));
+
 		await view.initializeModel(form.component());
 	}
 
@@ -48,9 +56,9 @@ export class SummaryPage extends MigrationWizardPage {
 			}
 		}).component();
 
-		targetDatabaseHyperlink.onDidClick(e => {
+		this._disposables.push(targetDatabaseHyperlink.onDidClick(e => {
 			targetDatabaseSummary.initialize();
-		});
+		}));
 
 		const targetDatabaseRow = this._view.modelBuilder.flexContainer()
 			.withLayout(

--- a/extensions/sql-migration/src/wizard/wizardController.ts
+++ b/extensions/sql-migration/src/wizard/wizardController.ts
@@ -9,7 +9,6 @@ import { MigrationStateModel } from '../models/stateMachine';
 import * as loc from '../constants/strings';
 import { MigrationWizardPage } from '../models/migrationWizardPage';
 import { SKURecommendationPage } from './skuRecommendationPage';
-// import { SubscriptionSelectionPage } from './subscriptionSelectionPage';
 import { DatabaseBackupPage } from './databaseBackupPage';
 import { AccountsSelectionPage } from './accountsSelectionPage';
 import { IntergrationRuntimePage } from './integrationRuntimePage';
@@ -61,13 +60,13 @@ export class WizardController {
 		wizardSetupPromises.push(...pages.map(p => p.registerWizardContent()));
 		wizardSetupPromises.push(wizard.open());
 
-		wizard.onPageChanged(async (pageChangeInfo: azdata.window.WizardPageChangeInfo) => {
+		this.extensionContext.subscriptions.push(wizard.onPageChanged(async (pageChangeInfo: azdata.window.WizardPageChangeInfo) => {
 			const newPage = pageChangeInfo.newPage;
 			const lastPage = pageChangeInfo.lastPage;
 
 			await pages[lastPage]?.onPageLeave();
 			await pages[newPage]?.onPageEnter();
-		});
+		}));
 
 		wizard.registerNavigationValidator(async validator => {
 			// const lastPage = validator.lastPage;
@@ -82,9 +81,9 @@ export class WizardController {
 		await Promise.all(wizardSetupPromises);
 		await pages[0].onPageEnter();
 
-		wizard.doneButton.onClick(async (e) => {
+		this.extensionContext.subscriptions.push(wizard.doneButton.onClick(async (e) => {
 			await stateModel.startMigration();
-		});
+		}));
 	}
 }
 


### PR DESCRIPTION
This PR fixes
* command loading issue in migration status page
* corrects migration status to 'Canceling;
* handle unknown migration status codes in migration status display page
* add disposable pattern to registered commands and .on* events
* temporarily disable icon images in DeclarativeTableComponents to prevent hang of undisposed images
