### PR TITLE
Add tooltip to input box on disabled dropdowns

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1036,4 +1036,11 @@ declare module 'azdata' {
 		 */
 		showToggleButton?: boolean;
 	}
+
+	export interface DropDownProperties extends LoadingComponentProperties {
+		/**
+		 * Whether to show tooltip when hovering on input box.
+		 */
+		showInputTooltip?: boolean;
+	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1040,11 +1040,4 @@ declare module 'azdata' {
 		 */
 		showToggleButton?: boolean;
 	}
-
-	export interface DropDownProperties extends LoadingComponentProperties {
-		/**
-		 * Whether to show tooltip when hovering on input box.
-		 */
-		showInputTooltip?: boolean;
-	}
 }

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -145,7 +145,12 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			}
 			this._editableDropdown.enabled = this.enabled;
 			this._editableDropdown.fireOnTextChange = this.fireOnTextChange;
-			this._editableDropdown.input.setTooltip(!this.enabled ? this._editableDropdown.input.value : '');
+
+			if (!this.enabled) {
+				this._editableDropdown.input.setTooltip(this._editableDropdown.input.value);
+			} else if (this._editableDropdown.input.inputElement.title) {
+				this._editableDropdown.input.setTooltip('');
+			}
 		} else {
 			this._selectBox.setOptions(this.getValues());
 			this._selectBox.selectWithOptionName(this.getSelectedValue());

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -147,7 +147,7 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			this._editableDropdown.fireOnTextChange = this.fireOnTextChange;
 
 			if (this.showInputTooltip) {
-				this._editableDropdown.input.setTooltip(this._editableDropdown.value);
+				this._editableDropdown.input.setTooltip(!this.enabled ? this._editableDropdown.input.value : '');
 			}
 		} else {
 			this._selectBox.setOptions(this.getValues());

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -145,6 +145,8 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			}
 			this._editableDropdown.enabled = this.enabled;
 			this._editableDropdown.fireOnTextChange = this.fireOnTextChange;
+
+			// Add tooltip when editable dropdown is disabled to show overflow text
 			this._editableDropdown.input.setTooltip(!this.enabled ? this._editableDropdown.input.value : '');
 		} else {
 			this._selectBox.setOptions(this.getValues());

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -145,12 +145,7 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			}
 			this._editableDropdown.enabled = this.enabled;
 			this._editableDropdown.fireOnTextChange = this.fireOnTextChange;
-
-			if (!this.enabled) {
-				this._editableDropdown.input.setTooltip(this._editableDropdown.input.value);
-			} else if (this._editableDropdown.input.inputElement.title) {
-				this._editableDropdown.input.setTooltip('');
-			}
+			this._editableDropdown.input.setTooltip(!this.enabled ? this._editableDropdown.input.value : '');
 		} else {
 			this._selectBox.setOptions(this.getValues());
 			this._selectBox.selectWithOptionName(this.getSelectedValue());

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -145,6 +145,10 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			}
 			this._editableDropdown.enabled = this.enabled;
 			this._editableDropdown.fireOnTextChange = this.fireOnTextChange;
+
+			if (this.showInputTooltip) {
+				this._editableDropdown.input.setTooltip(this._editableDropdown.value);
+			}
 		} else {
 			this._selectBox.setOptions(this.getValues());
 			this._selectBox.selectWithOptionName(this.getSelectedValue());
@@ -296,5 +300,13 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 		return this.mergeCss(super.CSSStyles, {
 			'width': this.getWidth()
 		});
+	}
+
+	public get showInputTooltip(): boolean {
+		return this.getPropertyOrDefault<boolean>((props) => props.showInputTooltip, false);
+	}
+
+	public set showInputTooltip(newValue: boolean) {
+		this.setPropertyFromUI<boolean>((props, value) => props.showInputTooltip = value, newValue);
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -145,10 +145,7 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			}
 			this._editableDropdown.enabled = this.enabled;
 			this._editableDropdown.fireOnTextChange = this.fireOnTextChange;
-
-			if (this.showInputTooltip) {
-				this._editableDropdown.input.setTooltip(!this.enabled ? this._editableDropdown.input.value : '');
-			}
+			this._editableDropdown.input.setTooltip(!this.enabled ? this._editableDropdown.input.value : '');
 		} else {
 			this._selectBox.setOptions(this.getValues());
 			this._selectBox.selectWithOptionName(this.getSelectedValue());
@@ -300,13 +297,5 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 		return this.mergeCss(super.CSSStyles, {
 			'width': this.getWidth()
 		});
-	}
-
-	public get showInputTooltip(): boolean {
-		return this.getPropertyOrDefault<boolean>((props) => props.showInputTooltip, false);
-	}
-
-	public set showInputTooltip(newValue: boolean) {
-		this.setPropertyFromUI<boolean>((props, value) => props.showInputTooltip = value, newValue);
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds tooltip to the input box on disabled editable dropdowns. Non-editable dropdowns already show tooltip on input box by default.

This will display tooltip only when editable dropdown is disabled. Similar to normal dropdowns, user can't expand the box for disabled editable dropdowns, so the tooltip is necessary.

Below is an example of a disabled, editable dropdown:
![image](https://user-images.githubusercontent.com/14362577/127711634-da9f6cb9-11eb-4f5d-a1c9-c565c3d5d576.png)