### PR TITLE
Fix SQL/Notebook editors opening as plaintext

### DIFF
--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -510,47 +510,47 @@ export class QueryEditorOverrideContribution extends Disposable implements IWork
 	) {
 		super();
 		this.registerEditorOverrides();
-	}
-
-	private registerEditorOverrides(): void {
 		// Refresh the editor overrides whenever the languages change so we ensure we always have
 		// the latest up to date list of extensions for each language
 		this._modeService.onLanguagesMaybeChanged(() => {
-			this._registeredOverrides.clear();
-			// List of language IDs to associate the query editor for. These are case sensitive.
-			QueryEditorLanguageAssociation.languages.map(lang => {
-				const langExtensions = this._modeService.getExtensions(lang);
-				if (langExtensions.length === 0) {
-					return;
-				}
-				// Create the selector from the list of all the language extensions we want to associate with the
-				// query editor (filtering out any languages which didn't have any extensions registered yet)
-				const selector = `*{${langExtensions.join(',')}}`;
-				this._registeredOverrides.add(this._editorOverrideService.registerContributionPoint(
-					selector,
-					{
-						id: QueryEditor.ID,
-						label: QueryEditor.LABEL,
-						describes: (currentEditor) => currentEditor instanceof FileQueryEditorInput,
-						priority: ContributedEditorPriority.builtin
-					},
-					{},
-					(resource, options, group) => {
-						const fileInput = this._editorService.createEditorInput({
-							resource: resource
-						}) as FileEditorInput;
-						const langAssociation = languageAssociationRegistry.getAssociationForLanguage(lang);
-						const queryEditorInput = langAssociation?.syncConvertinput?.(fileInput);
-						if (!queryEditorInput) {
-							this._logService.warn('Unable to create input for overriding editor ', resource);
-							return undefined;
-						}
-						return { editor: queryEditorInput, options: options, group: group };
+			this.registerEditorOverrides();
+		});
+	}
+
+	private registerEditorOverrides(): void {
+		this._registeredOverrides.clear();
+		// List of language IDs to associate the query editor for. These are case sensitive.
+		QueryEditorLanguageAssociation.languages.map(lang => {
+			const langExtensions = this._modeService.getExtensions(lang);
+			if (langExtensions.length === 0) {
+				return;
+			}
+			// Create the selector from the list of all the language extensions we want to associate with the
+			// query editor (filtering out any languages which didn't have any extensions registered yet)
+			const selector = `*{${langExtensions.join(',')}}`;
+			this._registeredOverrides.add(this._editorOverrideService.registerContributionPoint(
+				selector,
+				{
+					id: QueryEditor.ID,
+					label: QueryEditor.LABEL,
+					describes: (currentEditor) => currentEditor instanceof FileQueryEditorInput,
+					priority: ContributedEditorPriority.builtin
+				},
+				{},
+				(resource, options, group) => {
+					const fileInput = this._editorService.createEditorInput({
+						resource: resource
+					}) as FileEditorInput;
+					const langAssociation = languageAssociationRegistry.getAssociationForLanguage(lang);
+					const queryEditorInput = langAssociation?.syncConvertinput?.(fileInput);
+					if (!queryEditorInput) {
+						this._logService.warn('Unable to create input for overriding editor ', resource);
+						return undefined;
 					}
-				));
-			});
+					return { editor: queryEditorInput, options: options, group: group };
+				}
+			));
 		});
 	}
 }
-
-workbenchRegistry.registerWorkbenchContribution(QueryEditorOverrideContribution, LifecyclePhase.Restored);
+workbenchRegistry.registerWorkbenchContribution(QueryEditorOverrideContribution, LifecyclePhase.Starting);

