### PR TITLE
Fix azdata gallery links

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3624,19 +3624,19 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/extensions/azdata/images/extension.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/1.31.0/extensions/azdata/images/extension.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/extensions/azdata/README.md"
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/1.31.0/extensions/azdata/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/extensions/azdata/package.json"
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/1.31.0/extensions/azdata/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt"
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/1.31.0/LICENSE.txt"
 								}
 							],
 							"properties": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3624,19 +3624,19 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/extensions/azdata/images/extension.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/1.31.0/extensions/azdata/images/extension.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/extensions/azdata/README.md"
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/1.31.0/extensions/azdata/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/extensions/azdata/package.json"
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/1.31.0/extensions/azdata/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt"
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/1.31.0/LICENSE.txt"
 								}
 							],
 							"properties": [

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -201,7 +201,7 @@ function validateHasRequiredAssets(path, extensionName, filesJson) {
     // VSIXPackage or DownloadPage
     const vsixFile = filesJson.find(file => file.assetType === 'Microsoft.VisualStudio.Services.VSIXPackage');
     const downloadPageFile = filesJson.find(file => file.assetType === 'Microsoft.SQLOps.DownloadPage');
-    if(vsixFile && downloadPageFile) {
+    if (vsixFile && downloadPageFile) {
         throw new Error(`${path} - ${extensionName} - Can not have both VSIXPackage and DownloadPage file`);
     } else if (!vsixFile && !downloadPageFile) {
         throw new Error(`${path} - ${extensionName} - Must have file with either VSIXPackage or DownloadPage assetType`);
@@ -210,27 +210,27 @@ function validateHasRequiredAssets(path, extensionName, filesJson) {
     // Icon
     const iconFile = filesJson.find(file => file.assetType === 'Microsoft.VisualStudio.Services.Icons.Default');
     const noIconExtensions = ['poor-sql-formatter', 'qpi']; // Not all 3rd party extensions have icons so allow existing ones to pass for now
-    if(!iconFile && noIconExtensions.find(ext => ext === extensionName) === undefined) {
+    if (!iconFile && noIconExtensions.find(ext => ext === extensionName) === undefined) {
         throw new Error(`${path} - ${extensionName} - Must have an icon file`);
     }
 
     // Details
     const detailsFile = filesJson.find(file => file.assetType === 'Microsoft.VisualStudio.Services.Content.Details');
-    if(!detailsFile) {
+    if (!detailsFile) {
         throw new Error(`${path} - ${extensionName} - Must have a details file (README)`);
     }
 
     // Manifest
     const noManifestExtensions = ['plan-explorer', 'sql-prompt']; // Not all 3rd party extensions have manifests so allow existing ones to pass for now
     const manifestFile = filesJson.find(file => file.assetType === 'Microsoft.VisualStudio.Code.Manifest');
-    if(!manifestFile && noManifestExtensions.find(ext => ext === extensionName) === undefined) {
+    if (!manifestFile && noManifestExtensions.find(ext => ext === extensionName) === undefined) {
         throw new Error(`${path} - ${extensionName} - Must have a manifest file (package.json)`);
     }
 
     // License
     const noLicenseExtensions = ['sp_executesqlToSQL', 'simple-data-scripter', 'db-snapshot-creator']; // Not all 3rd party extensions have license files to link to so allow existing ones to pass for now
     const licenseFile = filesJson.find(file => file.assetType === 'Microsoft.VisualStudio.Services.Content.License');
-    if(!licenseFile && noLicenseExtensions.find(ext => ext === extensionName) === undefined) {
+    if (!licenseFile && noLicenseExtensions.find(ext => ext === extensionName) === undefined) {
         throw new Error(`${path} - ${extensionName} - Must have a license file`);
     }
 }
@@ -265,6 +265,10 @@ async function validateExtensionFile(path, extensionName, extensionFileJson) {
     }
     if (!extensionFileJson.source) {
         throw new Error(`${path} - ${extensionName} - No source\n${JSON.stringify(extensionFileJson)}`)
+    }
+    // Waka-time link is hitting rate limit for the download link so just ignore this one for now. 
+    if (extensionName === 'vscode-wakatime' && extensionFileJson.assetType === 'Microsoft.SQLOps.DownloadPage') {
+        return;
     }
     // Validate the source URL
     try {


### PR DESCRIPTION
Azdata CLI extension has been removed so links to main no longer work. I still plan on keeping this in the gallery for the time being since it still has some marginal usefulness - but this requires changing the links to point to an older tag instead. 