### PR TITLE
Announce the heading level and name for linked account heading

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountListRenderer.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountListRenderer.ts
@@ -64,8 +64,8 @@ export class AccountPickerListRenderer implements IListRenderer<azdata.Account, 
 		DOM.append(tableTemplate.icon, badge);
 		tableTemplate.badgeContent = DOM.append(badge, DOM.$('div.badge-content'));
 		tableTemplate.label = DOM.append(tableTemplate.root, DOM.$('div.label'));
-		tableTemplate.contextualDisplayName = DOM.append(tableTemplate.label, DOM.$('div.contextual-display-name'));
-		tableTemplate.displayName = DOM.append(tableTemplate.label, DOM.$('div.display-name'));
+		tableTemplate.contextualDisplayName = DOM.append(tableTemplate.label, DOM.$('h1.contextual-display-name'));
+		tableTemplate.displayName = DOM.append(tableTemplate.label, DOM.$('h2.display-name'));
 		return tableTemplate;
 	}
 

--- a/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
+++ b/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
@@ -18,11 +18,16 @@
 
 .list-row.account-picker-list .label .contextual-display-name {
 	font-size: 15px;
+	margin-top: 2px;
+	margin-bottom: 6px;
+	font-weight: normal;
 }
 
 .list-row.account-picker-list .label .display-name,
 .list-row.tenant-picker-list .label .display-name {
 	font-size: 13px;
+	margin-top: 0px;
+	font-weight: normal;
 }
 
 .list-row.account-picker-list .label .content,


### PR DESCRIPTION
This PR fixes #15836 which prevented screen readers from announcing the heading level and name for linked account headings.


**To confirm the fix**
1. Launch Azure Data Studio
2. Enable Auth: Device Code (Follow sub steps, if needed)
     - Select File > Preferences > Settings
     - In "Search settings" textbox, enter "Azure Authentication Method"
     - Enable "Device Code Method"
3. Link an account to ADS (Follow sub steps, if needed)
     - Hover over to the 'Azure' header and select the '+' icon.
     - Hover over to the Azure header in the blade that opens up and select "Add an account"
     - Select "Azure Device Code" in the pop up menu that appears
     - In the "Add Azure account" blade, select "Copy & Open"
     - In the "Do you want azuredatastudio to open the external website?" dialog box, select "Open"
     - When prompted to "Enter Code", paste the code into the "code" field (It should already be in your clipboard") and select "Next".
     - Continue through the remainder of the sign in steps
4. Start screen reader and select the added account in the "Linked accounts" blade. Use the arrow keys to navigate through the linked account heading information.

**Expected**: Screenreader will announce the heading level and name for linked account.

**Actual**: Meets expectation
