### PR TITLE
Add alert for description when modal message is shown

### DIFF
--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
@@ -353,7 +353,7 @@ export class ClusterSettingsPage extends ResourceTypePage {
 
 					if (messages.length > 0) {
 						this._model.wizard.wizardObject.message = {
-							text: messages.length === 1 ? messages[0] : localize('deployCluster.ValidationError', "There are some errors on this page, click 'Show Details' to view the errors."),
+							text: messages.length === 1 ? messages[0] : localizedConstants.multipleValidationErrors,
 							description: messages.length === 1 ? undefined : messages.join(EOL),
 							level: azdata.window.MessageLevel.Error
 						};

--- a/extensions/resource-deployment/src/ui/notebookWizard/notebookWizardPage.ts
+++ b/extensions/resource-deployment/src/ui/notebookWizard/notebookWizardPage.ts
@@ -5,7 +5,6 @@
 import * as azdata from 'azdata';
 import { EOL } from 'os';
 import * as vscode from 'vscode';
-import * as nls from 'vscode-nls';
 import { InitialVariableValues, NotebookWizardPageInfo } from '../../interfaces';
 import { initializeWizardPage, InputComponent, InputComponentInfo, setModelValues, Validator } from '../modelViewUtils';
 import { ResourceTypePage } from '../resourceTypePage';

--- a/extensions/resource-deployment/src/ui/notebookWizard/notebookWizardPage.ts
+++ b/extensions/resource-deployment/src/ui/notebookWizard/notebookWizardPage.ts
@@ -11,8 +11,7 @@ import { initializeWizardPage, InputComponent, InputComponentInfo, setModelValue
 import { ResourceTypePage } from '../resourceTypePage';
 import { WizardPageInfo } from '../wizardPageInfo';
 import { NotebookWizardModel } from './notebookWizardModel';
-
-const localize = nls.loadMessageBundle();
+import * as loc from '../../localizedConstants';
 
 export class NotebookWizardPage extends ResourceTypePage {
 
@@ -135,10 +134,7 @@ export class NotebookWizardPage extends ResourceTypePage {
 			this.wizard.wizardObject.message = {
 				text: messages.length === 1
 					? messages[0]
-					: localize(
-						"wizardPage.ValidationError",
-						"There are some errors on this page, click 'Show Details' to view the errors."
-					),
+					: loc.multipleValidationErrors,
 				description: messages.length === 1 ? undefined : messages.join(EOL),
 				level: azdata.window.MessageLevel.Error,
 			};

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -582,6 +582,11 @@ export abstract class Modal extends Disposable implements IThemable {
 			}
 			DOM.removeNode(this._messageDetail!);
 			this.messagesElementVisible = !!this._messageSummaryText;
+			// Read out the description to screen readers so they don't have to
+			// search around for the alert box to hear the extra information
+			if (description) {
+				alert(description);
+			}
 			this.updateExpandMessageState();
 		}
 	}


### PR DESCRIPTION
Was looking at making the behavior for https://github.com/microsoft/azuredatastudio/issues/15729 better since screen readers would have to tab up to the dialog (which is annoying because they'd have no idea where it was in the DOM), find the show more button and then click it to hear the actual error details.

So I'm making the modal messages read out their description when they're shown - in addition to the message text which is read automatically. 

Also removed a few duplicated error strings that already existed in the loc constants file. 