### PR TITLE
Synapse query editor dropdown fix

### DIFF
--- a/src/sql/platform/connection/common/constants.ts
+++ b/src/sql/platform/connection/common/constants.ts
@@ -32,3 +32,7 @@ export const dstsAuth = 'dstsAuth';
 export const cmsProviderName = 'MSSQL-CMS';
 
 export const UNSAVED_GROUP_ID = 'unsaved';
+
+/* Server Type Constants */
+export const sqlDataWarehouse = 'Azure SQL Data Warehouse';
+export const gen3Version = 12;

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -267,21 +267,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 	}
 
 	getServerInfo(profileId: string): azdata.ServerInfo {
-		const mockServerInfo: azdata.ServerInfo = {
-			serverMajorVersion: 12,
-			serverReleaseVersion: 12,
-			engineEditionId: 12,
-			serverVersion: 'Test',
-			serverLevel: 'Test',
-			serverEdition: 'Test',
-			isCloud: false,
-			azureVersion: 12,
-			osVersion: 'Test',
-			cpuCount: 0,
-			physicalMemoryInMb: 100,
-			options: undefined
-		};
-		return mockServerInfo;
+		return undefined;
 	}
 
 	getConnectionString(connectionId: string): Thenable<string> {

--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -267,7 +267,21 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 	}
 
 	getServerInfo(profileId: string): azdata.ServerInfo {
-		return undefined!;
+		const mockServerInfo: azdata.ServerInfo = {
+			serverMajorVersion: 12,
+			serverReleaseVersion: 12,
+			engineEditionId: 12,
+			serverVersion: 'Test',
+			serverLevel: 'Test',
+			serverEdition: 'Test',
+			isCloud: false,
+			azureVersion: 12,
+			osVersion: 'Test',
+			cpuCount: 0,
+			physicalMemoryInMb: 100,
+			options: undefined
+		};
+		return mockServerInfo;
 	}
 
 	getConnectionString(connectionId: string): Thenable<string> {

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -728,8 +728,11 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 	 */
 	private isDWGen3Database(id: string): boolean {
 		const serverInfo = this.connectionManagementService.getServerInfo(id);
-		return serverInfo.serverEdition === sqlDataWarehouse &&
-			serverInfo.serverMajorVersion === gen3Version;
+		if (serverInfo) {
+			return serverInfo.serverEdition === sqlDataWarehouse &&
+				serverInfo.serverMajorVersion === gen3Version;
+		}
+		return false;
 	}
 
 	/**

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -46,6 +46,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IRange } from 'vs/editor/common/core/range';
 import { getErrorMessage, onUnexpectedError } from 'vs/base/common/errors';
 import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
+import { gen3Version, sqlDataWarehouse } from 'sql/platform/connection/common/constants';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -720,6 +721,28 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 				});
 	}
 
+	/**
+	 *
+	 * @param id profile id
+	 * @returns boolean saying if the server connection is a Gen 3 DW server
+	 */
+	private isDWGen3Database(id: string): boolean {
+		const serverInfo = this.connectionManagementService.getServerInfo(id);
+		return serverInfo.serverEdition === sqlDataWarehouse &&
+			serverInfo.serverMajorVersion === gen3Version;
+	}
+
+	/**
+	 *
+	 * @returns
+	 */
+	private removePoolInstanceName(dbName: string): string {
+		if (dbName.includes('@')) {
+			dbName = dbName.split('@')[0];
+		}
+		return dbName;
+	}
+
 	private getCurrentDatabaseName(): string | undefined {
 		if (!this._editor.input) {
 			this.logService.error('editor input was null');
@@ -730,6 +753,9 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 		if (uri) {
 			let profile = this.connectionManagementService.getConnectionProfile(uri);
 			if (profile) {
+				if (this.isDWGen3Database(profile.id)) {
+					return this.removePoolInstanceName(profile.databaseName);
+				}
 				return profile.databaseName;
 			}
 		}

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -742,7 +742,8 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 	 */
 	private removePoolInstanceName(dbName: string): string {
 		if (dbName.includes('@')) {
-			dbName = dbName.split('@')[0];
+			const lastIndex = dbName.lastIndexOf('@');
+			dbName = dbName.slice(0, lastIndex);
 		}
 		return dbName;
 	}

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -734,7 +734,8 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 
 	/**
 	 *
-	 * @returns
+	 * @param dbName database name
+	 * @returns updated database name after stripping the pool name, if any
 	 */
 	private removePoolInstanceName(dbName: string): string {
 		if (dbName.includes('@')) {

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -33,6 +33,7 @@ import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/u
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 import { IRange } from 'vs/editor/common/core/range';
+import { ServerInfo } from 'azdata';
 
 suite('SQL QueryAction Tests', () => {
 
@@ -464,6 +465,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Mock "isConnected" in ConnectionManagementService
 		connectionManagementService.setup(x => x.isConnected(TypeMoq.It.isAnyString())).returns(() => isConnected);
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => Event.None);
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverEdition: 'test', serverMajorVersion: 12 });
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{
 			databaseName: databaseName
 		});
@@ -498,6 +500,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverEdition: 'test', serverMajorVersion: 12 });
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 
@@ -521,6 +524,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service that will not claim it's connected
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverEdition: 'test', serverMajorVersion: 12 });
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -33,6 +33,7 @@ import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/u
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 import { IRange } from 'vs/editor/common/core/range';
+import { ServerInfo } from 'azdata';
 
 suite('SQL QueryAction Tests', () => {
 
@@ -498,6 +499,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service and server info
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverMajorVersion: 12, serverVersion: 'Test' });
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -464,6 +464,7 @@ suite('SQL QueryAction Tests', () => {
 
 		// ... Mock "isConnected" in ConnectionManagementService
 		connectionManagementService.setup(x => x.isConnected(TypeMoq.It.isAnyString())).returns(() => isConnected);
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverMajorVersion: 12, serverEdition: 'Test' });
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => Event.None);
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{
 			databaseName: databaseName
@@ -523,6 +524,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service that will not claim it's connected
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverMajorVersion: 12, serverEdition: 'Test' });
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -45,6 +45,22 @@ suite('SQL QueryAction Tests', () => {
 	let queryModelService: TypeMoq.Mock<TestQueryModelService>;
 	let connectionManagementService: TypeMoq.Mock<TestConnectionManagementService>;
 
+	// Mock class for server info since interfaces can't be mocked
+	const mockServerInfo: ServerInfo = {
+		serverMajorVersion: 12,
+		serverReleaseVersion: 12,
+		engineEditionId: 12,
+		serverVersion: 'Test',
+		serverLevel: 'Test',
+		serverEdition: 'Test',
+		isCloud: false,
+		azureVersion: 12,
+		osVersion: 'Test',
+		cpuCount: 0,
+		physicalMemoryInMb: 100,
+		options: undefined
+	};
+
 	setup(() => {
 
 		const contextkeyservice = new MockContextKeyService();
@@ -465,7 +481,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Mock "isConnected" in ConnectionManagementService
 		connectionManagementService.setup(x => x.isConnected(TypeMoq.It.isAnyString())).returns(() => isConnected);
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => Event.None);
-		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverEdition: 'test', serverMajorVersion: 12 });
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => mockServerInfo);
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{
 			databaseName: databaseName
 		});
