### PR TITLE
Disable az cli prompt

### DIFF
--- a/extensions/azcli/src/extension.ts
+++ b/extensions/azcli/src/extension.ts
@@ -7,14 +7,13 @@ import * as azExt from 'az-ext';
 import * as rd from 'resource-deployment';
 import * as vscode from 'vscode';
 import { getExtensionApi } from './api';
-import { findAz } from './az';
 import { ArcControllerConfigProfilesOptionsSource } from './providers/arcControllerConfigProfilesOptionsSource';
 import { AzToolService } from './services/azToolService';
 
 export async function activate(context: vscode.ExtensionContext): Promise<azExt.IExtension> {
 	const azToolService = new AzToolService();
 
-	azToolService.localAz = await findAz();
+	// azToolService.localAz = await findAz(); Comment out until prompt dialog is fixed
 
 	const azApi = getExtensionApi(azToolService);
 


### PR DESCRIPTION
Disable the warning prompt when starting ADS Dev about the az CLI extension not being installed.

@candiceye Apologies for not catching this during the review, but any such prompts should always have an option to never show the warning again so that people aren't spammed by it if they decide they don't want to update (mostly for dev scenarios where it's more difficult to disable extensions in the repo, but in general just a good user-experience thing to have)

![image](https://user-images.githubusercontent.com/28519865/127358944-8830e524-4682-4026-bbfd-9bf20bd17014.png)
