### PR TITLE
improve migration context and error loading to improve provisioning error detection

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -263,27 +263,27 @@ export async function startDatabaseMigration(account: azdata.Account, subscripti
 	};
 }
 
-export async function getDatabaseMigration(account: azdata.Account, subscription: Subscription, regionName: string, migrationId: string, sessionId: string): Promise<DatabaseMigration> {
+export async function getMigrationStatus(account: azdata.Account, subscription: Subscription, migration: DatabaseMigration, sessionId: string, asyncUrl: string): Promise<DatabaseMigration> {
 	const api = await getAzureCoreAPI();
-	const path = `${migrationId}?api-version=2020-09-01-preview`;
+	const migrationOperationId = getMigrationOperationId(migration, asyncUrl);
+	const path = `${migration.id}?migrationOperationId=${migrationOperationId}&$expand=MigrationStatusDetails&api-version=2020-09-01-preview`;
 	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, undefined, getSessionIdHeader(sessionId));
 	if (response.errors.length > 0) {
-		if (response.response.status === 404 && response.response.data.error.code === 'ResourceDoesNotExist') {
-			throw new Error(response.response.data.error.code);
-		}
 		throw new Error(response.errors.toString());
 	}
 	return response.response.data;
 }
 
-export async function getMigrationStatus(account: azdata.Account, subscription: Subscription, migration: DatabaseMigration, sessionId: string): Promise<DatabaseMigration> {
-	const api = await getAzureCoreAPI();
-	const path = `${migration.id}?$expand=MigrationStatusDetails&api-version=2020-09-01-preview`;
-	const response = await api.makeAzureRestRequest(account, subscription, path, azurecore.HttpRequestMethod.GET, undefined, true, undefined, getSessionIdHeader(sessionId));
-	if (response.errors.length > 0) {
-		throw new Error(response.errors.toString());
+function getMigrationOperationId(migration: DatabaseMigration, asyncUrl: string): string {
+	// migrationOperationId may be undefined when provisioning has failed
+	// fall back to the operationId from the asyncUrl in the create migration response
+	if (migration.properties.migrationOperationId) {
+		return migration.properties.migrationOperationId;
 	}
-	return response.response.data;
+
+	return asyncUrl
+		? vscode.Uri.parse(asyncUrl)?.path?.split('/').reverse()[0]
+		: '';
 }
 
 export async function getMigrationAsyncOperationDetails(account: azdata.Account, subscription: Subscription, url: string, sessionId: string): Promise<AzureAsyncOperationResource> {
@@ -436,6 +436,7 @@ export interface DatabaseMigration {
 export interface DatabaseMigrationProperties {
 	scope: string;
 	provisioningState: 'Succeeded' | 'Failed' | 'Creating';
+	provisioningError: string;
 	migrationStatus: 'InProgress' | 'Failed' | 'Succeeded' | 'Creating' | 'Completing' | 'Canceling';
 	migrationStatusDetails?: MigrationStatusDetails;
 	startedOn: string;

--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialogModel.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialogModel.ts
@@ -30,6 +30,7 @@ export class MigrationCutoverDialogModel {
 			this._migration.subscription,
 			this._migration.migrationContext,
 			this._migration.sessionId!,
+			this._migration.asyncUrl
 		));
 
 		sendSqlMigrationActionEvent(
@@ -98,7 +99,7 @@ export class MigrationCutoverDialogModel {
 	}
 
 	public isBlobMigration(): boolean {
-		return this._migration.migrationContext.properties.backupConfiguration.sourceLocation?.azureBlob !== undefined;
+		return this._migration.migrationContext.properties.backupConfiguration?.sourceLocation?.azureBlob !== undefined;
 	}
 
 	public confirmCutoverStepsString(): string {

--- a/extensions/sql-migration/src/models/migrationLocalStorage.ts
+++ b/extensions/sql-migration/src/models/migrationLocalStorage.ts
@@ -32,14 +32,6 @@ export class MigrationLocalStorage {
 
 						await this.refreshMigrationAzureAccount(migration);
 
-						migration.migrationContext = await getMigrationStatus(
-							migration.azureAccount,
-							migration.subscription,
-							migration.migrationContext,
-							migration.sessionId!
-						);
-						migration.migrationContext.properties.sourceDatabaseName = sourceDatabase;
-						migration.migrationContext.properties.backupConfiguration = backupConfiguration;
 						if (migration.asyncUrl) {
 							migration.asyncOperationResult = await getMigrationAsyncOperationDetails(
 								migration.azureAccount,
@@ -47,6 +39,17 @@ export class MigrationLocalStorage {
 								migration.asyncUrl,
 								migration.sessionId!
 							);
+
+							migration.migrationContext = await getMigrationStatus(
+								migration.azureAccount,
+								migration.subscription,
+								migration.migrationContext,
+								migration.sessionId!,
+								migration.asyncUrl
+							);
+
+							migration.migrationContext.properties.sourceDatabaseName = sourceDatabase;
+							migration.migrationContext.properties.backupConfiguration = backupConfiguration;
 						}
 					}
 					catch (e) {


### PR DESCRIPTION
This PR fixes:
* add ability to show the user provisioning errors
* switch to get migration api that collects migration results based on operationid to see migration state for specific migration instance.  This api replaces a prior get migration api that only returns the latest migration results of last or current attempt.  if operation id is missing from migration context then the create migration operation id is used
* add provisioningError to migration get result to collect additional migration error info
* check for additional migration context error properties to catch provisioning errors
* add logic to remove duplicate error strings
* add additional null checks  to migration context status property reads
* add migration.asyncUrl check around get migration call to validate asyncUrl dependency
* removes unused method: getDatabaseMigration