### PR TITLE
AzTool version fix only

### DIFF
--- a/extensions/azcli/src/localizedConstants.ts
+++ b/extensions/azcli/src/localizedConstants.ts
@@ -33,3 +33,4 @@ export const unsupportedArcDataVersion = (requiredVersion: string, currentVersio
 export const doNotAskAgain = localize('az.doNotAskAgain', "Don't Ask Again");
 export const askLater = localize('az.askLater', "Ask Later");
 export const azOutputParseErrorCaught = (command: string): string => localize('az.azOutputParseErrorCaught', "An error occurred while parsing the output of az command: {0}. The output is not JSON.", command);
+export const parseVersionError = localize('az.parseVersionError', "An error occurred while parsing the output of az --version.");


### PR DESCRIPTION
AzTool was being created with the Azure CLI arcdata extension's version number and not the Azure CLI's version number. This change should fix it, and also parses out any '*' output of az --version. This is a small part of another PR https://github.com/microsoft/azuredatastudio/pull/16533 that is in the process of being merged in. 