### PR TITLE
Add autoCutoverConfiguration to local storage

### DIFF
--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -438,8 +438,8 @@ export interface StartDatabaseMigrationRequest {
 			password: string
 		},
 		scope: string,
-		autoCutoverConfiguration?: {
-			autoCutover?: boolean,
+		autoCutoverConfiguration: {
+			autoCutover: boolean,
 			lastBackupName?: string
 		},
 	}
@@ -507,7 +507,7 @@ export interface BackupConfiguration {
 
 export interface AutoCutoverConfiguration {
 	autoCutover: boolean;
-	lastBackupName: string;
+	lastBackupName?: string;
 }
 
 export interface ErrorInfo {

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -438,10 +438,7 @@ export interface StartDatabaseMigrationRequest {
 			password: string
 		},
 		scope: string,
-		autoCutoverConfiguration: {
-			autoCutover: boolean,
-			lastBackupName?: string
-		},
+		autoCutoverConfiguration: AutoCutoverConfiguration,
 	}
 }
 

--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -278,7 +278,7 @@ export class MigrationCutoverDialog {
 			enabled: false,
 			CSSStyles: {
 				'font-size': '13px',
-				'display': 'none'
+				'display': this._isOnlineMigration() ? 'inline' : 'none'
 			}
 		}).component();
 
@@ -527,7 +527,7 @@ export class MigrationCutoverDialog {
 		try {
 			clearDialogMessage(this._dialogObject);
 
-			if (this._isProvisioned() && this._isOnlineMigration()) {
+			if (this._isOnlineMigration()) {
 				this._cutoverButton.updateCssStyles({
 					'display': 'inline'
 				});
@@ -783,11 +783,7 @@ export class MigrationCutoverDialog {
 	}
 
 	private _isOnlineMigration(): boolean {
-		let migrationMode = null;
-		if (this._isProvisioned()) {
-			migrationMode = this._model._migration.migrationContext.properties.autoCutoverConfiguration?.autoCutover?.valueOf() ? MigrationMode.OFFLINE : MigrationMode.ONLINE;
-		}
-		return migrationMode === MigrationMode.ONLINE;
+		return this._model._migration.migrationContext.properties.autoCutoverConfiguration?.autoCutover?.valueOf() ? false : true;
 	}
 
 	private _shouldDisplayBackupFileTable(): boolean {

--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -12,7 +12,6 @@ import * as loc from '../../constants/strings';
 import { convertByteSizeToReadableUnit, convertIsoTimeToLocalTime, getSqlServerName, getMigrationStatusImage, SupportedAutoRefreshIntervals, clearDialogMessage } from '../../api/utils';
 import { EOL } from 'os';
 import { ConfirmCutoverDialog } from './confirmCutoverDialog';
-import { MigrationMode } from '../../models/stateMachine';
 
 const refreshFrequency: SupportedAutoRefreshIntervals = 30000;
 const statusImageSize: number = 14;

--- a/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
@@ -6,7 +6,7 @@
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import { IconPathHelper } from '../../constants/iconPathHelper';
-import { MigrationContext, MigrationLocalStorage, MigrationStatus, ProvisioningState } from '../../models/migrationLocalStorage';
+import { MigrationContext, MigrationLocalStorage, MigrationStatus } from '../../models/migrationLocalStorage';
 import { MigrationCutoverDialog } from '../migrationCutover/migrationCutoverDialog';
 import { AdsMigrationStatus, MigrationStatusDialogModel } from './migrationStatusDialogModel';
 import * as loc from '../../constants/strings';
@@ -408,9 +408,6 @@ export class MigrationStatusDialog {
 	}
 
 	private _getMigrationMode(migration: MigrationContext): string {
-		if (migration.migrationContext.properties.provisioningState === ProvisioningState.Creating) {
-			return '---';
-		}
 		return migration.migrationContext.properties.autoCutoverConfiguration?.autoCutover?.valueOf() ? loc.OFFLINE : loc.ONLINE;
 	}
 

--- a/extensions/sql-migration/src/models/migrationLocalStorage.ts
+++ b/extensions/sql-migration/src/models/migrationLocalStorage.ts
@@ -27,6 +27,7 @@ export class MigrationLocalStorage {
 			if (migration.sourceConnectionProfile.serverName === connectionProfile.serverName) {
 				if (refreshStatus) {
 					try {
+						const autoCutoverConfiguration = migration.migrationContext.properties.autoCutoverConfiguration;
 						const backupConfiguration = migration.migrationContext.properties.backupConfiguration;
 						const sourceDatabase = migration.migrationContext.properties.sourceDatabaseName;
 
@@ -50,6 +51,7 @@ export class MigrationLocalStorage {
 
 							migration.migrationContext.properties.sourceDatabaseName = sourceDatabase;
 							migration.migrationContext.properties.backupConfiguration = backupConfiguration;
+							migration.migrationContext.properties.autoCutoverConfiguration = autoCutoverConfiguration;
 						}
 					}
 					catch (e) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes adds autoCutoverConfiguration to local storage.
This fixes inconsistency of show/hide on cutover button and shows migration mode even during creating state.

![image](https://user-images.githubusercontent.com/14362577/129407946-a0f121bb-8ef3-4a97-8e1d-72cb07980c37.png)
