### PR TITLE
Encode %20 in Notebook link 

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -65,8 +65,14 @@ export class LinkHandlerDirective {
 				this.notebookService.navigateTo(this.notebookUri, uri.fragment);
 			} else {
 				if (uri.scheme === 'file') {
-					let exists = await this.fileService.exists(uri);
-					if (!exists) {
+					// this will check to see if both cases where file contains %20 (encoded) and file contains spaces (decoded) exists
+					let encodedFileExists = await this.fileService.exists(uri);
+					let decodedFileExists = await this.fileService.exists(URI.parse(content));
+					// If the encoded file is not found then we need to check if decoded path is found and set the uri to open that file
+					if (!encodedFileExists && decodedFileExists) {
+						uri = URI.parse(content);
+					}
+					if (!encodedFileExists && !decodedFileExists) {
 						let relPath = relative(this.workbenchFilePath.fsPath, uri.fsPath);
 						let path = resolve(this.notebookUri.fsPath, relPath);
 						try {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -56,7 +56,7 @@ export class LinkHandlerDirective {
 	private async handleLink(content: string): Promise<void> {
 		let uri: URI | undefined;
 		try {
-			uri = URI.parse(content);
+			uri = URI.parse(encodeURI(content));
 		} catch {
 			// ignore
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -21,7 +21,6 @@ import { TextModel } from 'vs/editor/common/model/textModel';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import * as path from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
-import { escape } from 'vs/base/common/strings';
 import { IImageCalloutDialogOptions, ImageCalloutDialog } from 'sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog';
 import { TextCellEditModes } from 'sql/workbench/services/notebook/common/contracts';
 
@@ -251,7 +250,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				}
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
-				document.execCommand('insertHTML', false, `<a href="${escape(linkUrl)}">${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
+				document.execCommand('insertHTML', false, `<a href="${linkUrl}">${linkCalloutResult?.insertUnescapedLinkLabel}</a>`);
 				return;
 			}
 		} else if (type === MarkdownButtonType.IMAGE_PREVIEW) {

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -132,7 +132,15 @@ export class HTMLMarkdownConverter {
 		this.turndownService.addRule('a', {
 			filter: 'a',
 			replacement: (content, node) => {
-				let href = node.href;
+				let href: string;
+				let hrefContainsSpace = node.attributes.href.nodeValue.includes(' ');
+
+				if (hrefContainsSpace) {
+					href = node.attributes.href.nodeValue;
+				} else {
+					href = node.href;
+				}
+
 				let notebookLink: URI | undefined;
 				const isAnchorLinkInFile = (node.attributes.href?.nodeValue.startsWith('#') || href.includes('#')) && href.startsWith('file://');
 				if (isAnchorLinkInFile) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #16196.

The issue was in the linkHandler handleLink function. Once we parse the linked string that includes %20. URI.parse decodes the %20 to space which would then not resolve properly. 

![Screen Shot 2021-07-23 at 4 30 49 PM](https://user-images.githubusercontent.com/23587151/126851430-4173c853-d582-46c5-a1da-f866b162da85.png)

Encoding the path that is passed in ensures that any folder/filename that contains %20 will be kept and be resolved correctly.
