### PR TITLE
Fix some ModelView API definitions

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3514,12 +3514,6 @@ declare module 'azdata' {
 		 * The content of the currently selected file
 		 */
 		fileContent?: string | undefined;
-		/**
-		 * @deprecated This will be moved to `ComponentWithIconProperties`
-		 *
-		 * The title for the button. This title will show when hovered over
-		 */
-		title?: string | undefined;
 	}
 
 	export interface LoadingComponentProperties extends ComponentProperties {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3172,7 +3172,7 @@ declare module 'azdata' {
 	 * Properties representing the card component, can be used
 	 * when using ModelBuilder to create the component
 	 */
-	export interface CardProperties extends ComponentProperties, ComponentWithIcon {
+	export interface CardProperties extends ComponentProperties, ComponentWithIconProperties {
 		label: string;
 		value?: string | undefined;
 		actions?: ActionDescriptor[] | undefined;
@@ -3243,7 +3243,7 @@ declare module 'azdata' {
 	export type ThemedIconPath = { light: string | vscode.Uri; dark: string | vscode.Uri };
 	export type IconPath = string | vscode.Uri | ThemedIconPath;
 
-	export interface ComponentWithIcon extends ComponentWithIconProperties { }
+	export interface ComponentWithIcon extends Component, ComponentWithIconProperties { }
 
 	export interface ComponentWithIconProperties extends ComponentProperties {
 		/**
@@ -3402,7 +3402,7 @@ declare module 'azdata' {
 		requiredIndicator?: boolean | undefined;
 	}
 
-	export interface ImageComponentProperties extends ComponentProperties, ComponentWithIcon {
+	export interface ImageComponentProperties extends ComponentProperties, ComponentWithIconProperties {
 	}
 
 	export interface GroupContainerProperties extends ComponentProperties {
@@ -3501,7 +3501,7 @@ declare module 'azdata' {
 		isAutoResizable: boolean;
 	}
 
-	export interface ButtonProperties extends ComponentProperties, ComponentWithIcon {
+	export interface ButtonProperties extends ComponentProperties, ComponentWithIconProperties {
 		/**
 		 * The label for the button
 		 */
@@ -3712,7 +3712,7 @@ declare module 'azdata' {
 		minimumHeight: number;
 	}
 
-	export interface ButtonComponent extends Component, ButtonProperties {
+	export interface ButtonComponent extends ComponentWithIcon, ButtonProperties {
 		/**
 		 * An event called when the button is clicked
 		 */

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3172,7 +3172,7 @@ declare module 'azdata' {
 	 * Properties representing the card component, can be used
 	 * when using ModelBuilder to create the component
 	 */
-	export interface CardProperties extends ComponentProperties, ComponentWithIconProperties {
+	export interface CardProperties extends ComponentWithIconProperties {
 		label: string;
 		value?: string | undefined;
 		actions?: ActionDescriptor[] | undefined;
@@ -3402,7 +3402,7 @@ declare module 'azdata' {
 		requiredIndicator?: boolean | undefined;
 	}
 
-	export interface ImageComponentProperties extends ComponentProperties, ComponentWithIconProperties {
+	export interface ImageComponentProperties extends ComponentWithIconProperties {
 	}
 
 	export interface GroupContainerProperties extends ComponentProperties {
@@ -3501,7 +3501,7 @@ declare module 'azdata' {
 		isAutoResizable: boolean;
 	}
 
-	export interface ButtonProperties extends ComponentProperties, ComponentWithIconProperties {
+	export interface ButtonProperties extends ComponentWithIconProperties {
 		/**
 		 * The label for the button
 		 */


### PR DESCRIPTION
1. Removed duplicate title property from ButtonProperties - it now inherits from ComponentWithIconProperties which has the title property on it already https://github.com/microsoft/azuredatastudio/blob/main/src/sql/azdata.d.ts#L3264
2. While fixing this I noticed that ButtonProperties was inheriting from the `ComponentWithIcon` interface. Generally this is incorrect - for ModelView stuff Properties interfaces should generally only be inheriting from other properties. Not the actual component interface definition. In this case it should be a mostly non-breaking change to do this as ComponentWithIcon directly inherited from ComponentWithIconProperties and had no other properties of its own
3. And then I fixed up ComponentWithIcon to inherit from Component itself, which should have been done from the start. **This one could potentially break the typings for people** if they were creating objects of that type (since Component has a bunch of required properties) but I feel that given how relatively new this API is and the low number of customer submitted extensions that this is worth it to make our ModelView API more consistent and accurate