### PR TITLE
AzureMonitorLogs version bump 0.1.2

### DIFF
--- a/extensions/azuremonitor/config.json
+++ b/extensions/azuremonitor/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.119",
+	"version": "3.0.0-release.122",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-net5.0.zip",
 		"Windows_64": "win-x64-net5.0.zip",

--- a/extensions/azuremonitor/package.json
+++ b/extensions/azuremonitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuremonitor",
   "description": "%azuremonitor.description%",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "Microsoft",
   "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [


### PR DESCRIPTION
Bumped SqlToolService version to 122. Bumped AzureMonitorLogs version to 0.1.2

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
