### PR TITLE
Notebook Markdown email rendering fix

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -135,14 +135,11 @@ export class NotebookMarkdownRenderer {
 			} else {
 				// HTML Encode href
 				let uri = URI.parse(href);
-				if (uri.scheme === 'mailto') {
-					href = href.replace(/</g, '&lt;')
-						.replace(/>/g, '&gt;')
-						.replace(/"/g, '&quot;')
-						.replace(/'/g, '&#39;');
+				// mailto uris do not need additional encoding of &, otherwise it would not render properly
+				if (uri.scheme !== 'mailto') {
+					href = href.replace(/&(?!amp;)/g, '&amp;');
 				} else {
-					href = href.replace(/&(?!amp;)/g, '&amp;')
-						.replace(/</g, '&lt;')
+					href = href.replace(/</g, '&lt;')
 						.replace(/>/g, '&gt;')
 						.replace(/"/g, '&quot;')
 						.replace(/'/g, '&#39;');

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -134,11 +134,19 @@ export class NotebookMarkdownRenderer {
 
 			} else {
 				// HTML Encode href
-				href = href.replace(/&(?!amp;)/g, '&amp;')
-					.replace(/</g, '&lt;')
-					.replace(/>/g, '&gt;')
-					.replace(/"/g, '&quot;')
-					.replace(/'/g, '&#39;');
+				let uri = URI.parse(href);
+				if (uri.scheme === 'mailto') {
+					href = href.replace(/</g, '&lt;')
+						.replace(/>/g, '&gt;')
+						.replace(/"/g, '&quot;')
+						.replace(/'/g, '&#39;');
+				} else {
+					href = href.replace(/&(?!amp;)/g, '&amp;')
+						.replace(/</g, '&lt;')
+						.replace(/>/g, '&gt;')
+						.replace(/"/g, '&quot;')
+						.replace(/'/g, '&#39;');
+				}
 				return `<a href=${href} data-href="${href}" title="${title || href}">${text}</a>`;
 			}
 		};

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -70,13 +70,13 @@ suite('NotebookMarkdownRenderer', () => {
 	});
 
 	test('email renders properly', () => {
-		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test@email.com](mailto:test@email.com)` });
-		assert.strictEqual(result.innerHTML, `<p>test@email.com</p>`);
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test@email.com](mailto:test@email.com)`, isTrusted: true });
+		assert.strictEqual(result.innerHTML, `<p><a href="mailto:test@email.com" data-href="mailto:test@email.com" title="mailto:test@email.com">test@email.com</a></p>`);
 	});
 
 	test('link to https with query parameters', () => {
-		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test](https://www.google.com?test=&test2=)` });
-		assert.strictEqual(result.innerHTML, `<p>test</p>`);
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test](https://www.test.com?test=&test2=)`, isTrusted: true });
+		assert.strictEqual(result.innerHTML, `<p><a href="https://www.test.com?test=&amp;test2=" data-href="https://www.test.com?test=&amp;test2=" title="https://www.test.com?test=&amp;test2=">test</a></p>`);
 	});
 
 	test('cell attachment image', () => {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -69,6 +69,16 @@ suite('NotebookMarkdownRenderer', () => {
 		assert.strict(markedPath, '<p>....\test.ipynb</p>');
 	});
 
+	test('email renders properly', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test@email.com](mailto:test@email.com)` });
+		assert.strictEqual(result.innerHTML, `<p>test@email.com</p>`);
+	});
+
+	test('link to https with query parameters', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test](https://www.google.com?test=&test2=)` });
+		assert.strictEqual(result.innerHTML, `<p>test</p>`);
+	});
+
 	test('cell attachment image', () => {
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![altText](attachment:ads.png)`, isTrusted: true }, { cellAttachments: JSON.parse('{"ads.png":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAggg=="}}') });
 		assert.strictEqual(result.innerHTML, `<p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAggg==" alt="altText"></p>`, 'Cell attachment basic test failed when trusted');

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -74,6 +74,16 @@ suite('NotebookMarkdownRenderer', () => {
 		assert.strictEqual(result.innerHTML, `<p><a href="mailto:test@email.com" data-href="mailto:test@email.com" title="mailto:test@email.com">test@email.com</a></p>`);
 	});
 
+	test('email in markdown format renders properly', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test@email.com](mailto:test@email.com)`, isTrusted: true });
+		assert.strictEqual(result.innerHTML, `<p><a href="mailto:test@email.com" data-href="mailto:test@email.com" title="mailto:test@email.com">test@email.com</a></p>`);
+	});
+
+	test('email inserted directly renders properly', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `test@email.com`, isTrusted: true });
+		assert.strictEqual(result.innerHTML, `<p><a href="mailto:test@email.com" data-href="mailto:test@email.com" title="mailto:test@email.com">test@email.com</a></p>`);
+	});
+
 	test('link to https with query parameters', () => {
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test](https://www.test.com?test=&test2=)`, isTrusted: true });
 		assert.strictEqual(result.innerHTML, `<p><a href="https://www.test.com?test=&amp;test2=" data-href="https://www.test.com?test=&amp;test2=" title="https://www.test.com?test=&amp;test2=">test</a></p>`);

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -69,11 +69,6 @@ suite('NotebookMarkdownRenderer', () => {
 		assert.strict(markedPath, '<p>....\test.ipynb</p>');
 	});
 
-	test('email renders properly', () => {
-		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test@email.com](mailto:test@email.com)`, isTrusted: true });
-		assert.strictEqual(result.innerHTML, `<p><a href="mailto:test@email.com" data-href="mailto:test@email.com" title="mailto:test@email.com">test@email.com</a></p>`);
-	});
-
 	test('email in markdown format renders properly', () => {
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[test@email.com](mailto:test@email.com)`, isTrusted: true });
 		assert.strictEqual(result.innerHTML, `<p><a href="mailto:test@email.com" data-href="mailto:test@email.com" title="mailto:test@email.com">test@email.com</a></p>`);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15983. 

The issue occurs when the user directly types in the email address, as the parsing `test@email.com` would double encode the `&` when converting it to a proper `mailto` format. The resulting markdown that is resolved contains the `&amp` and upon clicking the link it would send the improper format to the email client:
![image](https://user-images.githubusercontent.com/23587151/126758256-0141152c-9a5b-4543-a6cf-d5b176f49912.png)

In order to fix it, I removed the additional encoding (specifically for emails uri's) to make sure that the `&` is still encoded for other uri schemas.
