### PR TITLE
Added Refresh Assessment Button in Azure SQL Target Page

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -30,6 +30,7 @@ export const SKU_RECOMMENDATION_ALL_SUCCESSFUL = (databaseCount: number): string
 export const SKU_RECOMMENDATION_ASSESSMENT_ERROR = (serverName: string): string => {
 	return localize('sql.migration.wizard.sku.assessment.error', "An error occurred while assessing the server '{0}'.", serverName);
 };
+export const REFRESH_ASSESSMENT_BUTTON_LABEL = localize('sql.migration.refresh.assessment.button.label', "Refresh Assessment");
 export const SKU_RECOMMENDATION_CHOOSE_A_TARGET = localize('sql.migration.wizard.sku.choose_a_target', "Choose your Azure SQL target");
 export const SKU_RECOMMENDATION_MI_CARD_TEXT = localize('sql.migration.sku.mi.card.title', "Azure SQL Managed Instance (PaaS)");
 export const SKU_RECOMMENDATION_VM_CARD_TEXT = localize('sql.migration.sku.vm.card.title', "SQL Server on Azure Virtual Machine (IaaS)");

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -92,7 +92,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 			width: 130
 		}).component();
 
-		this._disposables.push(refreshAssessmentButton.onDidClick(async (e) => {
+		this._disposables.push(refreshAssessmentButton.onDidClick(() => {
 			this.constructDetails();
 		}));
 

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -87,11 +87,14 @@ export class SKURecommendationPage extends MigrationWizardPage {
 		this._detailsComponent = this.createDetailsComponent(view); // The details of what can be moved
 
 		const refreshAssessmentButton = this._view.modelBuilder.button().withProps({
+			iconPath: IconPathHelper.refresh,
 			label: constants.REFRESH_ASSESSMENT_BUTTON_LABEL,
 			width: 130
 		}).component();
 
-		refreshAssessmentButton.onDidClick(() => this.constructDetails());
+		this._disposables.push(refreshAssessmentButton.onDidClick(async (e) => {
+			this.constructDetails();
+		}));
 
 		const chooseYourTargetText = this._view.modelBuilder.text().withProps({
 			value: constants.SKU_RECOMMENDATION_CHOOSE_A_TARGET,

--- a/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
+++ b/extensions/sql-migration/src/wizard/skuRecommendationPage.ts
@@ -86,6 +86,13 @@ export class SKURecommendationPage extends MigrationWizardPage {
 
 		this._detailsComponent = this.createDetailsComponent(view); // The details of what can be moved
 
+		const refreshAssessmentButton = this._view.modelBuilder.button().withProps({
+			label: constants.REFRESH_ASSESSMENT_BUTTON_LABEL,
+			width: 130
+		}).component();
+
+		refreshAssessmentButton.onDidClick(() => this.constructDetails());
+
 		const chooseYourTargetText = this._view.modelBuilder.text().withProps({
 			value: constants.SKU_RECOMMENDATION_CHOOSE_A_TARGET,
 			CSSStyles: {
@@ -101,6 +108,7 @@ export class SKURecommendationPage extends MigrationWizardPage {
 			[
 				igContainer,
 				this._detailsComponent,
+				refreshAssessmentButton,
 				chooseYourTargetText
 			]
 		).component();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes 

- On clicking Refresh Assessment button, Assessments are re run
![Screenshot (13)](https://user-images.githubusercontent.com/87131830/129000916-8937ee7b-01f8-4c0c-ab3a-2bb47e6be660.png)
