### PR TITLE
Fix azdata API check when webpacked

### DIFF
--- a/extensions/data-workspace/src/common/utils.ts
+++ b/extensions/data-workspace/src/common/utils.ts
@@ -54,6 +54,10 @@ export function getPackageInfo(packageJson: any): IPackageInfo | undefined {
 let azdataApi: typeof azdataType | undefined = undefined;
 try {
 	azdataApi = require('azdata');
+	if (!azdataApi?.version) {
+		// webpacking makes the require return an empty object instead of throwing an error so make sure we clear the var
+		azdataApi = undefined;
+	}
 } catch {
 	// no-op
 }

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -367,6 +367,10 @@ export function timeConversion(duration: number): string {
 let azdataApi: typeof azdataType | undefined = undefined;
 try {
 	azdataApi = require('azdata');
+	if (!azdataApi?.version) {
+		// webpacking makes the require return an empty object instead of throwing an error so make sure we clear the var
+		azdataApi = undefined;
+	}
 } catch {
 	// no-op
 }


### PR DESCRIPTION
This was causing the webpacked extensions to fail since it was thinking it was running with an azdata API (empty object is truthy)