### PR TITLE
Python smoke test: increase wait time for install location

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -25,11 +25,11 @@ export class ConfigurePythonDialog extends Dialog {
 		const newPythonInstallation = `${dialogPageInView} input[aria-label="New Python installation"]`;
 		await this.code.waitAndClick(newPythonInstallation);
 
-		// Wait for the python install location to be loaded before clicking the next button.
+		// Wait up to 1 minute for the python install location to be loaded before clicking the next button.
 		// There may be a timing issue where the smoke test attempts to go to the next page before
 		// the contents are loaded, causing the test to fail.
 		const pythonInstallLocationDropdownValue = `${dialogPageInView} option[value*="/azuredatastudio-python (Default)"]`;
-		await this.code.waitForElement(pythonInstallLocationDropdownValue);
+		await this.code.waitForElement(pythonInstallLocationDropdownValue, undefined, 600);
 
 		const loadingSpinner = `${dialogPageInView} .modelview-loadingComponent-content-loading`;
 		await this.code.waitForElementGone(loadingSpinner);


### PR DESCRIPTION
The Python smoke test sometimes times out during our product builds. Based on the smoke logs, it timed out while waiting for the install location so I am increasing the wait time for that step. 