### PR TITLE
Sql Proj VS Code fixes

### DIFF
--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -7,7 +7,8 @@ declare module 'dataworkspace' {
 	import * as azdata from 'azdata';
 	import * as vscode from 'vscode';
 	export const enum extension {
-		name = 'Microsoft.data-workspace'
+		name = 'Microsoft.data-workspace',
+		vscodeName = 'Microsoft.data-workspace-vscode'
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -249,7 +249,8 @@ export function getSqlProjectsInWorkspace(): Promise<vscode.Uri[]> {
 }
 
 export function getDataWorkspaceExtensionApi(): dataworkspace.IExtension {
-	const extension = vscode.extensions.getExtension(dataworkspace.extension.name)!;
+	const dataworkspaceExtName = getAzdataApi() ? dataworkspace.extension.name : dataworkspace.extension.vscodeName;
+	const extension = vscode.extensions.getExtension(dataworkspaceExtName)!;
 	return extension.exports;
 }
 

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -6,7 +6,8 @@
 declare module 'sqldbproj' {
 	import * as vscode from 'vscode';
 	export const enum extension {
-		name = 'Microsoft.sql-database-projects'
+		name = 'Microsoft.sql-database-projects',
+		vsCodeName = 'Microsoft.sql-database-projects-vscode'
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -53,7 +53,6 @@ export class BuildHelper {
 		}
 
 		const buildfilesPath = await this.getBuildDirPathFromMssqlTools();
-		console.log(`BUILD FILES ${buildfilesPath}`);
 		buildFiles.forEach(async (fileName) => {
 			if (await (utils.exists(path.join(buildfilesPath, fileName)))) {
 				await fs.copyFile(path.join(buildfilesPath, fileName), path.join(this.extensionBuildDir, fileName));

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -35,7 +35,8 @@ export class BuildHelper {
 	private initialized: boolean = false;
 
 	constructor() {
-		this.extensionDir = vscode.extensions.getExtension(sqldbproj.extension.name)?.extensionPath ?? '';
+		const extName = utils.getAzdataApi() ? sqldbproj.extension.name : sqldbproj.extension.vsCodeName;
+		this.extensionDir = vscode.extensions.getExtension(extName)?.extensionPath ?? '';
 		this.extensionBuildDir = path.join(this.extensionDir, buildDirectory);
 	}
 
@@ -52,7 +53,7 @@ export class BuildHelper {
 		}
 
 		const buildfilesPath = await this.getBuildDirPathFromMssqlTools();
-
+		console.log(`BUILD FILES ${buildfilesPath}`);
 		buildFiles.forEach(async (fileName) => {
 			if (await (utils.exists(path.join(buildfilesPath, fileName)))) {
 				await fs.copyFile(path.join(buildfilesPath, fileName), path.join(this.extensionBuildDir, fileName));
@@ -81,8 +82,12 @@ export class BuildHelper {
 			if (utils.getAzdataApi()) {
 				installDir = config.installDirectory?.replace('{#version#}', config.version).replace('{#platform#}', this.getPlatform());
 			} else {
-				// VS Code MSSQL extension has its config.json
-				installDir = config.service?.installDir?.replace('{#version#}', config.version).replace('{#platform#}', this.getPlatform());
+				// VS Code MSSQL extension has a slightly different format for its config.json
+				installDir = config.service?.installDir?.replace('{#version#}', config.service.version).replace('{#platform#}', this.getPlatform());
+				if (installDir) {
+					// The path to the install location is relative to one directory above where the config is so account for that here
+					installDir = path.join('..', installDir);
+				}
 			}
 
 			if (installDir) {


### PR DESCRIPTION
1. Using correct extension name based on context. Not the most elegant but I wanted to avoid having to do a runtime check for these
2. Fix build tools path so we'll copy over the build DLLs and targets file correctly