### PR TITLE
Fix unstable test

### DIFF
--- a/extensions/notebook/src/test/book/bookTrustManager.test.ts
+++ b/extensions/notebook/src/test/book/bookTrustManager.test.ts
@@ -353,7 +353,9 @@ describe('BookTrustManagerTests', function () {
 					should(isNotebookTrusted).be.false('Notebook not should be trusted');
 				});
 
-				it('should trust notebook after book has been added to a folder @UNSTABLE@', async () => {
+				it('should trust notebook after book has been added to a folder', async () => {
+					//Set book as not trusted before running test
+					bookTrustManager.setBookAsTrusted('/temp/SubFolder2/', false);
 					let notebookUri = run.book2.notebook1;
 					let isNotebookTrustedBeforeChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 


### PR DESCRIPTION
In the test, we check that the book is not trusted, before setting the book as trusted. 
The problem was that the previous test is the one that sets the book as not trusted and not the current test. Adding this to the test fixes the issue.