### PR TITLE
update modal.ts

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -598,10 +598,14 @@ export abstract class Modal extends Disposable implements IThemable {
 				DOM.prepend(this._modalContent!, this._messageElement!);
 			}
 		} else {
-			DOM.removeNode(this._messageElement!);
-			// Set the focus to first focus element if the focus is not within the dialog
-			if (!DOM.isAncestor(document.activeElement, this._bodyContainer!)) {
-				this.setInitialFocusedElement();
+			// only do the removal when the messageElement has parent element.
+			if (this._messageElement!.parentElement) {
+				// Reset the focus if keyboard focus is currently in the message area.
+				const resetFocus = DOM.isAncestor(document.activeElement, this._messageElement!);
+				this._messageElement!.remove();
+				if (resetFocus) {
+					this.setInitialFocusedElement();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes #16722 

when the connection type is changed, the event handler will eventually call the setter messagesElementVisible and at the moment the activeElement is still on the dropdown's popup as shown below and caused it to reset focus to first focusable element.

![image](https://user-images.githubusercontent.com/13777222/129125360-4940dd62-a9ff-433e-88e9-ff58d01b8f2e.png)


fix: this logic was originally introduced by me, we actually only need to make sure the focus is reset properly when the focus is currently in the messages area that will be removed.
