### PR TITLE
Remove Azdata CLI Ext from recommend extensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -44,7 +44,7 @@
 		"Microsoft.admin-tool-ext-win",
 		"Microsoft.agent",
 		"Microsoft.arc",
-		"Microsoft.azdata",
+		"Microsoft.azcli",
 		"Microsoft.azuredatastudio-postgresql",
 		"Microsoft.azurehybridtoolkit",
 		"Microsoft.cms",


### PR DESCRIPTION
Replacing with az CLI since the azdata CLI extension is going to be (mostly) deprecated. 