### PR TITLE
Fix arc connect dialog color contrast

### DIFF
--- a/extensions/arc/src/ui/dialogs/connectSqlDialog.ts
+++ b/extensions/arc/src/ui/dialogs/connectSqlDialog.ts
@@ -37,7 +37,7 @@ export abstract class ConnectToSqlDialog extends InitializingComponent {
 			this.serverNameInputBox = this.modelBuilder.inputBox()
 				.withProps({
 					value: connectionProfile?.serverName,
-					enabled: false
+					readOnly: true
 				}).component();
 			this.usernameInputBox = this.modelBuilder.inputBox()
 				.withProps({


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15808

The color contrast of disabled input fields is currently too low as the issue mentions. I chose not to fix the colors for the disabled input box because according to https://www.w3.org/TR/WCAG21/#contrast-minimum the contrast requirements apply except when `Incidental Text or images of text that are part of an inactive user interface component,`. 

Changing this to be readonly makes more sense anyways since the text is just as important as other fields on the page and so doesn't really make sense to have visually different.

Dark:

![image](https://user-images.githubusercontent.com/28519865/127195110-f385a06e-a007-4429-9c89-05beda779260.png)

Light:

![image](https://user-images.githubusercontent.com/28519865/127195174-40ec8d11-99d8-4663-9b52-74291fffd42d.png)

HC: 

![image](https://user-images.githubusercontent.com/28519865/127195220-0d520d11-a0ee-457f-a0ef-cf501c6f9e9c.png)
