### PR TITLE
Remove extra click in python smoke test

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -22,9 +22,6 @@ export class ConfigurePythonDialog extends Dialog {
 		const dialogPageInView = '.modal .modal-body .dialogModal-pane:not(.dialogModal-hidden)';
 		const dialogButtonInView = '.modal .modal-footer .footer-button:not(.dialogModal-hidden)';
 
-		const newPythonInstallation = `${dialogPageInView} input[aria-label="New Python installation"]`;
-		await this.code.waitAndClick(newPythonInstallation);
-
 		// Wait up to 1 minute for the python install location to be loaded before clicking the next button.
 		// There may be a timing issue where the smoke test attempts to go to the next page before
 		// the contents are loaded, causing the test to fail.


### PR DESCRIPTION
This click is not needed since the New Python Installation option is selected by default.