### PR TITLE
Fix azure account tree subscription check

### DIFF
--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -357,7 +357,7 @@ export async function makeHttpRequest(account: azdata.Account, subscription: azu
 		return result;
 	}
 
-	let securityToken: { token: string, tokenType?: string };
+	let securityToken: azdata.accounts.AccountSecurityToken;
 	try {
 		securityToken = await azdata.accounts.getAccountSecurityToken(
 			account,

--- a/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
@@ -130,6 +130,7 @@ describe('AzureResourceAccountTreeNode.info', function (): void {
 	it('Should be correct when there are subscriptions listed.', async function (): Promise<void> {
 		mockSubscriptionService.setup((o) => o.getAllSubscriptions(mockAccount)).returns(() => Promise.resolve(mockSubscriptions));
 		mockSubscriptionFilterService.setup((o) => o.getSelectedSubscriptions(mockAccount)).returns(() => Promise.resolve(undefined));
+		sinon.stub(azdata.accounts, 'getAccountSecurityToken').resolves(mockToken);
 
 		const accountTreeNodeLabel = `${mockAccount.displayInfo.displayName} (${mockSubscriptions.length} / ${mockSubscriptions.length} subscriptions)`;
 
@@ -147,10 +148,30 @@ describe('AzureResourceAccountTreeNode.info', function (): void {
 		should(nodeInfo.label).equal(accountTreeNodeLabel);
 	});
 
+	it('Should only show subscriptions with valid tokens.', async function (): Promise<void> {
+		mockSubscriptionService.setup((o) => o.getAllSubscriptions(mockAccount)).returns(() => Promise.resolve(mockSubscriptions));
+		mockSubscriptionFilterService.setup((o) => o.getSelectedSubscriptions(mockAccount)).returns(() => Promise.resolve(mockFilteredSubscriptions));
+		sinon.stub(azdata.accounts, 'getAccountSecurityToken').onFirstCall().resolves(mockToken);
+		const accountTreeNodeLabel = `${mockAccount.displayInfo.displayName} (${mockFilteredSubscriptions.length} / ${mockSubscriptions.length} subscriptions)`;
+
+		const accountTreeNode = new AzureResourceAccountTreeNode(mockAccount, mockAppContext, mockTreeChangeHandler.object);
+
+		const subscriptionNodes = await accountTreeNode.getChildren();
+
+		should(subscriptionNodes).Array();
+		should(subscriptionNodes.length).equal(1);
+
+		const treeItem = await accountTreeNode.getTreeItem();
+		should(treeItem.label).equal(accountTreeNodeLabel);
+
+		const nodeInfo = accountTreeNode.getNodeInfo();
+		should(nodeInfo.label).equal(accountTreeNodeLabel);
+	});
+
 	it('Should be correct when there are subscriptions filtered.', async function (): Promise<void> {
 		mockSubscriptionService.setup((o) => o.getAllSubscriptions(mockAccount)).returns(() => Promise.resolve(mockSubscriptions));
 		mockSubscriptionFilterService.setup((o) => o.getSelectedSubscriptions(mockAccount)).returns(() => Promise.resolve(mockFilteredSubscriptions));
-
+		sinon.stub(azdata.accounts, 'getAccountSecurityToken').resolves(mockToken);
 		const accountTreeNodeLabel = `${mockAccount.displayInfo.displayName} (${mockFilteredSubscriptions.length} / ${mockSubscriptions.length} subscriptions)`;
 
 		const accountTreeNode = new AzureResourceAccountTreeNode(mockAccount, mockAppContext, mockTreeChangeHandler.object);

--- a/extensions/machine-learning/src/common/apiWrapper.ts
+++ b/extensions/machine-learning/src/common/apiWrapper.ts
@@ -99,7 +99,7 @@ export class ApiWrapper {
 		return azdata.accounts.getAllAccounts();
 	}
 
-	public getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Thenable<{ token: string, tokenType?: string } | undefined> {
+	public getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Thenable<azdata.accounts.AccountSecurityToken | undefined> {
 		return azdata.accounts.getAccountSecurityToken(account, tenant, resource);
 	}
 

--- a/extensions/machine-learning/src/modelManagement/azureModelRegistryService.ts
+++ b/extensions/machine-learning/src/modelManagement/azureModelRegistryService.ts
@@ -304,7 +304,7 @@ export class AzureModelRegistryService {
 		if (this._amlClient) {
 			return this._amlClient;
 		} else {
-			const tokens: { token: string, tokenType?: string } | undefined = await this._apiWrapper.getAccountSecurityToken(account, tenant.id, azdata.AzureResource.ResourceManagement);
+			const tokens: azdata.accounts.AccountSecurityToken | undefined = await this._apiWrapper.getAccountSecurityToken(account, tenant.id, azdata.AzureResource.ResourceManagement);
 			let token: string = '';
 			let tokenType: string | undefined = undefined;
 			if (tokens) {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2176,13 +2176,27 @@ declare module 'azdata' {
 		export function getSecurityToken(account: Account, resource?: AzureResource): Thenable<{ [key: string]: any }>;
 
 		/**
+		 * The token used to authenticate an account.
+		 */
+		export interface AccountSecurityToken {
+			/**
+			 * The token to use
+			 */
+			token: string,
+			/**
+			 * What type of token this is
+			 */
+			tokenType?: string | undefined
+		}
+
+		/**
 		 * Generates a security token by asking the account's provider
 		 * @param account The account to retrieve the security token for
 		 * @param tenantId The ID of the tenant associated with this account
 		 * @param resource Type of resource to get the security token for (defaults to
 		 * AzureResource.ResourceManagement if not given)
 		 */
-		export function getAccountSecurityToken(account: Account, tenantId: string, resource: AzureResource): Thenable<{ token: string, tokenType?: string | undefined } | undefined>;
+		export function getAccountSecurityToken(account: Account, tenantId: string, resource: AzureResource): Thenable<AccountSecurityToken | undefined>;
 
 		/**
 		 * An [event](#Event) which fires when the accounts have changed.

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2184,7 +2184,7 @@ declare module 'azdata' {
 			 */
 			token: string,
 			/**
-			 * What type of token this is
+			 * What type of token this is (such as Bearer)
 			 */
 			tokenType?: string | undefined
 		}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -836,7 +836,7 @@ declare module 'azdata' {
 		 * @param resource The resource to get the token for
 		 * @return Promise to return a security token object
 		 */
-		getAccountSecurityToken(account: Account, tenant: string, resource: AzureResource): Thenable<{ token: string } | undefined>;
+		getAccountSecurityToken(account: Account, tenant: string, resource: AzureResource): Thenable<accounts.AccountSecurityToken | undefined>;
 	}
 
 	export interface AccountKey {

--- a/src/sql/platform/accounts/common/interfaces.ts
+++ b/src/sql/platform/accounts/common/interfaces.ts
@@ -25,7 +25,7 @@ export interface IAccountManagementService {
 	 * @deprecated
 	 */
 	getSecurityToken(account: azdata.Account, resource: azdata.AzureResource): Promise<{ [key: string]: { token: string } } | undefined>;
-	getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Promise<{ token: string } | undefined>;
+	getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Promise<azdata.accounts.AccountSecurityToken | undefined>;
 	removeAccount(accountKey: azdata.AccountKey): Promise<boolean>;
 	removeAccounts(): Promise<boolean>;
 	refreshAccount(account: azdata.Account): Promise<azdata.Account>;

--- a/src/sql/platform/accounts/test/common/testAccountManagementService.ts
+++ b/src/sql/platform/accounts/test/common/testAccountManagementService.ts
@@ -55,7 +55,7 @@ export class TestAccountManagementService implements IAccountManagementService {
 		return Promise.resolve([]);
 	}
 
-	getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Promise<{ token: string }> {
+	getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Promise<azdata.accounts.AccountSecurityToken> {
 		return Promise.resolve(undefined!);
 	}
 

--- a/src/sql/workbench/api/browser/mainThreadAccountManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadAccountManagement.ts
@@ -78,7 +78,7 @@ export class MainThreadAccountManagement extends Disposable implements MainThrea
 			getSecurityToken(account: azdata.Account, resource: azdata.AzureResource): Thenable<{}> {
 				return self._proxy.$getSecurityToken(account, resource);
 			},
-			getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Thenable<{ token: string }> {
+			getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Thenable<azdata.accounts.AccountSecurityToken> {
 				return self._proxy.$getAccountSecurityToken(account, tenant, resource);
 			},
 			initialize(restoredAccounts: azdata.Account[]): Thenable<azdata.Account[]> {

--- a/src/sql/workbench/api/common/extHostAccountManagement.ts
+++ b/src/sql/workbench/api/common/extHostAccountManagement.ts
@@ -104,7 +104,7 @@ export class ExtHostAccountManagement extends ExtHostAccountManagementShape {
 		});
 	}
 
-	public override $getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource = AzureResource.ResourceManagement): Thenable<{ token: string }> {
+	public override $getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource = AzureResource.ResourceManagement): Thenable<azdata.accounts.AccountSecurityToken> {
 		return this.getAllProvidersAndAccounts().then(providerAndAccounts => {
 			const providerAndAccount = providerAndAccounts.find(providerAndAccount => providerAndAccount.account.key.accountId === account.key.accountId);
 			if (providerAndAccount) {

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -165,7 +165,7 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				getSecurityToken(account: azdata.Account, resource?: azdata.AzureResource): Thenable<{}> {
 					return extHostAccountManagement.$getSecurityToken(account, resource);
 				},
-				getAccountSecurityToken(account: azdata.Account, tenant: string, resource?: azdata.AzureResource): Thenable<{ token: string }> {
+				getAccountSecurityToken(account: azdata.Account, tenant: string, resource?: azdata.AzureResource): Thenable<azdata.accounts.AccountSecurityToken> {
 					return extHostAccountManagement.$getAccountSecurityToken(account, tenant, resource);
 				},
 				onDidChangeAccounts(listener: (e: azdata.DidChangeAccountsParams) => void, thisArgs?: any, disposables?: extHostTypes.Disposable[]) {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -32,7 +32,7 @@ export abstract class ExtHostAccountManagementShape {
 	$autoOAuthCancelled(handle: number): Thenable<void> { throw ni(); }
 	$clear(handle: number, accountKey: azdata.AccountKey): Thenable<void> { throw ni(); }
 	$getSecurityToken(account: azdata.Account, resource?: azdata.AzureResource): Thenable<{}> { throw ni(); }
-	$getAccountSecurityToken(account: azdata.Account, tenant: string, resource?: azdata.AzureResource): Thenable<{ token: string }> { throw ni(); }
+	$getAccountSecurityToken(account: azdata.Account, tenant: string, resource?: azdata.AzureResource): Thenable<azdata.accounts.AccountSecurityToken> { throw ni(); }
 	$initialize(handle: number, restoredAccounts: azdata.Account[]): Thenable<azdata.Account[]> { throw ni(); }
 	$prompt(handle: number): Thenable<azdata.Account | azdata.PromptFailedResult> { throw ni(); }
 	$refresh(handle: number, account: azdata.Account): Thenable<azdata.Account | azdata.PromptFailedResult> { throw ni(); }

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -246,7 +246,7 @@ export class AccountManagementService implements IAccountManagementService {
 	 * @param resource The resource to get the security token for
 	 * @return Promise to return the security token
 	 */
-	public getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Promise<{ token: string } | undefined> {
+	public getAccountSecurityToken(account: azdata.Account, tenant: string, resource: azdata.AzureResource): Promise<azdata.accounts.AccountSecurityToken | undefined> {
 		return this.doWithProvider(account.key.providerId, provider => {
 			return Promise.resolve(provider.provider.getAccountSecurityToken(account, tenant, resource));
 		});


### PR DESCRIPTION
Noticed this while fixing something else, but the check here isn't correct since filter doesn't support async functions. You need to generate a mapping and then filter from that if you want to do an async check.

While I was doing this I added a type for the account security token so we don't have to keep manually copying the type definition...

I'm promoting that directly to azdata.d.ts because the type is already used there and this isn't actually adding/changing a type - just giving it a strict definition.