### PR TITLE
Promote some proposed APIs

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3964,18 +3964,6 @@ declare module 'azdata' {
 		 */
 		export function createModelViewDialog(title: string, dialogName?: string, width?: DialogWidth): Dialog;
 
-		export interface ModelViewDashboardOptions {
-			/**
-			 * Whether to show the tab icon, default is true
-			 */
-			showIcon?: boolean;
-
-			/**
-			 * Whether to show the tab navigation pane even when there is only one tab, default is false
-			 */
-			alwaysShowTabs?: boolean;
-		}
-
 		export interface ModelViewDashboard {
 			/**
 			 * Registers the initial set of tabs for this dashboard
@@ -4000,25 +3988,6 @@ declare module 'azdata' {
 			 * @param id The ID of the tab to select
 			 */
 			selectTab(id: string): void;
-		}
-
-		export interface DashboardTab extends Tab {
-			/**
-			 * Toolbar of the tab, optional.
-			 */
-			toolbar?: ToolbarContainer;
-		}
-
-		export interface DashboardTabGroup {
-			/**
-			 * Title of the tab group
-			 */
-			title: string;
-
-			/**
-			 * Child tabs of the tab group
-			 */
-			tabs: DashboardTab[];
 		}
 
 		/**
@@ -4455,6 +4424,37 @@ declare module 'azdata' {
 		 * Get a QueryDocument object for a file URI
 		 */
 		export function getQueryDocument(fileUri: string): Thenable<QueryDocument>;
+	}
+
+	export interface DashboardTab extends Tab {
+		/**
+		 * Toolbar of the tab, optional.
+		 */
+		toolbar?: ToolbarContainer;
+	}
+
+	export interface DashboardTabGroup {
+		/**
+		 * Title of the tab group
+		 */
+		title: string;
+
+		/**
+		 * Child tabs of the tab group
+		 */
+		tabs: DashboardTab[];
+	}
+
+	export interface ModelViewDashboardOptions {
+		/**
+		 * Whether to show the tab icon, default is true
+		 */
+		showIcon?: boolean;
+
+		/**
+		 * Whether to show the tab navigation pane even when there is only one tab, default is false
+		 */
+		alwaysShowTabs?: boolean;
 	}
 
 	export interface ModelViewEditorOptions {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3395,10 +3395,6 @@ declare module 'azdata' {
 		columnName: string;
 	}
 
-	export interface ButtonCell extends TableCell {
-		columnName: string;
-	}
-
 	export interface FileBrowserTreeProperties extends ComponentProperties {
 		ownerUri: string;
 	}

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2306,7 +2306,19 @@ declare module 'azdata' {
 		/**
 		 * Microsoft Graph
 		 */
-		MsGraph = 7
+		MsGraph = 7,
+		/**
+		 * Azure Log Analytics
+		 */
+		AzureLogAnalytics = 8,
+		/**
+		 * Azure Storage
+		 */
+		AzureStorage = 9,
+		/**
+		 * Kusto
+		 */
+		AzureKusto = 10
 	}
 
 	export interface DidChangeAccountsParams {
@@ -2568,8 +2580,9 @@ declare module 'azdata' {
 		 * Create a new ModelView editor
 		 * @param title The title shown in the editor tab
 		 * @param options Options to configure the editor
+		 * @param name The name used to identify the editor in telemetry
 		 */
-		export function createModelViewEditor(title: string, options?: ModelViewEditorOptions): ModelViewEditor;
+		export function createModelViewEditor(title: string, options?: ModelViewEditorOptions, name?: string,): ModelViewEditor;
 
 		export interface ModelViewEditor extends window.ModelViewPanel {
 			/**
@@ -2693,7 +2706,15 @@ declare module 'azdata' {
 
 	export interface ComponentBuilder<TComponent extends Component, TPropertyBag extends ComponentProperties> {
 		component(): TComponent;
+		/**
+		 * @deprecated Use withProps instead
+		 */
 		withProperties<U>(properties: U): ComponentBuilder<TComponent, TPropertyBag>;
+		/**
+		 * Sets the initial set of properties for the component being created
+		 * @param properties The properties to apply to the component
+		 */
+		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
 		withValidation(validation: (component: TComponent) => boolean | Thenable<boolean>): ComponentBuilder<TComponent, TPropertyBag>;
 	}
 	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ComponentProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
@@ -2900,6 +2921,13 @@ declare module 'azdata' {
 		 * @param layout object
 		 */
 		setLayout(layout: TLayout): void;
+
+		/**
+		 * Sets the layout for the specified child component
+		 * @param component The component to set the layout for
+		 * @param layout The layout to apply
+		 */
+		setItemLayout(component: Component, layout: TItemLayout): void;
 	}
 
 	export interface NavContainer extends Container<any, any> {
@@ -3306,6 +3334,10 @@ declare module 'azdata' {
 		 * This title will show when hovered over
 		 */
 		title?: string | undefined;
+		/**
+		 * The maximum number of characters allowed in the input box.
+		 */
+		maxLength?: number;
 	}
 
 	export interface TableColumn {
@@ -3360,6 +3392,10 @@ declare module 'azdata' {
 
 	export interface CheckBoxCell extends TableCell {
 		checked: boolean;
+		columnName: string;
+	}
+
+	export interface ButtonCell extends TableCell {
 		columnName: string;
 	}
 
@@ -3507,19 +3543,57 @@ declare module 'azdata' {
 		isAutoResizable: boolean;
 	}
 
+	export enum ButtonType {
+		/**
+		 * Opens up the File Picker dialog when clicked
+		 */
+		File = 'File',
+		/**
+		 * Normal button with no special behavior
+		 */
+		Normal = 'Normal',
+		/**
+		 * Button that displays additional information when hovered over
+		 */
+		Informational = 'Informational'
+	}
+
 	export interface ButtonProperties extends ComponentWithIconProperties {
 		/**
 		 * The label for the button
 		 */
 		label?: string | undefined;
+
 		/**
 		 * Whether the button opens the file browser dialog
+		 * @deprecated Use fileType instead
 		 */
 		isFile?: boolean | undefined;
+
 		/**
 		 * The content of the currently selected file
 		 */
 		fileContent?: string | undefined;
+
+		/**
+		* Specifies the type of button this is. Default is Normal.
+		*/
+		buttonType?: ButtonType;
+
+		/**
+		* Description text to display inside button element.
+		*/
+		description?: string;
+
+		/**
+		 * Specifies whether this is a secondary button. Default value is false.
+		 */
+		secondary?: boolean;
+
+		/**
+		 * The file type filter used for the file input dialog box - only used when the button type is File
+		 */
+		fileType?: string
 	}
 
 	export interface LoadingComponentProperties extends ComponentProperties {
@@ -3599,6 +3673,10 @@ declare module 'azdata' {
 		 * An event called when the radio button is clicked
 		 */
 		onDidClick: vscode.Event<any>;
+		/**
+		 * An event called when the value of radio button changes
+		 */
+		onDidChangeCheckedState: vscode.Event<boolean>;
 	}
 
 	export interface CheckBoxComponent extends Component, CheckBoxProperties {
@@ -3890,6 +3968,71 @@ declare module 'azdata' {
 		 */
 		export function createModelViewDialog(title: string, dialogName?: string, width?: DialogWidth): Dialog;
 
+		export interface ModelViewDashboardOptions {
+			/**
+			 * Whether to show the tab icon, default is true
+			 */
+			showIcon?: boolean;
+
+			/**
+			 * Whether to show the tab navigation pane even when there is only one tab, default is false
+			 */
+			alwaysShowTabs?: boolean;
+		}
+
+		export interface ModelViewDashboard {
+			/**
+			 * Registers the initial set of tabs for this dashboard
+			 * @param handler Callback for creating the initial set of tabs to display
+			 */
+			registerTabs(handler: (view: ModelView) => Thenable<(DashboardTab | DashboardTabGroup)[]>): void;
+			/**
+			 * Open the dashboard
+			 */
+			open(): Thenable<void>;
+			/**
+			 * Close the dashboard
+			 */
+			close(): Thenable<void>;
+			/**
+			 * Updates the tabs that are currently displayed
+			 * @param tabs The new set of tabs to display
+			 */
+			updateTabs(tabs: (DashboardTab | DashboardTabGroup)[]): void;
+			/**
+			 * Selects the tab with the given ID
+			 * @param id The ID of the tab to select
+			 */
+			selectTab(id: string): void;
+		}
+
+		export interface DashboardTab extends Tab {
+			/**
+			 * Toolbar of the tab, optional.
+			 */
+			toolbar?: ToolbarContainer;
+		}
+
+		export interface DashboardTabGroup {
+			/**
+			 * Title of the tab group
+			 */
+			title: string;
+
+			/**
+			 * Child tabs of the tab group
+			 */
+			tabs: DashboardTab[];
+		}
+
+		/**
+		 * Creates a ModelView Dashboard that when opened will be displayed in an editor pane.
+		 * @param title The title displayed in the editor tab for the dashboard
+		 * @param name The name used to identify this dashboard in telemetry
+		 * @param options Options to configure the dashboard
+		 */
+		export function createModelViewDashboard(title: string, name?: string, options?: ModelViewDashboardOptions): ModelViewDashboard;
+
 		/**
 		 * Create a dialog tab which can be included as part of the content of a dialog
 		 * @param title The title of the page, displayed on the tab to select the page
@@ -4077,6 +4220,11 @@ declare module 'azdata' {
 			 * Position of the button on the dialog footer
 			 */
 			position?: DialogButtonPosition | undefined;
+
+			/**
+			 * Specifies whether this is a secondary button. Default is false.
+			 */
+			secondary?: boolean;
 		}
 
 		export type DialogButtonPosition = 'left' | 'right';
@@ -4119,6 +4267,11 @@ declare module 'azdata' {
 			 * An optional description for the page. If provided it will be displayed underneath the page title.
 			 */
 			description: string;
+
+			/**
+			 * An optional name for the page. If provided it will be used for telemetry
+			 */
+			pageName?: string;
 		}
 
 		export interface Wizard {
@@ -4210,8 +4363,9 @@ declare module 'azdata' {
 
 			/**
 			 * Open the wizard. Does nothing if the wizard is already open.
+			 * @param source Where the wizard was opened from for telemetry (ex: command palette, context menu)
 			 */
-			open(): Thenable<void>;
+			open(source?: string): Thenable<void>;
 
 			/**
 			 * Close the wizard. Does nothing if the wizard is not open.
@@ -4479,6 +4633,11 @@ declare module 'azdata' {
 		 * An event that is emitted when a [notebook's](#NotebookDocument) cell contents are changed.
 		 */
 		export const onDidChangeNotebookCell: vscode.Event<NotebookCellChangeEvent>;
+
+		/**
+		 * An event that is emitted when the active Notebook editor is changed.
+		 */
+		export const onDidChangeActiveNotebookEditor: vscode.Event<NotebookEditor>;
 
 		/**
 		 * Show the given document in a notebook editor. A [column](#ViewColumn) can be provided

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -257,13 +257,6 @@ declare module 'azdata' {
 		title: string;
 	}
 
-	export interface RadioButtonComponent {
-		/**
-		 * An event called when the value of radio button changes
-		 */
-		onDidChangeCheckedState: vscode.Event<boolean>;
-	}
-
 	export interface DeclarativeTableColumn {
 		headerCssStyles?: CssStyles;
 		rowCssStyles?: CssStyles;
@@ -324,10 +317,6 @@ declare module 'azdata' {
 		listView(): ComponentBuilder<ListViewComponent, ListViewComponentProperties>;
 		tabbedPanel(): TabbedPanelComponentBuilder;
 		slider(): ComponentBuilder<SliderComponent, SliderComponentProperties>;
-	}
-
-	export interface ComponentBuilder<TComponent extends Component, TPropertyBag extends ComponentProperties> {
-		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
 	}
 
 	export interface RadioCard {
@@ -600,28 +589,7 @@ declare module 'azdata' {
 		textType?: TextType;
 	}
 
-	export namespace nb {
-		/**
-		 * An event that is emitted when the active Notebook editor is changed.
-		 */
-		export const onDidChangeActiveNotebookEditor: vscode.Event<NotebookEditor>;
-	}
 	export namespace window {
-		export interface ModelViewDashboard {
-			registerTabs(handler: (view: ModelView) => Thenable<(DashboardTab | DashboardTabGroup)[]>): void;
-			open(): Thenable<void>;
-			close(): Thenable<void>;
-			updateTabs(tabs: (DashboardTab | DashboardTabGroup)[]): void;
-			selectTab(id: string): void;
-		}
-
-		/**
-		 *
-		 * @param title The title displayed in the editor tab for the dashboard
-		 * @param name The name used to identify this dashboard in telemetry
-		 * @param options Options to configure the dashboard
-		 */
-		export function createModelViewDashboard(title: string, name?: string, options?: ModelViewDashboardOptions): ModelViewDashboard;
 
 		export interface Dialog {
 			/**
@@ -661,40 +629,41 @@ declare module 'azdata' {
 			 * Width of the wizard
 			 */
 			width?: DialogWidth;
-
-			/**
-			 * Open the wizard. Does nothing if the wizard is already open.
-			 * @param source Where the wizard was opened from for telemetry (ex: command palette, context menu)
-			 */
-			open(source?: string): Thenable<void>;
-		}
-
-		export interface WizardPage extends ModelViewPanel {
-			/**
-			 * An optional name for the page. If provided it will be used for telemetry
-			 */
-			pageName?: string;
 		}
 
 		/**
 		 * These dialog styles affect how the dialog displays in the application.
 		 * normal: Positioned top and centered.
-		 * flyout (default): Existing panel appearance - positioned full screen height, opens from the right side of the application.
-		 * callout: Opens below or beside button clicked, contains footer section with buttons.
+		 * flyout (default): Positioned full screen height, opens from the right side of the application.
+		 * callout: Opens below or beside parent element, contains footer section with buttons.
 		 */
 		export type DialogStyle = 'normal' | 'flyout' | 'callout';
 
+		/**
+		 * Where to position the dialog relative to the parent element
+		 */
 		export type DialogPosition = 'left' | 'below';
 
 		/**
-		 * These are positional data prior to opening of dialog.
-		 * They are needed for positioning relative to the button which triggers the opening of the dialog.
-		 * Default is undefined.
+		 * The p
+		 * They are needed for positioning relative to the element which triggers the opening of the dialog.
 		 */
 		export interface IDialogProperties {
+			/**
+			 * x position of the dialog relative to the parent element
+			 */
 			xPos: number,
+			/**
+			 * y position of the dialog relative to the parent element
+			 */
 			yPos: number,
+			/**
+			 * width of the dialog
+			 */
 			width: number,
+			/**
+			 * height of the dialog
+			 */
 			height: number
 		}
 
@@ -711,57 +680,6 @@ declare module 'azdata' {
 		 */
 		export function createModelViewDialog(title: string, dialogName?: string, width?: DialogWidth, dialogStyle?: DialogStyle, dialogPosition?: DialogPosition, renderHeader?: boolean, renderFooter?: boolean, dialogProperties?: IDialogProperties): Dialog;
 
-		export interface Button {
-			/**
-			 * Specifies whether this is a secondary button. Default is false.
-			 */
-			secondary?: boolean;
-		}
-	}
-
-	export namespace workspace {
-		/**
-		 * Create a new ModelView editor
-		 * @param title The title shown in the editor tab
-		 * @param options Options to configure the editor
-		 * @param name The name used to identify the editor in telemetry
-		 */
-		export function createModelViewEditor(title: string, options?: ModelViewEditorOptions, name?: string,): ModelViewEditor;
-	}
-
-	export interface DashboardTab extends Tab {
-		/**
-		 * Toolbar of the tab, optional.
-		 */
-		toolbar?: ToolbarContainer;
-	}
-
-	export interface DashboardTabGroup {
-		/**
-		 * * Title of the tab group
-		 */
-		title: string;
-
-		/**
-		 * children of the tab group
-		 */
-		tabs: DashboardTab[];
-	}
-
-	export interface ModelViewDashboardOptions {
-		/**
-		 * Whether to show the tab icon, default is true
-		 */
-		showIcon?: boolean;
-
-		/**
-		 * Whether to show the tab navigation pane even when there is only one tab, default is false
-		 */
-		alwaysShowTabs?: boolean;
-	}
-
-	export interface Container<TLayout, TItemLayout> extends Component {
-		setItemLayout(component: Component, layout: TItemLayout): void;
 	}
 
 	export interface TaskInfo {
@@ -770,10 +688,6 @@ declare module 'azdata' {
 
 	export interface ButtonColumnOption {
 		icon?: IconPath;
-	}
-
-	export interface ButtonCell extends TableCell {
-		columnName: string;
 	}
 
 	export namespace sqlAssessment {
@@ -851,54 +765,6 @@ declare module 'azdata' {
 		 * Specifies if an account should be deleted
 		 */
 		delete?: boolean;
-	}
-
-	export enum AzureResource {
-		/**
-		 * Azure Log Analytics
-		 */
-		AzureLogAnalytics = 8,
-		/**
-		 * Azure Storage
-		 */
-		AzureStorage = 9,
-		/**
-		 * Kusto
-		 */
-		AzureKusto = 10
-	}
-
-	export interface ButtonProperties {
-		/**
-		* Specifies whether to use expanded layout or not.
-		*/
-		buttonType?: ButtonType;
-		/**
-		* Description text to display inside button element.
-		*/
-		description?: string;
-		/**
-		 * Specifies whether this is a secondary button. Default value is false.
-		 */
-		secondary?: boolean;
-
-		/**
-		 * The file type filter used for the file input dialog box - only used when the button type is File
-		 */
-		fileType?: string
-	}
-
-	export enum ButtonType {
-		File = 'File',
-		Normal = 'Normal',
-		Informational = 'Informational'
-	}
-
-	export interface InputBoxProperties {
-		/**
-		 * The maximum number of characters allowed in the input box.
-		 */
-		maxLength?: number;
 	}
 
 	export namespace workspace {


### PR DESCRIPTION
Just picked some that seem to make sense to promote. Plan on doing a few passes of this - trying to keep each of these small. 

A couple notes : 

1. I was looking at promoting the dialog properties stuff but when taking a closer look at it I'm still not super happy with the current state of the properties so I'd like to keep it in proposed for now
2. I removed the ButtonCell (proposed) interface. It was added in https://github.com/microsoft/azuredatastudio/commit/4a88adffd260393d58fa72f9ece8f8a8392f5bec but I can' t find anywhere where it's actually used - and the `columnName` property doesn't seem to be anything we actually use/need.