### PR TITLE
Package VS Code extensions

### DIFF
--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -129,7 +129,7 @@ gulp.task('package-external-extensions', task.series(
 				const packageManifestPath = path.join(packageDir, 'package.json');
 				const json = require('gulp-json-editor');
 				const packageJsonStream = gulp.src(packageManifestPath) // Create stream for the original package.json
-					.pipe(json((data => { // And now use gulp-json-editor to modify the contents
+					.pipe(json(data => { // And now use gulp-json-editor to modify the contents
 						const updateData = JSON.parse(fs.readFileSync(vscodeManifestFullPath)); // Read in the set of values to replace from package.vscode.json
 						Object.keys(updateData).forEach(key => {
 							data[key] = updateData[key];
@@ -140,7 +140,7 @@ gulp.task('package-external-extensions', task.series(
 							delete data.contributes.menus[menu];
 						});
 						return data;
-					}), { beautify: false }))
+					}, { beautify: false }))
 					.pipe(gulp.dest(packageDir));
 				await new Promise(resolve => packageJsonStream.on('finish', resolve)); // Wait for the files to finish being updated before packaging
 				const pkgJson = JSON.parse(fs.readFileSync(packageManifestPath));

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -15,6 +15,8 @@ const task = require('./lib/task');
 const glob = require('glob');
 const vsce = require('vsce');
 const mkdirp = require('mkdirp');
+const rename = require('gulp-rename');
+const fs = require('fs');
 
 gulp.task('fmt', () => formatStagedFiles());
 const formatFiles = (some) => {
@@ -94,12 +96,14 @@ const root = path.dirname(__dirname);
 
 gulp.task('package-external-extensions', task.series(
 	task.define('bundle-external-extensions-build', () => ext.packageExternalExtensionsStream().pipe(gulp.dest('.build/external'))),
-	task.define('create-external-extension-vsix-build', () => {
+	task.define('create-external-extension-vsix-build', async () => {
 		const vsixes = glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
 			const extensionPath = path.dirname(path.join(root, manifestPath));
 			const extensionName = path.basename(extensionPath);
 			return { name: extensionName, path: extensionPath };
-		}).map(element => {
+		})
+		.filter(element => ext.vscodeExternalExtensions.indexOf(element.name) === -1) // VS Code external extensions are bundled into ADS so no need to create a normal VSIX for them
+		.map(element => {
 			const pkgJson = require(path.join(element.path, 'package.json'));
 			const vsixDirectory = path.join(root, '.build', 'extensions');
 			mkdirp.sync(vsixDirectory);
@@ -111,8 +115,49 @@ gulp.task('package-external-extensions', task.series(
 				useYarn: true
 			});
 		});
+		// Wait for all the initial VSIXes to be completed before making the VS Code ones since we'll be overwriting
+		// values in the package.json for those.
+		await Promise.all(vsixes);
 
-		return Promise.all(vsixes);
+		// Go through and find the extensions which build separate versions of themselves for VS Code.
+		// This is currently a pretty simplistic process, essentially just replacing certain values in
+		// the package.json. It doesn't handle more complex tasks such as replacing localized strings.
+		const vscodeVsixes = glob.sync('.build/external/extensions/*/package.vscode.json')
+			.map(async vscodeManifestRelativePath => {
+				const vscodeManifestFullPath = path.join(root, vscodeManifestRelativePath);
+				const packageDir = path.dirname(vscodeManifestFullPath);
+				const packageManifestPath = path.join(packageDir, 'package.json');
+				const json = require('gulp-json-editor');
+				const packageJsonStream = gulp.src(packageManifestPath) // Create stream for the original package.json
+					.pipe(json((data => { // And now use gulp-json-editor to modify the contents
+						const updateData = JSON.parse(fs.readFileSync(vscodeManifestFullPath)); // Read in the set of values to replace from package.vscode.json
+						Object.keys(updateData).forEach(key => {
+							data[key] = updateData[key];
+						});
+						// Remove ADS-only menus. This is a subset of the menus listed in https://github.com/microsoft/azuredatastudio/blob/main/src/vs/workbench/api/common/menusExtensionPoint.ts
+						// More can be added to the list as needed.
+						['objectExplorer/item/context', 'dataExplorer/context', 'dashboard/toolbar'].forEach(menu => {
+							delete data.contributes.menus[menu];
+						});
+						return data;
+					}), { /* beautify: false */ }))
+					.pipe(gulp.dest(packageDir))
+					.pipe(rename('package.vscode.json'))
+					.pipe(gulp.dest(packageDir));
+				await new Promise(resolve => packageJsonStream.on('finish', resolve));
+				const pkgJson = require(vscodeManifestFullPath);
+				const vsixDirectory = path.join(root, '.build', 'extensions');
+				mkdirp.sync(vsixDirectory);
+				const packagePath = path.join(vsixDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
+				console.info('Creating vsix for ' + packageDir + ' result:' + packagePath);
+				return vsce.createVSIX({
+					cwd: packageDir,
+					packagePath: packagePath,
+					useYarn: true
+				});
+			});
+
+		return Promise.all(vscodeVsixes);
 	})
 ));
 

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -140,14 +140,10 @@ gulp.task('package-external-extensions', task.series(
 							delete data.contributes.menus[menu];
 						});
 						return data;
-					}), { /* beautify: false */ }))
-					.pipe(gulp.dest(packageDir))
-					.pipe(rename('package.vscode.json'))
+					}), { beautify: false }))
 					.pipe(gulp.dest(packageDir));
