### PR TITLE
Better handle errors fetching subscriptions from subset of tenants

### DIFF
--- a/extensions/azurecore/src/azureResource/commands.ts
+++ b/extensions/azurecore/src/azureResource/commands.ts
@@ -5,14 +5,12 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { TokenCredentials } from '@azure/ms-rest-js';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 import { AppContext } from '../appContext';
 import { azureResource } from 'azureResource';
 import { TreeNode } from './treeNode';
-import { AzureResourceCredentialError } from './errors';
 import { AzureResourceTreeProvider } from './tree/treeProvider';
 import { AzureResourceAccountTreeNode } from './tree/accountTreeNode';
 import { IAzureResourceSubscriptionService, IAzureResourceSubscriptionFilterService, IAzureTerminalService } from '../azureResource/interfaces';
@@ -20,6 +18,7 @@ import { AzureResourceServiceNames } from './constants';
 import { AzureAccount, Tenant } from 'azurecore';
 import { FlatAccountTreeNode } from './tree/flatAccountTreeNode';
 import { ConnectionDialogTreeProvider } from './tree/connectionDialogTreeProvider';
+import { AzureResourceErrorMessageUtil } from './utils';
 
 export function registerAzureResourceCommands(appContext: AppContext, azureViewTree: AzureResourceTreeProvider, connectionDialogTree: ConnectionDialogTreeProvider): void {
 	const trees = [azureViewTree, connectionDialogTree];
@@ -109,21 +108,14 @@ export function registerAzureResourceCommands(appContext: AppContext, azureViewT
 		const subscriptionService = appContext.getService<IAzureResourceSubscriptionService>(AzureResourceServiceNames.subscriptionService);
 		const subscriptionFilterService = appContext.getService<IAzureResourceSubscriptionFilterService>(AzureResourceServiceNames.subscriptionFilterService);
 
-		const subscriptions = [];
+		let subscriptions: azureResource.AzureResourceSubscription[] = [];
 		if (subscriptions.length === 0) {
 			try {
-
-				for (const tenant of account.properties.tenants) {
-					const response = await azdata.accounts.getAccountSecurityToken(account, tenant.id, azdata.AzureResource.ResourceManagement);
-
-					const token = response.token;
-					const tokenType = response.tokenType;
-
-					subscriptions.push(...await subscriptionService.getSubscriptions(account, new TokenCredentials(token, tokenType), tenant.id));
-				}
+				subscriptions = await subscriptionService.getAllSubscriptions(account);
 			} catch (error) {
 				account.isStale = true;
-				throw new AzureResourceCredentialError(localize('azure.resource.selectsubscriptions.credentialError', "Failed to get credential for account {0}. Please refresh the account.", account.displayInfo.displayName), error);
+				vscode.window.showErrorMessage(AzureResourceErrorMessageUtil.getErrorMessage(error));
+				return;
 			}
 		}
 

--- a/extensions/azurecore/src/azureResource/errors.ts
+++ b/extensions/azurecore/src/azureResource/errors.ts
@@ -3,11 +3,14 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export class AzureResourceCredentialError extends Error {
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
+
+export class AzureSubscriptionError extends Error {
 	constructor(
-		message: string,
-		public readonly innerError: Error
+		accountName: string,
+		public readonly errors: Error[]
 	) {
-		super(message);
+		super(localize('azure.subscriptionError', "Failed to get subscriptions for account {0}. Please refresh the account.", accountName));
 	}
 }

--- a/extensions/azurecore/src/azureResource/interfaces.ts
+++ b/extensions/azurecore/src/azureResource/interfaces.ts
@@ -12,6 +12,7 @@ import { AzureAccount, Tenant } from 'azurecore';
 
 export interface IAzureResourceSubscriptionService {
 	getSubscriptions(account: Account, credential: msRest.ServiceClientCredentials, tenantId: string): Promise<azureResource.AzureResourceSubscription[]>;
+	getAllSubscriptions(account: Account): Promise<azureResource.AzureResourceSubscription[]>;
 }
 
 export interface IAzureResourceSubscriptionFilterService {

--- a/extensions/azurecore/src/azureResource/services/subscriptionService.ts
+++ b/extensions/azurecore/src/azureResource/services/subscriptionService.ts
@@ -3,14 +3,30 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Account } from 'azdata';
+import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 import { SubscriptionClient } from '@azure/arm-subscriptions';
 
 import { azureResource } from 'azureResource';
 import { IAzureResourceSubscriptionService } from '../interfaces';
+import { TokenCredentials } from '@azure/ms-rest-js';
+import { AzureSubscriptionError } from '../errors';
+import { AzureResourceErrorMessageUtil } from '../utils';
+
+import * as nls from 'vscode-nls';
+import { AzureAccount } from 'azurecore';
+const localize = nls.loadMessageBundle();
 
 export class AzureResourceSubscriptionService implements IAzureResourceSubscriptionService {
-	public async getSubscriptions(account: Account, credential: any, tenantId: string): Promise<azureResource.AzureResourceSubscription[]> {
+	/**
+	 * Gets all of the subscriptions for the specified account using the specified credential. This assumes that the credential passed is for
+	 * the specified tenant - which the subscriptions returned will be associated with.
+	 * @param account The account to get the subscriptions for
+	 * @param credential The credential to use for querying the subscriptions
+	 * @param tenantId The ID of the tenant these subscriptions are for
+	 * @returns The list of all subscriptions on this account for the specified tenant
+	 */
+	public async getSubscriptions(account: azdata.Account, credential: any, tenantId: string): Promise<azureResource.AzureResourceSubscription[]> {
 		const subscriptions: azureResource.AzureResourceSubscription[] = [];
 
 		const subClient = new SubscriptionClient(credential, { baseUri: account.properties.providerSettings.settings.armResource.endpoint });
@@ -21,6 +37,35 @@ export class AzureResourceSubscriptionService implements IAzureResourceSubscript
 			tenant: tenantId
 		}));
 
+		return subscriptions;
+	}
+
+	/**
+	 * Gets all subscriptions for all tenants of the given account. Any errors that occur while fetching the subscriptions for each tenant
+	 * will be displayed to the user, but this function will only throw an error if it's unable to fetch any subscriptions.
+	 * @param account The account to get the subscriptions for
+	 * @returns The list of all subscriptions on this account that were able to be retrieved
+	 */
+	public async getAllSubscriptions(account: AzureAccount): Promise<azureResource.AzureResourceSubscription[]> {
+		const subscriptions: azureResource.AzureResourceSubscription[] = [];
+		let gotSubscriptions = false;
+		const errors: Error[] = [];
+
+		for (const tenant of account.properties.tenants) {
+			try {
+				const token = await azdata.accounts.getAccountSecurityToken(account, tenant.id, azdata.AzureResource.ResourceManagement);
+				subscriptions.push(...(await this.getSubscriptions(account, new TokenCredentials(token.token, token.tokenType), tenant.id) || <azureResource.AzureResourceSubscription[]>[]));
+				gotSubscriptions = true;
+			} catch (error) {
+				const errorMsg = localize('azure.resource.tenantSubscriptionsError', "Failed to get subscriptions for account {0} (tenant '{1}'). {2}", account.key.accountId, tenant.id, AzureResourceErrorMessageUtil.getErrorMessage(error));
+				console.warn(errorMsg);
+				errors.push(error);
+				vscode.window.showWarningMessage(errorMsg);
+			}
+		}
+		if (!gotSubscriptions) {
+			throw new AzureSubscriptionError(account.key.accountId, errors);
+		}
 		return subscriptions;
 	}
 }


### PR DESCRIPTION
Currently if a user hits an error trying to fetch subscriptions from any of their tenants then we just fail out and don't let them continue. But stuff can fail for a variety of reasons - for example a tenant may be temporarily inaccessible or require additional login requirements. Sometimes these aren't anything a customer can really do anything about and so with the current behavior they'd be completely blocked from using most of the Azure features in ADS.

This fix here is to move over a couple of places where we were doing that to query for all the subscriptions, but only fail if ALL queries failed - displaying errors for any others that failed while fetching the list. This allows the user to at least use subscriptions from those tenants that succeeded while still notifying them that an issue occurred. 

There's still a lot of improvements we could make in this area - for example having users be able to select which tenants they care about (similar to the subscription filtering we have now) would be a good idea. But that's a much more complicated task and so I focused here first on making it so we could at least unblock users who were stuck with the current behavior. 

Partial Failure : 

![PartialSuccess](https://user-images.githubusercontent.com/28519865/129280530-b989bbcb-2ac4-4784-9489-8281b54ff5f0.gif)
![PartialSuccessFilter](https://user-images.githubusercontent.com/28519865/129280536-58f51e5b-4b80-4aa9-991b-597db6eea453.gif)
![PartialSuccessBrowse](https://user-images.githubusercontent.com/28519865/129280543-8c3789b2-fd72-4a83-8018-8aca5a957d6a.gif)

Complete Failure : 

![FailureTreeView](https://user-images.githubusercontent.com/28519865/129280562-55c7f681-ea83-4942-a633-2132f7645f39.gif)
![FailureFilter](https://user-images.githubusercontent.com/28519865/129280568-936518e8-7e94-4d3b-a6cd-fa1ec3a7c2e4.gif)
![FailureBrowse](https://user-images.githubusercontent.com/28519865/129280571-add4c8db-d0c8-4637-8fd5-57f1d6b380ae.gif)
