### PR TITLE
enable task cancellation for wizard operation

### DIFF
--- a/src/sql/workbench/contrib/tasks/common/tasksAction.ts
+++ b/src/sql/workbench/contrib/tasks/common/tasksAction.ts
@@ -24,7 +24,7 @@ export class CancelAction extends Action {
 		super(id, label);
 	}
 	public override async run(element: TaskNode): Promise<void> {
-		if (element instanceof TaskNode && element.providerName) {
+		if (element instanceof TaskNode) {
 			try {
 				const result = await this._taskService.cancelTask(element.providerName, element.id);
 				if (!result) {


### PR DESCRIPTION
This PR fixes #16689 

remove the provider name check as it is not required in the task service (see code below)
![image](https://user-images.githubusercontent.com/13777222/129783155-e1f6910d-6532-418b-ab54-a8d5a2d26feb.png)

with this fix, using the example code provided in the issue description, the extension can receive the status update:
![image](https://user-images.githubusercontent.com/13777222/129783378-b8c97624-3320-4ae1-bde6-26fff09381c5.png)