-				await new Promise(resolve => packageJsonStream.on('finish', resolve));
-				const pkgJson = require(vscodeManifestFullPath);
-				const vsixDirectory = path.join(root, '.build', 'extensions');
-				mkdirp.sync(vsixDirectory);
+				await new Promise(resolve => packageJsonStream.on('finish', resolve)); // Wait for the files to finish being updated before packaging
+				const pkgJson = JSON.parse(fs.readFileSync(packageManifestPath));
 				const packagePath = path.join(vsixDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
 				console.info('Creating vsix for ' + packageDir + ' result:' + packagePath);
 				return vsce.createVSIX({

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -144,6 +144,7 @@ gulp.task('package-external-extensions', task.series(
 					.pipe(gulp.dest(packageDir));
 				await new Promise(resolve => packageJsonStream.on('finish', resolve)); // Wait for the files to finish being updated before packaging
 				const pkgJson = JSON.parse(fs.readFileSync(packageManifestPath));
+				const vsixDirectory = path.join(root, '.build', 'extensions');
 				const packagePath = path.join(vsixDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
 				console.info('Creating vsix for ' + packageDir + ' result:' + packagePath);
 				return vsce.createVSIX({

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -4,7 +4,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.translatePackageJSON = exports.packageRebuildExtensionsStream = exports.cleanRebuildExtensions = exports.packageExternalExtensionsStream = exports.scanBuiltinExtensions = exports.packageMarketplaceExtensionsStream = exports.packageLocalExtensionsStream = exports.fromMarketplace = exports.fromLocalNormal = exports.fromLocal = void 0;
+exports.translatePackageJSON = exports.packageRebuildExtensionsStream = exports.cleanRebuildExtensions = exports.packageExternalExtensionsStream = exports.scanBuiltinExtensions = exports.packageMarketplaceExtensionsStream = exports.packageLocalExtensionsStream = exports.vscodeExternalExtensions = exports.fromMarketplace = exports.fromLocalNormal = exports.fromLocal = void 0;
 const es = require("event-stream");
 const fs = require("fs");
 const glob = require("glob");
@@ -232,6 +232,12 @@ const externalExtensions = [
     'sql-database-projects',
     'sql-migration'
 ];
+/**
+ * Extensions that are built into ADS but should be packaged externally as well for VS Code.
+ */
+exports.vscodeExternalExtensions = [
+    'data-workspace'
+];
 // extensions that require a rebuild since they have native parts
 const rebuildExtensions = [
     'big-data-cluster',
@@ -348,7 +354,7 @@ function packageExternalExtensionsStream() {
         const extensionName = path.basename(extensionPath);
         return { name: extensionName, path: extensionPath };
     })
-        .filter(({ name }) => externalExtensions.indexOf(name) >= 0);
+        .filter(({ name }) => externalExtensions.indexOf(name) >= 0 || exports.vscodeExternalExtensions.indexOf(name) >= 0);
     const builtExtensions = extenalExtensionDescriptions.map(extension => {
         return fromLocal(extension.path, false)
             .pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -268,6 +268,13 @@ const externalExtensions = [
 	'sql-migration'
 ];
 
+/**
+ * Extensions that are built into ADS but should be packaged externally as well for VS Code.
+ */
+export const vscodeExternalExtensions = [
+	'data-workspace'
+];
+
 // extensions that require a rebuild since they have native parts
 const rebuildExtensions = [
 	'big-data-cluster',
@@ -425,7 +432,7 @@ export function packageExternalExtensionsStream(): NodeJS.ReadWriteStream {
 			const extensionName = path.basename(extensionPath);
 			return { name: extensionName, path: extensionPath };
 		})
-		.filter(({ name }) => externalExtensions.indexOf(name) >= 0);
+		.filter(({ name }) => externalExtensions.indexOf(name) >= 0 || vscodeExternalExtensions.indexOf(name) >= 0);
 
 	const builtExtensions = extenalExtensionDescriptions.map(extension => {
 		return fromLocal(extension.path, false)

--- a/extensions/data-workspace/.vscodeignore
+++ b/extensions/data-workspace/.vscodeignore
@@ -1,5 +1,8 @@
-coverageConfig.json
+coverConfig.json
 coverage
 src
 tsconfig.json
 yarn.lock
+out
+extension.webpack.config.js
+package.vscode.json

--- a/extensions/data-workspace/.vscodeignore
+++ b/extensions/data-workspace/.vscodeignore
@@ -5,4 +5,3 @@ tsconfig.json
 yarn.lock
 out
 extension.webpack.config.js
-package.vscode.json

--- a/extensions/data-workspace/package.vscode.json
+++ b/extensions/data-workspace/package.vscode.json
@@ -1,0 +1,6 @@
+{
+	"name": "data-workspace-vscode",
+	"extensionDependencies": [
+		"ms-mssql.mssql"
+	]
+}

--- a/extensions/sql-database-projects/.vscodeignore
+++ b/extensions/sql-database-projects/.vscodeignore
@@ -1,5 +1,5 @@
-src/**
-out/**
+src
+out
 tsconfig.json
 .gitignore
 coverage
@@ -7,3 +7,4 @@ coverConfig.json
 extension.webpack.config.js
 *.vsix
 yarn.lock
+package.vscode.json

--- a/extensions/sql-database-projects/.vscodeignore
+++ b/extensions/sql-database-projects/.vscodeignore
@@ -7,4 +7,3 @@ coverConfig.json
 extension.webpack.config.js
 *.vsix
 yarn.lock
-package.vscode.json

--- a/extensions/sql-database-projects/package.vscode.json
+++ b/extensions/sql-database-projects/package.vscode.json
@@ -1,7 +1,7 @@
 {
-		"name": "sql-database-projects-vscode",
-		"extensionDependencies": [
-			"ms-mssql.mssql",
-			"Microsoft.data-workspace-vscode"
-		]
+	"name": "sql-database-projects-vscode",
+	"extensionDependencies": [
+		"ms-mssql.mssql",
+		"Microsoft.data-workspace-vscode"
+	]
 }

--- a/extensions/sql-database-projects/package.vscode.json
+++ b/extensions/sql-database-projects/package.vscode.json
@@ -1,0 +1,7 @@
+{
+		"name": "sql-database-projects-vscode",
+		"extensionDependencies": [
+			"ms-mssql.mssql",
+			"Microsoft.data-workspace-vscode"
+		]
+}


### PR DESCRIPTION
Add steps for creating separate VSIXs for extensions that we also publish to VS Code - this is needed because there are certain values (such as extension dependencies) which may be different in VS Code and need to be updated.

I haven't done an exhaustive look at all the values in the package.json that would need to be updated - this is just a few starter ones mostly to verify that the logic is working as expected and then I'll follow up with another PR to finish out the process. 

The VSIX's generated will have the name defined in the package.vscode.json - in this case `sql-database-projects-vscode` and `data-workspace-vscode`. I thought this best to clearly differentiate the packages to avoid potential mistakes with installing the wrong one.