### PR TITLE
Fixing the redacted migration service id by encoding it to base64

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -909,7 +909,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 							'serverName': this._targetServerInstance.name,
 							'tenantId': this._azureAccount.properties.tenants[0].id,
 							'location': this._targetServerInstance.location,
-							'sqlMigrationServiceId': this._sqlMigrationService.id,
+							'sqlMigrationServiceId': Buffer.from(this._sqlMigrationService.id).toString('base64'),
 							'irRegistered': (this._nodeNames.length > 0).toString()
 						},
 						{


### PR DESCRIPTION
Encoding user path like telemetry property to base64 to avoid redaction. 

I have tested it through fiddler and I can see the encoded string
