### PR TITLE
Fix DB pool in connection dropdown for managed instances

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -700,6 +700,9 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 			return;
 		}
 
+		// Remove the pool instance from database name in the dropdown
+		dbName = this.removePoolInstanceName(dbName);
+
 		this.connectionManagementService.changeDatabase(this._editor.input.uri, dbName)
 			.then(
 				result => {
@@ -718,6 +721,15 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 						message: nls.localize('changeDatabase.failedWithError', "Failed to change database: {0}", getErrorMessage(error))
 					});
 				});
+	}
+
+	// Removes the DB pool instance name from the database name
+	private removePoolInstanceName(dbName: string): string {
+		if (dbName.includes('@')) {
+			return dbName.split('@')[0];
+		} else {
+			return dbName;
+		}
 	}
 
 	private getCurrentDatabaseName(): string | undefined {


### PR DESCRIPTION
Before: 
![Screen Shot 2021-07-29 at 1 19 56 PM](https://user-images.githubusercontent.com/6411451/127560713-30942f47-8579-4407-8e83-7f9191f2c0aa.png)

After:
![Screen Shot 2021-07-29 at 1 17 29 PM](https://user-images.githubusercontent.com/6411451/127560735-a759ba01-31cb-4a6a-b0b8-093bdfc75d6e.png)

Ideally, we'd also check the server edition in case the database name has an "@" in it's name, but there's no way to check since the serverInfo returned doesn't have that information yet. So I used the same logic as: https://github.com/microsoft/sqltoolsservice/blob/a7703e63a4f3a217bffce303a2d1c395a41adfab/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs#L1626
