### PR TITLE
Porting fix for a bug where the message type for a sqlproj build failure was informational rather than an error

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -238,7 +238,10 @@ export class ProjectsController {
 				.withAdditionalMeasurements({ duration: timeToFailureBuild })
 				.send();
 
-			vscode.window.showErrorMessage(constants.projBuildFailed(utils.getErrorMessage(err)));
+			const error = utils.getErrorMessage(err);
+			if (error !== (constants.NetCoreInstallationConfirmation || constants.NetCoreSupportedVersionInstallationConfirmation)) {
+				vscode.window.showErrorMessage(constants.projBuildFailed(error));
+			}
 			return '';
 		}
 	}

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -55,7 +55,7 @@ export class NetCoreTool {
 	public async findOrInstallNetCore(): Promise<boolean> {
 		if ((!this.isNetCoreInstallationPresent || !await this.isNetCoreVersionSupported())) {
 			if (vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreDoNotAskAgainKey] !== true) {
-				await this.showInstallDialog();
+				this.showInstallDialog();		// Removing await so that Build and extension load process doesn't wait on user input
 			}
 			return false;
 		}
@@ -66,9 +66,9 @@ export class NetCoreTool {
 	public async showInstallDialog(): Promise<void> {
 		let result;
 		if (this.netCoreInstallState === netCoreInstallState.netCoreNotPresent) {
-			result = await vscode.window.showInformationMessage(NetCoreInstallationConfirmation, UpdateNetCoreLocation, InstallNetCore, DoNotAskAgain);
+			result = await vscode.window.showErrorMessage(NetCoreInstallationConfirmation, UpdateNetCoreLocation, InstallNetCore, DoNotAskAgain);
 		} else {
-			result = await vscode.window.showInformationMessage(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!), UpdateNetCoreLocation, InstallNetCore, DoNotAskAgain);
+			result = await vscode.window.showErrorMessage(NetCoreSupportedVersionInstallationConfirmation(this.netCoreSdkInstalledVersion!), UpdateNetCoreLocation, InstallNetCore, DoNotAskAgain);
 		}
 
 		if (result === UpdateNetCoreLocation) {


### PR DESCRIPTION
Issue: https://github.com/microsoft/azuredatastudio/issues/16657
PR for main: https://github.com/microsoft/azuredatastudio/pull/16660