### PR TITLE
Fix schema compare diff editor not showing

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -33,7 +33,7 @@ export class SchemaCompareMainWindow {
 	private waitText: azdata.TextComponent;
 	private editor: azdata.workspace.ModelViewEditor;
 	private diffEditor: azdata.DiffEditorComponent;
-	private splitView: azdata.SplitViewContainer;
+	private splitView: azdata.SplitViewContainer | undefined;
 	private flexModel: azdata.FlexContainer;
 	private noDifferencesLabel: azdata.TextComponent;
 	private sourceTargetFlexLayout: azdata.FlexContainer;
@@ -131,19 +131,6 @@ export class SchemaCompareMainWindow {
 				if (isNullOrUndefined(this.view)) {
 					this.view = view;
 				}
-
-				this.differencesTable = this.view.modelBuilder.table().withProps({
-					data: [],
-					title: loc.differencesTableTitle,
-					columns: []
-				}).component();
-
-				this.diffEditor = this.view.modelBuilder.diffeditor().withProperties({
-					contentLeft: os.EOL,
-					contentRight: os.EOL,
-					height: 500,
-					title: loc.diffEditorTitle
-				}).component();
 
 				this.splitView = this.view.modelBuilder.splitViewContainer().component();
 
@@ -299,56 +286,90 @@ export class SchemaCompareMainWindow {
 				'operationId': this.comparisonResult.operationId
 			}).send();
 
-		let data = this.getAllDifferences(this.comparisonResult.differences);
-
-		this.differencesTable.updateProperties({
-			data: data,
-			columns: [
-				{
-					value: loc.type,
-					cssClass: 'align-with-header',
-					width: 50
-				},
-				{
-					value: loc.sourceName,
-					cssClass: 'align-with-header',
-					width: 90
-				},
-				<azdata.CheckboxColumn>
-				{
-					value: loc.include,
-					cssClass: 'align-with-header',
-					width: 60,
-					type: azdata.ColumnType.checkBox,
-					action: azdata.ActionOnCellCheckboxCheck.customAction
-				},
-				{
-					value: loc.action,
-					cssClass: 'align-with-header',
-					width: 30
-				},
-				{
-					value: loc.targetName,
-					cssClass: 'align-with-header',
-					width: 150
-				}
-			],
-			CSSStyles: { 'left': '15px' },
-			width: '98%'
-		});
-
-		this.splitView.addItem(this.differencesTable);
-		this.splitView.addItem(this.diffEditor);
-		this.splitView.setLayout({
-			orientation: 'vertical',
-			splitViewHeight: 800
-		});
-
 		this.flexModel.removeItem(this.loader);
 		this.flexModel.removeItem(this.waitText);
 		this.resetButtons(ResetButtonState.afterCompareComplete);
 
 		if (this.comparisonResult.differences.length > 0) {
+			const data = this.getAllDifferences(this.comparisonResult.differences);
+
+			this.differencesTable = this.view.modelBuilder.table().withProps({
+				data: data,
+				columns: [
+					{
+						value: loc.type,
+						cssClass: 'align-with-header',
+						width: 50
+					},
+					{
+						value: loc.sourceName,
+						cssClass: 'align-with-header',
+						width: 90
+					},
+					<azdata.CheckboxColumn>
+					{
+						value: loc.include,
+						cssClass: 'align-with-header',
+						width: 60,
+						type: azdata.ColumnType.checkBox,
+						action: azdata.ActionOnCellCheckboxCheck.customAction
+					},
+					{
+						value: loc.action,
+						cssClass: 'align-with-header',
+						width: 30
+					},
+					{
+						value: loc.targetName,
+						cssClass: 'align-with-header',
+						width: 150
+					}
+				],
+				CSSStyles: { 'left': '15px' },
+				width: '98%',
+				title: loc.differencesTableTitle
+			}).component();
+
+			this.diffEditor = this.view.modelBuilder.diffeditor().withProperties({
+				contentLeft: os.EOL,
+				contentRight: os.EOL,
+				height: 500,
+				title: loc.diffEditorTitle
+			}).component();
+
+			let sourceText = '';
+			let targetText = '';
+			this.tablelistenersToDispose.push(this.differencesTable.onRowSelected(() => {
+				let difference = this.comparisonResult.differences[this.differencesTable.selectedRows[0]];
+				if (difference !== undefined) {
+					sourceText = this.getFormattedScript(difference, true);
+					targetText = this.getFormattedScript(difference, false);
+
+					this.diffEditor.updateProperties({
+						contentLeft: sourceText,
+						contentRight: targetText,
+						title: loc.diffEditorTitle
+					});
+				}
+			}));
+			this.tablelistenersToDispose.push(this.differencesTable.onCellAction(async (rowState) => {
+				let checkboxState = <azdata.ICheckboxCellActionEventArgs>rowState;
+				if (checkboxState) {
+					await this.applyIncludeExclude(checkboxState);
+				}
+			}));
+
+			this.splitView = this.view.modelBuilder.splitViewContainer().withItems([
+				this.differencesTable,
+				this.diffEditor
+			]).component();
+
+			// this.splitView.addItem(this.differencesTable);
+			// this.splitView.addItem(this.diffEditor);
+			this.splitView.setLayout({
+				orientation: 'vertical',
+				splitViewHeight: 800
+			});
 			this.flexModel.addItem(this.splitView);
 
 			// create a map of the differences to row numbers
@@ -380,28 +401,6 @@ export class SchemaCompareMainWindow {
 				this.setButtonStatesForNoChanges(false);
 			}
 		}
-
-		let sourceText = '';
-		let targetText = '';
-		this.tablelistenersToDispose.push(this.differencesTable.onRowSelected(() => {
-			let difference = this.comparisonResult.differences[this.differencesTable.selectedRows[0]];
-			if (difference !== undefined) {
-				sourceText = this.getFormattedScript(difference, true);
-				targetText = this.getFormattedScript(difference, false);
-
-				this.diffEditor.updateProperties({
-					contentLeft: sourceText,
-					contentRight: targetText,
-					title: loc.diffEditorTitle
-				});
-			}
-		}));
-		this.tablelistenersToDispose.push(this.differencesTable.onCellAction(async (rowState) => {
-			let checkboxState = <azdata.ICheckboxCellActionEventArgs>rowState;
-			if (checkboxState) {
-				await this.applyIncludeExclude(checkboxState);
-			}
-		}));
 	}
 
 	public async applyIncludeExclude(checkboxState: azdata.ICheckboxCellActionEventArgs): Promise<void> {
@@ -596,19 +595,17 @@ export class SchemaCompareMainWindow {
 	}
 
 	public async startCompare(): Promise<void> {
-		this.flexModel.removeItem(this.splitView);
+		if (this.splitView) {
+			this.flexModel.removeItem(this.splitView);
+			this.splitView = undefined;
+		}
 		this.flexModel.removeItem(this.noDifferencesLabel);
 		this.flexModel.removeItem(this.startText);
 		this.flexModel.addItem(this.loader, { CSSStyles: { 'margin-top': '30px' } });
 		this.flexModel.addItem(this.waitText, { CSSStyles: { 'margin-top': '30px', 'align-self': 'center' } });
 		this.showIncludeExcludeWaitingMessage = true;
-		this.diffEditor.updateProperties({
-			contentLeft: os.EOL,
-			contentRight: os.EOL,
-			title: loc.diffEditorTitle
-		});
 
-		this.differencesTable.selectedRows = null;
+		// this.differencesTable.selectedRows = null;
 		if (this.tablelistenersToDispose) {
 			this.tablelistenersToDispose.forEach(x => x.dispose());
 		}
@@ -842,7 +839,10 @@ export class SchemaCompareMainWindow {
 
 	// reset state afer loading an scmp
 	private resetForNewCompare(): void {
-		this.flexModel.removeItem(this.splitView);
+		if (this.splitView) {
+			this.flexModel.removeItem(this.splitView);
+			this.splitView = undefined;
+		}
 		this.flexModel.removeItem(this.noDifferencesLabel);
 		this.flexModel.addItem(this.startText, { CSSStyles: { 'margin': 'auto' } });
 	}

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -364,8 +364,6 @@ export class SchemaCompareMainWindow {
 				this.diffEditor
 			]).component();
 
-			// this.splitView.addItem(this.differencesTable);
-			// this.splitView.addItem(this.diffEditor);
 			this.splitView.setLayout({
 				orientation: 'vertical',
 				splitViewHeight: 800

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -605,7 +605,6 @@ export class SchemaCompareMainWindow {
 		this.flexModel.addItem(this.waitText, { CSSStyles: { 'margin-top': '30px', 'align-self': 'center' } });
 		this.showIncludeExcludeWaitingMessage = true;
 
-		// this.differencesTable.selectedRows = null;
 		if (this.tablelistenersToDispose) {
 			this.tablelistenersToDispose.forEach(x => x.dispose());
 		}

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2691,7 +2691,7 @@ declare module 'azdata' {
 	}
 
 	// Building on top of flex item
-	export interface SplitViewBuilder extends ContainerBuilder<SplitViewContainer, SplitViewLayout, FlexItemLayout, SplitViewContainer> {
+	export interface SplitViewBuilder extends ContainerBuilder<SplitViewContainer, SplitViewLayout, FlexItemLayout, ComponentProperties> {
 	}
 
 	export interface DivBuilder extends ContainerBuilder<DivContainer, DivLayout, DivItemLayout, DivContainerProperties> {


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/16691

This is a targeted fix to reduce chance of other regressions - there is a more ideal long-term fix that I will be working on but that's going to be more complex so for ask mode just doing the smaller simpler fix.

This issue was caused by https://github.com/microsoft/azuredatastudio/pull/16166 - the end result of this was that in the schema compare window we were calling removeItem on the splitview component (that contained the diff editor among other things). The PR linked there fixed a bug where child items weren't being removed properly - but this had the side effect of meaning that these components were being removed and thus also being disposed. This disposed the editor and thus when the splitview was added back in the editor was still disposed and so wouldn't display (throwing an error when the component tried to set its input)

The quick fix here is to just recreate the splitview, diff editor and results table each time we finish a new compare.

(sorry for the long gif - my computer isn't the fastest apparently) 

![SchemaCompare](https://user-images.githubusercontent.com/28519865/129116130-413e05d4-3827-4d72-a51c-f6a21604e985.gif)

