### PR TITLE
filter assessment results by SQL MI target type

### DIFF
--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -444,7 +444,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 		const serverName = (await this.migrationStateModel.getSourceConnectionProfile()).serverName;
 		this._igComponent.value = constants.ASSESSMENT_COMPLETED(serverName);
 		try {
-			await this.migrationStateModel.getDatabaseAssessments();
+			await this.migrationStateModel.getDatabaseAssessments(MigrationTargetType.SQLMI);
 			this._detailsComponent.value = constants.SKU_RECOMMENDATION_ALL_SUCCESSFUL(this.migrationStateModel._assessmentResults.databaseAssessments.length);
 
 			const errors: string[] = [];


### PR DESCRIPTION
This PR fixes:
* add api support to filter assessment results by target type
* filter assessments for SQL MI target

Before
Assessment with 'Azure SQL Database" results
Server
![image](https://user-images.githubusercontent.com/61598682/128975296-5f715947-e8a9-4a33-ba08-d821c198c45c.png)

Database
![image](https://user-images.githubusercontent.com/61598682/128975351-f14425fe-a227-4466-8dce-bcd66f18d7aa.png)

Assessment with only 'Azure SQL Managed Instance" results
Server
![image](https://user-images.githubusercontent.com/61598682/128975407-4fe4a1a0-148a-41d5-a97d-e8282dce98ec.png)

Database
![image](https://user-images.githubusercontent.com/61598682/128975417-ef91ae6d-7d5a-4136-97a9-2b225a627bc1.png)
