### PR TITLE
Fix download manually link

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -141,7 +141,7 @@ export class PromptExtensionInstallFailureAction extends Action {
 		if (this.extension.gallery && this.productService.extensionsGallery) {
 			promptChoices.push({
 				label: localize('download', "Try Downloading Manually..."),
-				run: () => this.openerService.open(URI.parse(`${this.productService.extensionsGallery!.serviceUrl}/publishers/${this.extension.publisher}/vsextensions/${this.extension.name}/${this.version}/vspackage`)).then(() => {
+				run: () => this.openerService.open(URI.parse(this.extension.gallery.assets.download?.uri ?? this.extension.gallery.assets.downloadPage.uri)).then(() => { // {{SQL CARBON EDIT}} Use links from the assets since we don't have the same marketplace
 					this.notificationService.prompt(
 						Severity.Info,
 						localize('install vsix', 'Once downloaded, please manually install the downloaded VSIX of \'{0}\'.', this.extension.identifier.id),

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -101,7 +101,7 @@ export class PromptExtensionInstallFailureAction extends Action {
 
 	constructor(
 		private readonly extension: IExtension,
-		private readonly version: string,
+		public readonly version: string, // {{SQL CARBON EDIT}} Making public to get around compile error since we don't use this anymore (easier than updating all constructor calls)
 		private readonly installOperation: InstallOperation,
 		private readonly error: Error,
 		@IProductService private readonly productService: IProductService,


### PR DESCRIPTION
If an error occurs while trying to install a VSIX (such as invalid version) then it prompts the user to install the extension manually - but the link is for the VS Code marketplace so is broken for us. Fixing it to point to the correct link 