### PR TITLE
Add card widget 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -115,6 +115,7 @@
 					"vs/nls",
 					"vs/css!./**/*",
 					"**/{vs,sql}/base/{common,browser}/**",
+					"**/{vs,sql}/platform/**/{common,browser}/**",
 					"@angular/*",
 					"rxjs/*"
 				]

--- a/src/sql/base/browser/ui/card/card.ts
+++ b/src/sql/base/browser/ui/card/card.ts
@@ -19,7 +19,7 @@ export class Card extends Widget {
 	private _onChange = new Emitter<boolean>();
 	public readonly onChange: Event<boolean> = this._onChange.event;
 
-	constructor() {
+	constructor(container: HTMLElement) {
 		super();
 
 		// Contains all the content added to the card via the content property
@@ -30,6 +30,8 @@ export class Card extends Widget {
 
 		this._radioButton = new RadioButton(true);
 		this._radioButtonContainer = this._cardElement.appendChild(this._radioButton.content);
+
+		container.appendChild(this._cardElement);
 
 		this.onclick(this._cardElement, e => this.onclicked());
 

--- a/src/sql/base/browser/ui/card/card.ts
+++ b/src/sql/base/browser/ui/card/card.ts
@@ -1,0 +1,173 @@
+import 'vs/css!./media/card';
+import * as DOM from 'vs/base/browser/dom';
+import { IColorTheme, ICssStyleCollector, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { inputBorder, inputValidationInfoBorder } from 'vs/platform/theme/common/colorRegistry';
+import { calloutDialogBodyBackground } from 'sql/platform/theme/common/colorRegistry';
+import { Widget } from 'vs/base/browser/ui/widget';
+import { Event, Emitter } from 'vs/base/common/event';
+
+export class Card extends Widget {
+	protected _cardElement: HTMLElement;
+	protected _contentWrapper: HTMLElement;
+	protected _radioButton: RadioButton;
+	protected _radioButtonContainer: HTMLElement;
+
+	protected _selected: boolean = false;
+	protected _hasFocus: boolean;
+	protected _enabled: boolean = true;
+
+	private _onChange = new Emitter<boolean>();
+	public readonly onChange: Event<boolean> = this._onChange.event;
+
+	constructor() {
+		super();
+
+		// Contains all the content added to the card via the content property
+		this._contentWrapper = DOM.$<HTMLDivElement>('div');
+
+		this._cardElement = DOM.$<HTMLDivElement>('div');
+		this._cardElement.appendChild(this._contentWrapper);
+
+		this._radioButton = new RadioButton(true);
+		this._radioButtonContainer = this._cardElement.appendChild(this._radioButton.content);
+
+		this.onclick(this._cardElement, e => this.onclicked());
+
+		this.update();
+	}
+
+	private onclicked(): void {
+		this.selected = !this.selected; //toggle value
+		this.update();
+	}
+
+	private update(): void {
+		this._radioButton.selected = this.selected;
+		this._radioButtonContainer.replaceWith(this._radioButton.content);
+
+		this._cardElement.className = this.cardClass;
+
+		if (this.enabled) {
+			this._cardElement.style.cursor = 'pointer';
+		} else {
+			this._cardElement.style.cursor = 'auto';
+		}
+	}
+
+	public set selected(selected: boolean) {
+		if (this.selected !== selected) {
+			this._selected = selected;
+			this._onChange.fire(this.selected);
+		}
+	}
+
+	public get selected(): boolean {
+		return this._selected;
+	}
+
+	public get cardElement(): HTMLElement {
+		return this._cardElement;
+	}
+
+	public set content(content: string) {
+		this._contentWrapper.innerHTML = content;
+	}
+
+	public get content() {
+		return this._contentWrapper.innerHTML;
+	}
+
+	public get showRadioButton(): boolean {
+		return this.selected || (this.enabled && this._hasFocus);
+	}
+
+	public set enabled(val: boolean) {
+		this._enabled = val;
+	}
+
+	public get enabled(): boolean {
+		return this._enabled;
+	}
+
+	protected get cardClass(): string {
+		return `selectable-card ${this.selected ? 'selected' : ''}`;
+	}
+
+	protected get contentWrapperClass(): string {
+		return `selectable-card-content-wrapper`;
+	}
+}
+
+class RadioButton {
+	private readonly SHOWRADIOBUTTON_DEFAULT: boolean = true;
+	private readonly SELECTED_DEFAULT: boolean = false;
+
+	private _indicatorContainer: HTMLSpanElement;
+	private _indicatorSelection: HTMLDivElement;
+
+	constructor(private _display?: boolean, private _selected?: boolean) {
+		this._indicatorContainer = DOM.$<HTMLSpanElement>('span');
+		this._indicatorContainer.classList.add('selectable-card-indicator-container');
+		this._indicatorContainer.hidden = !this._display ?? !this.SHOWRADIOBUTTON_DEFAULT;
+
+		this._indicatorSelection = DOM.$<HTMLDivElement>('div');
+		this._indicatorSelection.classList.add('selectable-card-indicator');
+		this._indicatorSelection.hidden = !this._selected ?? !this.SELECTED_DEFAULT;
+
+		this._indicatorContainer.appendChild(this._indicatorSelection);
+	}
+
+	public set selected(selected: boolean) {
+		this._selected = selected;
+		this._indicatorSelection.hidden = !this._selected;
+	}
+
+	public get selected(): boolean {
+		return this._selected;
+	}
+
+	public set display(display: boolean) {
+		this._display = display;
+	}
+
+	public get display(): boolean {
+		return this._display;
+	}
+
+	public get content(): HTMLElement {
+		return this._indicatorContainer;
+	}
+}
+
+registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
+	const inputBorderColor = theme.getColor(inputBorder);
+	collector.addRule(`
+	.selectable-card, .selectable-card .selection-indicator-container {
+			border-color: ${inputBorderColor.toString()};
+		}
+	`);
+
+	const background = theme.getColor(calloutDialogBodyBackground);
+	if (background) {
+		collector.addRule(`
+			.selectable-card .selection-indicator-container {
+				background-color: ${background.toString()};
+			}
+		`);
+	}
+
+	const inputActiveOptionBorderColor = theme.getColor(inputValidationInfoBorder);
+	if (inputActiveOptionBorderColor) {
+		collector.addRule(`
+			.selectable-card.selected, .selectable-card.selected .selectable-card-indicator-container {
+				border-color: ${inputActiveOptionBorderColor.toString()};
+			}
+		`);
+
+		collector.addRule(`
+		.selectable-card .selectable-card-indicator {
+				background: ${inputActiveOptionBorderColor.toString()};
+			}
+		`);
+	}
+});

--- a/src/sql/base/browser/ui/card/media/card.css
+++ b/src/sql/base/browser/ui/card/media/card.css
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+.selectable-card {
+	position: relative;
+	display: inline-block;
+	height: auto;
+	min-height: 100px;
+	width: 100%;
+	border-width: 1px;
+	border-style: solid;
+	text-align: left;
+	vertical-align: top;
+	border-color: rgb(214, 214, 214);
+	overflow: hidden;
+}
+
+.selectable-card-indicator-container {
+	position: absolute;
+	top: 5px;
+	right: 5px;
+	overflow: hidden;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	border-width: 1px;
+	border-style: solid;
+}
+
+
+.selectable-card-indicator {
+	margin: 4px;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+}


### PR DESCRIPTION
This PR adds a selectable card widget to be used within core. It is intended to be generic enough to be used in multiple scenarios.

I looked at using the creating a new component that extended the divContainer component, but these components seem to be intended to be used by extensions and not meant to be initialized within core.

Here is an example of how it could be used in a modal:
![selectable-card](https://user-images.githubusercontent.com/8183814/127360797-d7e71c09-6b0d-44bd-a531-8a2cde06a88c.gif)

