### PR TITLE
Porting fix for when "project is already open in workspace" message displays at incorrect times

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -20,6 +20,7 @@ export const projectNameNull = localize('projectNameNull', "Project name is null
 export const noPreviousData = (tableName: string): string => { return localize('noPreviousData', "Prior {0} for the current project will appear here, please run to see the results.", tableName); };
 export const gitCloneMessage = (url: string): string => { return localize('gitCloneMessage', "Cloning git repository '{0}'...", url); };
 export const gitCloneError = localize('gitCloneError', "Error during git clone. View git output for more details");
+export const openedProjectsUndefinedAfterRefresh = localize('openedProjectsUndefinedAfterRefresh', "List of opened projects should not be undefined after refresh from disk.");
 
 // UI
 export const OkButtonText = localize('dataworkspace.ok', "OK");

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -20,7 +20,7 @@ export class WorkspaceService implements IWorkspaceService {
 	private _onDidWorkspaceProjectsChange: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 	readonly onDidWorkspaceProjectsChange: vscode.Event<void> = this._onDidWorkspaceProjectsChange?.event;
 
-	private openedProjects: vscode.Uri[] = [];
+	private openedProjects: vscode.Uri[] | undefined = undefined;
 
 	constructor() {
 		this.getProjectsInWorkspace(undefined, true);
@@ -72,9 +72,9 @@ export class WorkspaceService implements IWorkspaceService {
 			vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders?.length || 0, undefined, ...(newWorkspaceFolders.map(folder => ({ uri: vscode.Uri.file(folder) }))));
 		}
 
-		// 2. Re-detect projects from the updated set of workspace folders
+		// 2. Compare projcets being added against prior (cached) list of projects in the workspace
 
-		const previousProjects: string[] = await (await this.getProjectsInWorkspace(undefined, true)).map(p => p.path);
+		const previousProjects: string[] = (await this.getProjectsInWorkspace(undefined, false)).map(p => p.path);
 		let newProjectAdded: boolean = false;
 		const projectsAlreadyOpen: string[] = [];
 
@@ -119,8 +119,12 @@ export class WorkspaceService implements IWorkspaceService {
 	 */
 	public async getProjectsInWorkspace(ext?: string, refreshFromDisk: boolean = false): Promise<vscode.Uri[]> {
 
-		if (refreshFromDisk || this.openedProjects.length === 0) { // always check if nothing cached
+		if (refreshFromDisk || this.openedProjects === undefined) { // always check if nothing cached
 			await this.refreshProjectsFromDisk();
+		}
+
+		if (this.openedProjects === undefined) {
+			throw new Error(constants.openedProjectsUndefinedAfterRefresh);
 		}
 
 		// filter by specified extension


### PR DESCRIPTION
Issue: https://github.com/microsoft/azuredatastudio/issues/16755
PR for main: https://github.com/microsoft/azuredatastudio/pull/16762