@@ -497,10 +513,10 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create event emitter we can use to trigger db changed event
 		let dbChangedEmitter = new Emitter<IConnectionParams>();
 
-		// ... Create mock connection management service
+		// ... Create mock connection management service and server info
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
-		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverEdition: 'test', serverMajorVersion: 12 });
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => mockServerInfo);
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 
@@ -524,7 +540,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service that will not claim it's connected
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
-		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverEdition: 'test', serverMajorVersion: 12 });
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => mockServerInfo);
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -499,7 +499,7 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service and server info
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
-		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverMajorVersion: 12, serverVersion: 'Test' });
+		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => <ServerInfo>{ serverMajorVersion: 12, serverEdition: 'Test' });
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -33,7 +33,6 @@ import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/u
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 import { IRange } from 'vs/editor/common/core/range';
-import { ServerInfo } from 'azdata';
 
 suite('SQL QueryAction Tests', () => {
 
@@ -44,22 +43,6 @@ suite('SQL QueryAction Tests', () => {
 	let configurationService: TypeMoq.Mock<TestConfigurationService>;
 	let queryModelService: TypeMoq.Mock<TestQueryModelService>;
 	let connectionManagementService: TypeMoq.Mock<TestConnectionManagementService>;
-
-	// Mock class for server info since interfaces can't be mocked
-	const mockServerInfo: ServerInfo = {
-		serverMajorVersion: 12,
-		serverReleaseVersion: 12,
-		engineEditionId: 12,
-		serverVersion: 'Test',
-		serverLevel: 'Test',
-		serverEdition: 'Test',
-		isCloud: false,
-		azureVersion: 12,
-		osVersion: 'Test',
-		cpuCount: 0,
-		physicalMemoryInMb: 100,
-		options: undefined
-	};
 
 	setup(() => {
 
@@ -481,7 +464,6 @@ suite('SQL QueryAction Tests', () => {
 		// ... Mock "isConnected" in ConnectionManagementService
 		connectionManagementService.setup(x => x.isConnected(TypeMoq.It.isAnyString())).returns(() => isConnected);
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => Event.None);
-		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => mockServerInfo);
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{
 			databaseName: databaseName
 		});
@@ -516,7 +498,6 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service and server info
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
-		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => mockServerInfo);
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 
@@ -540,7 +521,6 @@ suite('SQL QueryAction Tests', () => {
 		// ... Create mock connection management service that will not claim it's connected
 		let databaseName = 'foobar';
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
-		connectionManagementService.setup(x => x.getServerInfo(TypeMoq.It.isAny())).returns(() => mockServerInfo);
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 		connectionManagementService.setup(x => x.changeDatabase(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => Promise.resolve(true));
 


### PR DESCRIPTION
This is a substitute for https://github.com/microsoft/azuredatastudio/pull/16485

It fixes https://github.com/microsoft/azuredatastudio/issues/16501

Seems the issue with fetching serverInfo from STS was fixed with Aasim's recent fix. I was able to remove the instance name based off of that.