### PR TITLE
Update urlProtocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.32.0",
-  "distro": "9c5f9c1fe9efe543ee235b94d5fdc57553c2d271",
+  "distro": "588b820db3a79fc00075ce1ed4d8c7603e07402b",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.32.0",
-  "distro": "588b820db3a79fc00075ce1ed4d8c7603e07402b",
+  "distro": "671045bb5a1831234a52d27e9e69cff2c946d229",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.32.0",
-  "distro": "671045bb5a1831234a52d27e9e69cff2c946d229",
+  "distro": "1f2b2d261ab9f176d75b6c1ca668d64ea8a65b28",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/product.json
+++ b/product.json
@@ -24,7 +24,7 @@
 	"requestFeatureUrl": "https://go.microsoft.com/fwlink/?linkid=2118021",
 	"privacyStatementUrl": "https://privacy.microsoft.com/privacystatement",
 	"telemetryOptOutUrl": "https://github.com/Microsoft/azuredatastudio/wiki/How-to-Disable-Telemetry-Reporting",
-	"urlProtocol": "azuredatastudio",
+	"urlProtocol": "azuredatastudio-oss",
 	"enableTelemetry": true,
 	"aiConfig": {
 		"asimovKey": "AIF-37eefaf0-8022-4671-a3fb-64752724682e"


### PR DESCRIPTION
Currently all versions of ADS have the `urlProtocol` set to `azuredatastudio`. This is set every time ADS launches - which means that if you type `azuredatastudio://` into the address bar it'll try to open up the latest version of ADS that you had opened. This is not only confusing, but can lead to weird bugs such as :

1. User has both stable and insiders installed
2. They open up ADS insiders so now `azuredatastudio://` links will open up the insiders version of the app
3. They then close and uninstall ADS Insiders
4. Now `azuredatastudio://` links are broken until they open up ADS stable to re-register the protocol handler

I'm fixing it here to use separate urlProtocols based on the quality level : 

dev - `azuredatastudio-oss` (based on VS Code one here)
stable - `azuredatastudio`
insiders - `azuredatastudio-insiders`
saw - `azuredatastudio-saw`
rc1 - `azuredatastudio-rc1`

@MsSQLGirl @qifahs Do you see any issues with changing this for any of your stuff?