### PR TITLE
Fix link accessibilty issues

### DIFF
--- a/src/sql/workbench/browser/modelComponents/hyperlink.component.ts
+++ b/src/sql/workbench/browser/modelComponents/hyperlink.component.ts
@@ -21,7 +21,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 
 @Component({
 	selector: 'modelview-hyperlink',
-	template: `<a [href]="url" [title]="title" [attr.aria-label]="ariaLabel" [attr.role]="ariaRole" target="blank" [ngStyle]="CSSStyles" [class]="cssClass">{{label}}</a>`
+	template: `<a [href]="url" [title]="getDisplayedTitle()" [attr.aria-label]="ariaLabel" [attr.role]="ariaRole" target="blank" [ngStyle]="CSSStyles" [class]="cssClass">{{label}}</a>`
 })
 export default class HyperlinkComponent extends TitledComponent<azdata.HyperlinkComponentProperties> implements IComponent, OnDestroy, AfterViewInit {
 	@Input() descriptor: IComponentDescriptor;
@@ -71,6 +71,10 @@ export default class HyperlinkComponent extends TitledComponent<azdata.Hyperlink
 
 	public get showLinkIcon(): boolean {
 		return this.getPropertyOrDefault<boolean>((props) => props.showLinkIcon, false);
+	}
+
+	public getDisplayedTitle(): string {
+		return this.title || this.url || '';
 	}
 
 	public onClick(e: MouseEvent): void {

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -76,9 +76,9 @@ body.web {
 	cursor: pointer;
 }
 
-.monaco-workbench a {
-	text-decoration: none;
-}
+/* .monaco-workbench a {
+	text-decoration: none; {{SQL CARBON EDIT}} Underline links
+} */
 
 .monaco-workbench a:active {
 	color: inherit;

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -76,9 +76,11 @@ body.web {
 	cursor: pointer;
 }
 
-/* .monaco-workbench a {
-	text-decoration: none; {{SQL CARBON EDIT}} Underline links
-} */
+/* {{SQL CARBON EDIT}} Underline links
+.monaco-workbench a {
+	text-decoration: none;
+}
+*/
 
 .monaco-workbench a:active {
 	color: inherit;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15771

This does mean that ALL links in the app are now underlined. I don't think this should be an issue as VS Code doesn't tend to use that many links, but something to keep an eye on and selectively disable if we think it's appropriate. 

@radentonev Does this seem ok with you?

I don't know if we'll ever get context on why they hid the underlining to begin with, it's been like that since the very beginning.

I considered having it be fancier such as only showing the underline on hover - but opted to go for the simpler route for now. We can revisit if we get negative feedback about changing this. 

![image](https://user-images.githubusercontent.com/28519865/126844500-09b29cc9-9a57-4f56-bdfe-79aa738391db.png)

![image](https://user-images.githubusercontent.com/28519865/126844534-6a55a6ce-0eb9-4a9b-8c97-1069db6c2cbc.png)

![image](https://user-images.githubusercontent.com/28519865/126844545-6673d57a-17e6-4549-b9c3-e20e16d9e9bc.png)
