### PR TITLE
Remove unused commands from vs code sql proj

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -119,7 +119,7 @@
       "view/item/context": [
         {
           "command": "projects.manageProject",
-          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project && azdataAvailable",
           "group": "0_projectsFirst@1"
         }
       ]

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -17,6 +17,8 @@ import { getAzdataApi } from './common/utils';
 import { createNewProjectWithQuickpick } from './dialogs/newProjectQuickpick';
 
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
+	const azdataApi = getAzdataApi();
+	vscode.commands.executeCommand('setContext', 'azdataAvailable', !!azdataApi);
 	const workspaceService = new WorkspaceService();
 
 	const workspaceTreeDataProvider = new WorkspaceTreeDataProvider(workspaceService);
@@ -31,7 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	setProjectProviderContextValue(workspaceService);
 
 	context.subscriptions.push(vscode.commands.registerCommand('projects.new', async () => {
-		if (getAzdataApi()) {
+		if (azdataApi) {
 			const dialog = new NewProjectDialog(workspaceService);
 			await dialog.open();
 		} else {
@@ -40,7 +42,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('projects.openExisting', async () => {
-		if (getAzdataApi()) {
+		if (azdataApi) {
 			const dialog = new OpenExistingDialog(workspaceService);
 			await dialog.open();
 		} else {

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -261,7 +261,7 @@
         },
         {
           "command": "sqlDatabaseProjects.schemaCompare",
-          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project",
+          "when": "view == dataworkspace.views.main && viewItem == databaseProject.itemType.project && azdataAvailable",
           "group": "1_dbProjectsFirst@3"
         },
         {

--- a/extensions/sql-database-projects/src/extension.ts
+++ b/extensions/sql-database-projects/src/extension.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { getAzdataApi } from './common/utils';
 import MainController from './controllers/mainController';
 import { SqlDatabaseProjectProvider } from './projectProvider/projectProvider';
 
 let controllers: MainController[] = [];
 
 export function activate(context: vscode.ExtensionContext): Promise<SqlDatabaseProjectProvider> {
+	vscode.commands.executeCommand('setContext', 'azdataAvailable', !!getAzdataApi());
 	// Start the main controller
 	const mainController = new MainController(context);
 	controllers.push(mainController);


### PR DESCRIPTION
Remove "Manage" and "Schema Compare".

Tested all other actions and they work as expected except for "Create Project from Database". I'm going to look into that one to see how feasible it is to fix up for VS Code.