### PR TITLE
Add new extensions location var

### DIFF
--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -144,7 +144,7 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 			return resolve(cliExtensionsDir);
 		}
 
-		const vscodeExtensions = env['VSCODE_EXTENSIONS'];
+		const vscodeExtensions = env['ADS_EXTENSIONS'] || env['VSCODE_EXTENSIONS']; // {{SQL CARBON EDIT}} Add another option 
 		if (vscodeExtensions) {
 			return vscodeExtensions;
 		}


### PR DESCRIPTION
Closes https://github.com/microsoft/azuredatastudio/issues/16739

This seems generally useful to have so that users can have separate locations for ADS and VS Code if they want - since not all extensions work in both environments. 