### PR TITLE
UI bugbash: sql-migration fix assessment db selection

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -34,6 +34,9 @@ export const SKU_RECOMMENDATION_PAGE_TITLE = localize('sql.migration.wizard.sku.
 export const SKU_RECOMMENDATION_ALL_SUCCESSFUL = (databaseCount: number): string => {
 	return localize('sql.migration.wizard.sku.all', "Based on the assessment results, all {0} of your database(s) in online state can be migrated to Azure SQL.", databaseCount);
 };
+export const SKU_RECOMMENDATION_ASSESSMENT_ERROR = (serverName: string): string => {
+	return localize('sql.migration.qizard.sku.assessment.error', "An error occurred while assessing the server '{0}'.", serverName);
+};
 export const SKU_RECOMMENDATION_SOME_SUCCESSFUL = (migratableCount: number, databaseCount: number): string => {
 	return localize('sql.migration.wizard.sku.some', "Based on the results of our source configuration scans, {0} out of {1} of your databases can be migrated to Azure SQL.", migratableCount, databaseCount);
 };

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -138,6 +138,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 
 	private _skuRecommendations: SKURecommendations | undefined;
 	public _assessmentResults!: ServerAssessement;
+	public _runAssessments: boolean = true;
 	private _assessmentApiResponse!: mssql.AssessmentResult;
 
 	public _vmDbs: string[] = [];
@@ -186,16 +187,27 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 
 	public async getDatabaseAssessments(): Promise<ServerAssessement> {
 		const ownerUri = await azdata.connection.getUriForConnection(this.sourceConnectionId);
-		this._assessmentApiResponse = (await this.migrationService.getAssessments(ownerUri, this._databaseAssessment))!;
-		this._assessmentResults = {
-			issues: this._assessmentApiResponse.assessmentResult.items,
-			databaseAssessments: this._assessmentApiResponse.assessmentResult.databases.map(d => {
-				return {
-					name: d.name,
-					issues: d.items
-				};
-			})
-		};
+		try {
+			this._assessmentApiResponse = (await this.migrationService.getAssessments(ownerUri, this._databaseAssessment))!;
+			this._assessmentResults = {
+				issues: this._assessmentApiResponse.assessmentResult.items,
+				databaseAssessments: this._assessmentApiResponse.assessmentResult.databases.map(d => {
+					return {
+						name: d.name,
+						issues: d.items,
+						errors: d.errors
+					};
+				}),
+				errors: this._assessmentApiResponse.errors
+			};
+		} catch (error) {
+			this._assessmentResults = {
+				issues: [],
+				databaseAssessments: [],
+				errors: [],
+				assessmentError: error
+			};
+		}
 
 		// Generating all the telemetry asynchronously as we don't need to block the user for it.
 		this.generateAssessmentTelemetry().catch(e => console.error(e));
@@ -528,7 +540,6 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 		return this._resourceGroups[index];
 	}
 
-
 	public async getManagedInstanceValues(subscription: azureResource.AzureResourceSubscription, location: azureResource.AzureLocation, resourceGroup: azureResource.AzureResourceResourceGroup): Promise<azdata.CategoryValue[]> {
 		let managedInstanceValues: azdata.CategoryValue[] = [];
 		if (!this._azureAccount) {
@@ -536,7 +547,7 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 		}
 		try {
 			this._targetManagedInstances = (await getAvailableManagedInstanceProducts(this._azureAccount, subscription)).filter((mi) => {
-				if (mi.location.toLowerCase() === location.name.toLowerCase() && mi.resourceGroup?.toLowerCase() === resourceGroup.name.toLowerCase()) {
+				if (mi.location.toLowerCase() === location.name.toLowerCase() && mi.resourceGroup?.toLowerCase() === resourceGroup?.name.toLowerCase()) {
 					return true;
 				}
 				return false;
@@ -581,21 +592,25 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 	public async getSqlVirtualMachineValues(subscription: azureResource.AzureResourceSubscription, location: azureResource.AzureLocation, resourceGroup: azureResource.AzureResourceResourceGroup): Promise<azdata.CategoryValue[]> {
 		let virtualMachineValues: azdata.CategoryValue[] = [];
 		try {
-			this._targetSqlVirtualMachines = (await getAvailableSqlVMs(this._azureAccount, subscription, resourceGroup)).filter((virtualMachine) => {
-				if (virtualMachine.location === location.name) {
-					if (virtualMachine.properties.sqlImageOffer) {
-						return virtualMachine.properties.sqlImageOffer.toLowerCase().includes('-ws'); //filtering out all non windows sql vms.
+			if (this._azureAccount && subscription && resourceGroup) {
+				this._targetSqlVirtualMachines = (await getAvailableSqlVMs(this._azureAccount, subscription, resourceGroup)).filter((virtualMachine) => {
+					if (virtualMachine.location === location.name) {
+						if (virtualMachine.properties.sqlImageOffer) {
+							return virtualMachine.properties.sqlImageOffer.toLowerCase().includes('-ws'); //filtering out all non windows sql vms.
+						}
+						return true; // Returning all VMs that don't have this property as we don't want to accidentally skip valid vms.
 					}
-					return true; // Returning all VMs that don't have this property as we don't want to accidentally skip valid vms.
-				}
-				return false;
-			});
-			virtualMachineValues = this._targetSqlVirtualMachines.map((virtualMachine) => {
-				return {
-					name: virtualMachine.id,
-					displayName: `${virtualMachine.name}`
-				};
-			});
+					return false;
+				});
+				virtualMachineValues = this._targetSqlVirtualMachines.map((virtualMachine) => {
+					return {
+						name: virtualMachine.id,
+						displayName: `${virtualMachine.name}`
+					};
+				});
+			} else {
+				this._targetSqlVirtualMachines = [];
+			}
 
 			if (virtualMachineValues.length === 0) {
 				virtualMachineValues = [
@@ -944,5 +959,8 @@ export interface ServerAssessement {
 	databaseAssessments: {
 		name: string;
 		issues: mssql.SqlMigrationAssessmentResultItem[];
+		errors?: mssql.ErrorModel[];
 	}[];
+	errors?: mssql.ErrorModel[];
+	assessmentError?: Error;
 }

--- a/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseSelectorPage.ts
@@ -81,7 +81,18 @@ export class DatabaseSelectorPage extends MigrationWizardPage {
 		});
 	}
 	public async onPageLeave(): Promise<void> {
-		this.migrationStateModel._databaseAssessment = this.selectedDbs();
+		const assessedDatabases = this.migrationStateModel._databaseAssessment ?? [];
+		const selectedDatabases = this.selectedDbs();
+		// run assessment if
+		// * the prior assessment had an error or
+		// * the assessed databases list is different from the selected databases list
+		this.migrationStateModel._runAssessments = !!this.migrationStateModel._assessmentResults?.assessmentError
+			|| assessedDatabases.length === 0
+			|| assessedDatabases.length !== selectedDatabases.length
+			|| assessedDatabases.some(db => selectedDatabases.indexOf(db) < 0);
+
+		this.migrationStateModel._databaseAssessment = selectedDatabases;
+
 		this.wizard.registerNavigationValidator((pageChangeInfo) => {
 			return true;
 		});


### PR DESCRIPTION
This PR fixes
* adds error handing and an error banner for assessment errors
* fix issue refreshing assessment results for runtime error and database selection changes
* fix issue with assessed and selected database counters on sku recommendation page
* show loader while assessments are re-run
* add context check to improve error handling for vm and mi asset queries