--- a/src/vs/workbench/services/editor/browser/editorOverrideService.ts
+++ b/src/vs/workbench/services/editor/browser/editorOverrideService.ts
@@ -72,9 +72,9 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 
 	async resolveEditorOverride(editor: IEditorInput, options: IEditorOptions | ITextEditorOptions | undefined, group: IEditorGroup): Promise<IEditorInputWithOptionsAndGroup | undefined> {
 		// If it was an override before we await for the extensions to activate and then proceed with overriding or else they won't be registered
-		if (this.cache && editor.resource && this.resourceMatchesCache(editor.resource)) {
-			await this.extensionService.whenInstalledExtensionsRegistered();
-		}
+		//if (this.cache && editor.resource && this.resourceMatchesCache(editor.resource)) { // {{SQL CARBON EDIT}} Always wait for extensions so that our language-based overrides (SQL/Notebooks) will always have those registered
+		await this.extensionService.whenInstalledExtensionsRegistered();
+		//}
 
 		if (options?.override === EditorOverride.DISABLED) {
 			throw new Error(`Calling resolve editor override when override is explicitly disabled!`);

--- a/src/vs/workbench/services/editor/browser/editorOverrideService.ts
+++ b/src/vs/workbench/services/editor/browser/editorOverrideService.ts
@@ -43,7 +43,7 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 
 	private _contributionPoints: Map<string | glob.IRelativePattern, ContributionPoints> = new Map<string | glob.IRelativePattern, ContributionPoints>();
 	private static readonly overrideCacheStorageID = 'editorOverrideService.cache';
-	private cache: Set<string> | undefined;
+	// private cache: Set<string> | undefined; {{SQL CARBON EDIT}} Remove unused
 
 	constructor(
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
@@ -56,7 +56,7 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 	) {
 		super();
 		// Read in the cache on statup
-		this.cache = new Set<string>(JSON.parse(this.storageService.get(EditorOverrideService.overrideCacheStorageID, StorageScope.GLOBAL, JSON.stringify([]))));
+		// this.cache = new Set<string>(JSON.parse(this.storageService.get(EditorOverrideService.overrideCacheStorageID, StorageScope.GLOBAL, JSON.stringify([])))); {{SQL CARBON EDIT}} Remove unused
 		this.storageService.remove(EditorOverrideService.overrideCacheStorageID, StorageScope.GLOBAL);
 
 		this._register(this.storageService.onWillSaveState(() => {
@@ -65,9 +65,11 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 		}));
 
 		// When extensions have registered we no longer need the cache
+		/* {{SQL CARBON EDIT}} Remove unused
 		this.extensionService.onDidRegisterExtensions(() => {
 			this.cache = undefined;
 		});
+		*/
 	}
 
 	async resolveEditorOverride(editor: IEditorInput, options: IEditorOptions | ITextEditorOptions | undefined, group: IEditorGroup): Promise<IEditorInputWithOptionsAndGroup | undefined> {
@@ -547,6 +549,7 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 		this.storageService.store(EditorOverrideService.overrideCacheStorageID, JSON.stringify(Array.from(cacheStorage)), StorageScope.GLOBAL, StorageTarget.MACHINE);
 	}
 
+	/* {{SQL CARBON EDIT}} Remove unused
 	private resourceMatchesCache(resource: URI): boolean {
 		if (!this.cache) {
 			return false;
@@ -559,6 +562,7 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 		}
 		return false;
 	}
+	*/
 }
 
 registerSingleton(IEditorOverrideService, EditorOverrideService);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/16436
Fixes https://github.com/microsoft/azuredatastudio/issues/16435
Fixes https://github.com/microsoft/azuredatastudio/issues/16427

I'm still waiting on hearing back from the people hitting this issue to make sure I'm not missing another scenario, but the specific scenario being fixed here is that when starting up a fresh instance of ADS (i.e. no cached state) the language-based overrides weren't being registered when the editor override service looked for an appropriate editor override to use.

So here's what the order of events for the broken scenario would be : 

1. Launch ADS
2. Language (Mode) service loads its cache (empty currently except for built-in languages)
3. Editor is created, no overrides available so opens as text
4. Languages from extensions are registered, and now the overrides are registered so opening files at this point should work correclty

Note that because of the cache in 2 this should only happen when starting from a clean state. In subsequent launches the mode service caches the registered languages and so it looks like this 

1. Launch ADS
2. Mode service loads its cache. It now has the full list of extension-registered languages cached as well so that triggers the editor overrides being registered
3. Editor is created and override is found so creates the expected editor type

**Important** This way of fixing this will have a perf impact as we will now be waiting for extensions to be registered before opening any editor. But in my testing this wasn't a huge impact and anyways given that our editors rely on STS to be activated anyways the overall time people have to wait to run anything shouldn't change at all.

But if we want to avoid this then we could consider hard-coding the language extensions in the app (either in the editor overrides or as a built-in language registration). But I'd rather keep the language registration-based overrides since that means one less place we have to keep these extension mappings in sync. 