### PR TITLE
Use local webview endpoint for web mode

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -411,7 +411,10 @@ class WindowIndicator implements IWindowIndicator {
 		throw new Error('Missing web configuration element');
 	}
 
-	const config: IWorkbenchConstructionOptions & { folderUri?: UriComponents, workspaceUri?: UriComponents } = JSON.parse(configElementAttribute);
+	const config: IWorkbenchConstructionOptions & { folderUri?: UriComponents, workspaceUri?: UriComponents } = {
+		...JSON.parse(configElementAttribute),
+		webviewEndpoint: `${window.location.origin}${window.location.pathname.replace(/\/+$/, '')}/webview`
+	}; // {{SQL CARBON EDIT}} Use local webview endpoint
 
 	// Find workspace to open and payload
 	let foundWorkspace = false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is part of fixes for #15962.

Currently the webview endpoint is set to `*.vscode-webview-test.com` which is just a placeholder and will give 404 to webview requests since it doesn't actually exist.

This PR sets the correct local webview endpoint.

This `webviewEndpoint` config should only affect web mode and should not have any impact on desktop builds.