### PR TITLE
Fix query database drop-down rendering location after resize

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -136,8 +136,14 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 			}
 		});
 
+		/*
+			This event listener is intended to close the expanded drop down when the ADS shell window is resized
+			to prevent the list from rendering incorrectly at the top left corner of the window.
+		 */
 		this._register(DOM.addDisposableListener(window, DOM.EventType.RESIZE, () => {
-			this._hideList();
+			if (this._isDropDownVisible) {
+				this._hideList();
+			}
 		}));
 
 		this._register(DOM.addStandardDisposableListener(this._input.inputElement, DOM.EventType.KEY_DOWN, (e: StandardKeyboardEvent) => {

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -136,6 +136,10 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 			}
 		});
 
+		this._register(DOM.addDisposableListener(window, DOM.EventType.RESIZE, () => {
+			this._hideList();
+		}));
+
 		this._register(DOM.addStandardDisposableListener(this._input.inputElement, DOM.EventType.KEY_DOWN, (e: StandardKeyboardEvent) => {
 			switch (e.keyCode) {
 				case KeyCode.Enter:

--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -319,10 +319,34 @@ export class ContextView extends Disposable {
 		this.view.classList.toggle('fixed', this.useFixedPosition);
 
 		const containerPosition = DOM.getDomNodePagePosition(this.container!);
-		this.view.style.top = `${top - (this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).top : containerPosition.top)}px`;
-		this.view.style.left = `${left - (this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).left : containerPosition.left)}px`;
+
+		// {{SQL CARBON EDIT}} - START
+		let previousTopPositionForView: number = this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).top : containerPosition.top;
+		let previousLeftPositionForView: number = this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).left : containerPosition.left;
+
+		// Confirm that the anchor is an HTML element AND check if new position will appear at the origin (0, 0) of the window, so we can avoid and keep current top and left values.
+		if (DOM.isHTMLElement(anchor) && this.isNewPositionAtOrigin(top, left, previousTopPositionForView, previousLeftPositionForView)) {
+			this.view.style.top = `${top}px`;
+			this.view.style.left = `${left}px`;
+		}
+		// If anchor is not an HTML element OR it won't appear at the origin, then continue using pre-exisitng behavior
+		else {
+			this.view.style.top = `${top - previousTopPositionForView}px`;
+			this.view.style.left = `${left - previousLeftPositionForView}px`;
+		}
+		// {{SQL CARBON EDIT}} - END
+
 		this.view.style.width = 'initial';
 	}
+
+	// {{SQL CARBON EDIT}} - START
+	private isNewPositionAtOrigin(top: number, left: number, previousTopPositionForView: number, previousLeftPositionForView: number): boolean {
+		const newTopOffset: number = top - previousTopPositionForView;
+		const newLeftOffset: number = left - previousLeftPositionForView;
+
+		return newTopOffset === 0 && newLeftOffset === 0;
+	}
+	// {{SQL CARBON EDIT}} - END
 
 	hide(data?: unknown): void {
 		const delegate = this.delegate;

--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -319,34 +319,10 @@ export class ContextView extends Disposable {
 		this.view.classList.toggle('fixed', this.useFixedPosition);
 
 		const containerPosition = DOM.getDomNodePagePosition(this.container!);
-
-		// {{SQL CARBON EDIT}} - START
-		let previousTopPositionForView: number = this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).top : containerPosition.top;
-		let previousLeftPositionForView: number = this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).left : containerPosition.left;
-
-		// Confirm that the anchor is an HTML element AND check if new position will appear at the origin (0, 0) of the window, so we can avoid and keep current top and left values.
-		if (DOM.isHTMLElement(anchor) && this.isNewPositionAtOrigin(top, left, previousTopPositionForView, previousLeftPositionForView)) {
-			this.view.style.top = `${top}px`;
-			this.view.style.left = `${left}px`;
-		}
-		// If anchor is not an HTML element OR it won't appear at the origin, then continue using pre-exisitng behavior
-		else {
-			this.view.style.top = `${top - previousTopPositionForView}px`;
-			this.view.style.left = `${left - previousLeftPositionForView}px`;
-		}
-		// {{SQL CARBON EDIT}} - END
-
+		this.view.style.top = `${top - (this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).top : containerPosition.top)}px`;
+		this.view.style.left = `${left - (this.useFixedPosition ? DOM.getDomNodePagePosition(this.view).left : containerPosition.left)}px`;
 		this.view.style.width = 'initial';
 	}
-
-	// {{SQL CARBON EDIT}} - START
-	private isNewPositionAtOrigin(top: number, left: number, previousTopPositionForView: number, previousLeftPositionForView: number): boolean {
-		const newTopOffset: number = top - previousTopPositionForView;
-		const newLeftOffset: number = left - previousLeftPositionForView;
-
-		return newTopOffset === 0 && newLeftOffset === 0;
-	}
-	// {{SQL CARBON EDIT}} - END
 
 	hide(data?: unknown): void {
 		const delegate = this.delegate;


### PR DESCRIPTION
This PR fixes issue #15499

This PR resolves issue #15499 by correcting the rendering behavior for the select database drop down list when the list is expanded and the ADS shell window is resized. 

Steps to verify fix:
Run a query
Expand the database drop-down
Resize the ADS shell window
Correct & expected behavior: Drop-down doesn't appear at window origin position (0px, 0px) after resize.
Incorrect & previous behavior: Drop down appears at the window origin position (0px, 0px) after resize.
