### PR TITLE
Fix connection prompt for publish database quickpick

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseQuickpick.ts
@@ -76,7 +76,7 @@ export async function getPublishDatabaseSettings(project: Project, promptForConn
 	// 2. Select connection
 
 	let connectionProfile: IConnectionInfo | undefined = undefined;
-	let dbs: string[] = [];
+	let dbs: string[] | undefined = undefined;
 	let connectionUri: string | undefined;
 	if (promptForConnection) {
 		const vscodeMssqlApi = await getVscodeMssqlApi();
@@ -95,6 +95,8 @@ export async function getPublishDatabaseSettings(project: Project, promptForConn
 				// back and prompt the user for a connection again
 			}
 		}
+	} else {
+		dbs = [];
 	}
 
 	// 3. Select database


### PR DESCRIPTION
The logic here was recently changed but the check wasn't updated correctly - it was relying on dbs being undefined to determine whether it had been able to fetch the list of dbs yet so having it initialized to an empty array meant that it skipped the prompt logic. 

Changing it back and adding default empty list for the no-prompt scenario. 