### PR TITLE
layout the child component

### DIFF
--- a/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
+++ b/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
@@ -67,10 +67,18 @@ export default class LoadingComponent extends ComponentBase<azdata.LoadingCompon
 		this.layout();
 	}
 
+	public override layout() {
+		super.layout();
+		if (this._component) {
+			const childComponent = this.modelStore.getComponent(this._component.id);
+			childComponent?.layout();
+		}
+	}
+
 	public override setProperties(properties: { [key: string]: any; }): void {
 		const wasLoading = this.loading;
 		super.setProperties(properties);
-		if (wasLoading && !this.loading) {
+		if (wasLoading !== this.loading) {
 			status(this.getStatusText());
 		}
 	}


### PR DESCRIPTION
This PR fixes #16693

when doing layout for the loading component we also need to invoke the layout method for the child component to make sure it is sized properly.
