### PR TITLE
Remove infrastructure from resource-deployment

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -291,19 +291,19 @@
                           "required": true
                         },
                         {
+                          "type": "options",
                           "label": "%arc.data.controller.infrastructure%",
                           "defaultValue": "azure",
+                          "required": true,
                           "variableName": "AZDATA_NB_VAR_ARC_INFRASTRUCTURE",
-                          "type": "infrastructure",
-                          "infrastructure": [
+                          "options": [
                             "azure",
                             "gcp",
                             "aws",
                             "alibaba",
                             "onpremises",
                             "other"
-                          ],
-                          "required": true
+                          ]
                         }
                       ]
                     },

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -361,11 +361,6 @@ export interface AzureLocationsFieldInfo extends FieldInfo {
 	locations?: string[]
 }
 
-export interface InfrastructureFieldInfo extends FieldInfo {
-	infrastructureName?: string;
-	infrastructure?: string[]
-}
-
 export interface FilePickerFieldInfo extends FieldInfo {
 	filter: FilePickerFilter;
 }
@@ -401,7 +396,6 @@ export enum FieldType {
 	Checkbox = 'checkbox',
 	AzureAccount = 'azure_account',
 	AzureLocations = 'azure_locations',
-	Infrastructure = 'infrastructure',
 	FilePicker = 'file_picker',
 	KubeClusterContextPicker = 'kube_cluster_context_picker',
 	KubeStorageClass = 'kube_storage_class'

--- a/extensions/resource-deployment/src/localizedConstants.ts
+++ b/extensions/resource-deployment/src/localizedConstants.ts
@@ -15,7 +15,6 @@ export const subscription = localize('azure.account.subscription', "Subscription
 export const subscriptionDescription = localize('azure.account.subscriptionDescription', "Change the currently selected subscriptions through the 'Select Subscriptions' action on an account listed in the 'Azure' tree view of the 'Connections' viewlet");
 export const resourceGroup = localize('azure.account.resourceGroup', "Resource Group");
 export const location = localize('azure.account.location', "Azure Location");
-export const infrastructure = localize('azure.account.infrastructure', "Infrastructure");
 export const browse = localize('filePicker.browse', "Browse");
 export const select = localize('button.label', "Select");
 export const kubeConfigFilePath = localize('kubeConfigClusterPicker.kubeConfigFilePath', "Kube config file path");

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -11,7 +11,7 @@ import { IOptionsSourceProvider } from 'resource-deployment';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { getDateTimeString, getErrorMessage, isUserCancelledError, throwUnless } from '../common/utils';
-import { AzureAccountFieldInfo, AzureLocationsFieldInfo, ComponentCSSStyles, DialogInfoBase, FieldInfo, FieldType, FilePickerFieldInfo, InfrastructureFieldInfo, InitialVariableValues, instanceOfDynamicEnablementInfo, IOptionsSource, KubeClusterContextFieldInfo, LabelPosition, NoteBookEnvironmentVariablePrefix, OptionsInfo, OptionsType, PageInfoBase, RowInfo, SectionInfo, TextCSSStyles } from '../interfaces';
+import { AzureAccountFieldInfo, AzureLocationsFieldInfo, ComponentCSSStyles, DialogInfoBase, FieldInfo, FieldType, FilePickerFieldInfo, InitialVariableValues, instanceOfDynamicEnablementInfo, IOptionsSource, KubeClusterContextFieldInfo, LabelPosition, NoteBookEnvironmentVariablePrefix, OptionsInfo, OptionsType, PageInfoBase, RowInfo, SectionInfo, TextCSSStyles } from '../interfaces';
 import * as loc from '../localizedConstants';
 import { apiService } from '../services/apiService';
 import { valueProviderService } from '../services/valueProviderService';
@@ -110,10 +110,6 @@ interface KubeClusterContextFieldContext extends FieldContext {
 
 interface AzureLocationsFieldContext extends FieldContext {
 	fieldInfo: AzureLocationsFieldInfo;
-}
-
-interface InfrastructureFieldContext extends FieldContext {
-	fieldInfo: InfrastructureFieldInfo;
 }
 
 interface AzureAccountFieldContext extends FieldContext {
@@ -576,9 +572,6 @@ async function processField(context: FieldContext): Promise<void> {
 			break;
 		case FieldType.AzureLocations:
 			await processAzureLocationsField(context);
-			break;
-		case FieldType.Infrastructure:
-			await processInfrastructureField(context);
 			break;
 		case FieldType.FilePicker:
 			processFilePickerField(context);
@@ -1531,55 +1524,6 @@ async function processAzureLocationsField(context: AzureLocationsFieldContext): 
 	}
 	addLabelInputPairToContainer(context.view, context.components, label, locationInputInfo.component, context.fieldInfo);
 	return locationInputInfo.component;
-}
-
-/**
- * An Infrastructure field consists of a dropdown field for infrastructure types
- * @param context The context to use to create the field
- */
-async function processInfrastructureField(context: InfrastructureFieldContext): Promise<void> {
-	const label = createLabel(context.view, {
-		text: context.fieldInfo.label || loc.infrastructure,
-		required: context.fieldInfo.required,
-		width: context.fieldInfo.labelWidth,
-		cssStyles: context.fieldInfo.labelCSSStyles
-	});
-	const defaultValue = context.initialVariableValues?.[context.fieldInfo.infrastructureName || '']?.toString() ?? (context.fieldInfo.required ? undefined : '');
-	let infrastructureInputInfo: InputComponentInfo<AzureComponent>;
-	// If we have an default value then we don't allow users to modify it - so use a disabled text input box instead
-	if (defaultValue) {
-		infrastructureInputInfo = createInputBoxInputInfo(context.view, {
-			type: 'text',
-			defaultValue: defaultValue,
-			ariaLabel: loc.infrastructure,
-			required: context.fieldInfo.required,
-			width: context.fieldInfo.inputWidth,
-			enabled: false
-		});
-	} else {
-		const infrastructureValues = context.fieldInfo.infrastructure;
-		infrastructureInputInfo = createDropdownInputInfo(context.view, {
-			defaultValue: infrastructureValues?.find(l => l === context.fieldInfo.defaultValue),
-			width: context.fieldInfo.inputWidth,
-			editable: false,
-			required: context.fieldInfo.required,
-			label: loc.infrastructure,
-			values: infrastructureValues
-		});
-		(<InputComponentInfo<azdata.DropDownComponent>>infrastructureInputInfo).component.fireOnTextChange = true;
-	}
-
-	infrastructureInputInfo.labelComponent = label;
-	context.fieldInfo.subFields = context.fieldInfo.subFields || [];
-	if (context.fieldInfo.infrastructureName) {
-		context.fieldInfo.subFields!.push({
-			label: label.value!,
-			variableName: context.fieldInfo.infrastructureName
-		});
-		context.onNewInputComponentCreated(context.fieldInfo.infrastructureName, infrastructureInputInfo);
-	}
-	context.onNewInputComponentCreated(context.fieldInfo.variableName || context.fieldInfo.label, infrastructureInputInfo);
-	addLabelInputPairToContainer(context.view, context.components, label, infrastructureInputInfo.component, context.fieldInfo);
 }
 
 export function isValidSQLPassword(password: string, userName: string = 'sa'): boolean {


### PR DESCRIPTION
Infrastructure is just a simple choice of values so we can just use the options field for that - no reason to have a custom type. 

![image](https://user-images.githubusercontent.com/28519865/127895951-2f431ebe-9db0-4554-b666-eff7bc0e7f73.png)
