### PR TITLE
Fix expanded state announce for dialog headers

### DIFF
--- a/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
@@ -25,15 +25,18 @@ import { ILogService } from 'vs/platform/log/common/log';
 		<div *ngIf="hasHeader()" [class]="getHeaderClass()" (click)="changeState()" (keydown)="onKeyDown($event)" [tabindex]="isCollapsible()? 0 : -1" [attr.role]="isCollapsible() ? 'button' : null" [attr.aria-expanded]="isCollapsible() ? !collapsed : null">
 				{{_containerLayout.header}}
 		</div>
-		<div #container *ngIf="items" class="modelview-group-container" [ngStyle]="CSSStyles">
-			<ng-container *ngFor="let item of items">
-			<div class="modelview-group-row" >
-				<div  class="modelview-group-cell">
-				<model-component-wrapper  [descriptor]="item.descriptor" [modelStore]="modelStore" >
-				</model-component-wrapper>
+		<!-- This extra is needed so that the expanded state of the header is updated correctly. See
+		<div>
+			<div #container *ngIf="items" class="modelview-group-container" [ngStyle]="CSSStyles">
+				<ng-container *ngFor="let item of items">
+				<div class="modelview-group-row" >
+					<div  class="modelview-group-cell">
+					<model-component-wrapper  [descriptor]="item.descriptor" [modelStore]="modelStore" >
+					</model-component-wrapper>
+					</div>
 				</div>
+				</ng-container>
 			</div>
-			</ng-container>
 		</div>
 	`
 })

--- a/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
@@ -25,7 +25,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 		<div *ngIf="hasHeader()" [class]="getHeaderClass()" (click)="changeState()" (keydown)="onKeyDown($event)" [tabindex]="isCollapsible()? 0 : -1" [attr.role]="isCollapsible() ? 'button' : null" [attr.aria-expanded]="isCollapsible() ? !collapsed : null">
 				{{_containerLayout.header}}
 		</div>
-		<!-- This extra is needed so that the expanded state of the header is updated correctly. See
+		<!-- This extra div is needed so that the expanded state of the header is updated correctly. See https://github.com/microsoft/azuredatastudio/pull/16499 for more details -->
 		<div>
 			<div #container *ngIf="items" class="modelview-group-container" [ngStyle]="CSSStyles">
 				<ng-container *ngFor="let item of items">


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15728

This is a really odd one. I feel like this is a bug with NVDA, Angular or some combination of the two - if I make it so clicking the button doesn't change the container display then it announces just fine. So something with setting the display on the container is messing with the announce. But nesting it in an empty div fixes it for some reason...

(Narrator is even worse - it doesn't even announce the expanded state when it changes in any scenario, just when you tab over it initially. But it announces it correctly for actual buttons, so maybe some issue with it and the button role?)

I can't seem to repro this outside of ADS so don't really have much to give to the NVDA folks - I'll see if there's any issues that seem similar though to at least try to understand why this is broken. 