### PR TITLE
Fix incorrect .NET error

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -24,7 +24,7 @@ import { IDeploySettings } from '../models/IDeploySettings';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { ImportDataModel } from '../models/api/import';
-import { NetCoreTool, DotNetCommandOptions } from '../tools/netcoreTool';
+import { NetCoreTool, DotNetCommandOptions, DotNetError } from '../tools/netcoreTool';
 import { BuildHelper } from '../tools/buildHelper';
 import { readPublishProfile } from '../models/publishProfile/publishProfile';
 import { AddDatabaseReferenceDialog } from '../dialogs/addDatabaseReferenceDialog';
@@ -241,9 +241,11 @@ export class ProjectsController {
 				.withAdditionalMeasurements({ duration: timeToFailureBuild })
 				.send();
 
-			const error = utils.getErrorMessage(err);
-			if (error !== (constants.NetCoreInstallationConfirmation || constants.NetCoreSupportedVersionInstallationConfirmation)) {
-				vscode.window.showErrorMessage(constants.projBuildFailed(error));
+			const message = utils.getErrorMessage(err);
+			if (err instanceof DotNetError) {
+				vscode.window.showErrorMessage(message);
+			} else {
+				vscode.window.showErrorMessage(constants.projBuildFailed(message));
 			}
 			return '';
 		}

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -254,7 +254,5 @@ export class NetCoreTool {
 }
 
 export class DotNetError extends Error {
-	constructor(message?: string) {
-		super(message);
-	}
+
 }

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -148,15 +148,21 @@ export class NetCoreTool {
 				child.on('exit', () => {
 					this.netCoreSdkInstalledVersion = Buffer.concat(stdoutBuffers).toString('utf8').trim();
 
-					if (semver.gte(this.netCoreSdkInstalledVersion, minSupportedNetCoreVersion)) {		// Net core version greater than or equal to minSupportedNetCoreVersion are supported for Build
-						isSupported = true;
-					} else {
-						isSupported = false;
+					try {
+						if (semver.gte(this.netCoreSdkInstalledVersion, minSupportedNetCoreVersion)) {		// Net core version greater than or equal to minSupportedNetCoreVersion are supported for Build
+							isSupported = true;
+						} else {
+							isSupported = false;
+						}
+						resolve({ stdout: this.netCoreSdkInstalledVersion });
+					} catch (err) {
+						console.log(err);
+						reject(err);
 					}
-					resolve({ stdout: this.netCoreSdkInstalledVersion });
 				});
 				child.on('error', (err) => {
 					console.log(err);
+					this.netCoreInstallState = netCoreInstallState.netCoreNotPresent;
 					reject(err);
 				});
 			});
@@ -170,7 +176,7 @@ export class NetCoreTool {
 			return isSupported;
 		} catch (err) {
 			console.log(err);
-			this.netCoreInstallState = netCoreInstallState.netCoreVersionNotSupported;
+			this.netCoreInstallState = netCoreInstallState.netCoreNotPresent;
 			return undefined;
 		}
 	}
@@ -182,9 +188,9 @@ export class NetCoreTool {
 
 		if (!(await this.findOrInstallNetCore())) {
 			if (this.netCoreInstallState === netCoreInstallState.netCoreNotPresent) {
-				throw new Error(NetCoreInstallationConfirmation);
+				throw new DotNetError(NetCoreInstallationConfirmation);
 			} else {
-				throw new Error(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!));
+				throw new DotNetError(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!));
 			}
 		}
 
@@ -244,5 +250,11 @@ export class NetCoreTool {
 			.forEach(line => {
 				outputChannel.appendLine(header + line);
 			});
+	}
+}
+
+export class DotNetError extends Error {
+	constructor(message?: string) {
+		super(message);
 	}
 }


### PR DESCRIPTION
This PR provides a fix for #16676.
The error condition when dotnet couldn't be found (by running dotnet --version) didn't provide appropriate results, the code should default to present the error that states .NET core isn't installed; but it was instead presenting the installed .NET core version isn't supported- which is incorrect. This is fixed. 
Also, while throwing installation or unsupported error for .NET core, the build failure presented impractical message- this is fixed as well.
![image](https://user-images.githubusercontent.com/57200045/128959712-95897e8a-6073-470d-a368-4e03539c8bde.png)
The highlighted part doesn't show up because there is nothing in the output pane to look for. As the prior behavior, it still shows the same error twice- once as an error and another to collect data from user (with options).
![image](https://user-images.githubusercontent.com/57200045/128959686-f23079f7-16bf-46b2-a1b6-08a026a13488.png) 

