### PR TITLE
Fix modelview container removal issue

### DIFF
--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -81,8 +81,8 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 		return descriptor;
 	}
 
-	private removeComponent(component: IComponentShape): void {
-		this.logService.debug(`Removing component ${component.id} from view ${this.id}`);
+	private removeComponentChildren(component: IComponentShape): void {
+		this.logService.debug(`Removing children of component ${component.id} from view ${this.id}`);
 		if (component.itemConfigs) {
 			for (let item of component.itemConfigs) {
 				this.removeFromContainer(component.id, item);
@@ -138,8 +138,8 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 				return;
 			}
 			this.logService.debug(`Removing component ${itemConfig.componentShape.id} from container ${containerId}`);
+			this.removeComponentChildren(itemConfig.componentShape);
 			component.removeFromContainer({ id: itemConfig.componentShape.id, type: componentRegistry.getIdForTypeMapping(itemConfig.componentShape.type) });
-			this.removeComponent(itemConfig.componentShape);
 		});
 	}
 


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/16691 and https://github.com/microsoft/azuredatastudio/issues/16751

So turns out the actual issue here was the ordering of the removals that was happening. When a component is removed from the view then it also removes all its children. But we were removing the children AFTER the parent container had been removed. So what happened was this : 

1. Call remove on the parent container
2. It removes itself 
3. Angular triggers the ngOnDestroy functions for all the components that were removed (parent + its children since they were no longer in the DOM)
4. This causes all of them to unregister themselves from the modelview view
5. Back in our code we go through the parent container and remove the children from their parent container
6. But in the code we have a check that if the component doesn't exist then we queue up the action (this is primarily for queuing up actions while we wait for the component to be initialized). But because the components had unregistered themselves instead of removing the children right away we queued up the action to remove those children
7. Later on when we added the parent component back it would go and see these queued up actions and then run them - immediately removing the children from the container 

So now the fix is to remove the children from the parent before removing the parent. This makes sense anyway - it's standard practice that in order to dispose of something you should first dispose of all the things within it. 

This issue has always been around, but previously was hidden by the logic that was replaced here : #16166 With that fix being made we were no longer skipping calling removeContainer in these cases - which meant that the actions to remove the children were never queued up.

This also fixes the schema compare issue and so I'm reverting that change. What was happening there that I missed was that the component was being created successfully (it was actually making a new editor each time). But because we then immediately disposed it nothing was shown. 

![ProjFix](https://user-images.githubusercontent.com/28519865/129251628-1621981b-325f-41f2-9bc5-152021d9abaa.gif)
