### PR TITLE
Filter plugin: don't set columns if auto size column plugin is also on

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
@@ -97,6 +97,9 @@ export class AutoColumnSize<T extends Slick.SlickData> implements Slick.Plugin<T
 			}
 
 			let headerWidths: number[] = this.getElementWidths(headerElements);
+			headerWidths = headerWidths.map(width => {
+				return width + 34; // 16 from .slick-sort-indicator , 18 from .slick-header-menubutton
+			});
 			let maxColumnTextWidths: number[] = this.getMaxColumnTextWidths(columnDefs, colIndices);
 
 			for (let i = 0; i < columnDefs.length; i++) {

--- a/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
@@ -98,7 +98,7 @@ export class AutoColumnSize<T extends Slick.SlickData> implements Slick.Plugin<T
 
 			let headerWidths: number[] = this.getElementWidths(headerElements);
 			headerWidths = headerWidths.map(width => {
-				return width + 34; // 16 from .slick-sort-indicator , 18 from .slick-header-menubutton
+				return width + 34; // Add to the header width to accommodate for the sort indicator (16px) and the filter menu button (18px)
 			});
 			let maxColumnTextWidths: number[] = this.getMaxColumnTextWidths(columnDefs, colIndices);
 

--- a/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
@@ -7,11 +7,13 @@ import { deepClone } from 'vs/base/common/objects';
 export interface IAutoColumnSizeOptions extends Slick.PluginOptions {
 	maxWidth?: number;
 	autoSizeOnRender?: boolean;
+	extraColumnHeaderWidth?: number;
 }
 
 const defaultOptions: IAutoColumnSizeOptions = {
 	maxWidth: 212,
-	autoSizeOnRender: false
+	autoSizeOnRender: false,
+	extraColumnHeaderWidth: 0
 };
 
 // Set the max number of rows to scan to 10 since the result grid viewport in query editor is usually around 10 rows but can go up to 20 rows for notebooks.
@@ -98,7 +100,7 @@ export class AutoColumnSize<T extends Slick.SlickData> implements Slick.Plugin<T
 
 			let headerWidths: number[] = this.getElementWidths(headerElements);
 			headerWidths = headerWidths.map(width => {
-				return width + 34; // Add to the header width to accommodate for the sort indicator (16px) and the filter menu button (18px)
+				return width + this._options.extraColumnHeaderWidth;
 			});
 			let maxColumnTextWidths: number[] = this.getMaxColumnTextWidths(columnDefs, colIndices);
 

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -86,7 +86,8 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.subscribe(this.grid.onColumnsResized, () => this.columnsResized())
 			.subscribe(this.grid.onKeyDown, async (e: DOMEvent) => { await this.handleGridKeyDown(e as KeyboardEvent); });
 
-		// If auto size columns plugin is on, then the filter dropdown will be added when the auto size plugin sets the columns
+		// If the auto size columns plugin is on, then the filter menu buttons will be added when the auto size plugin calls setColumns.
+		// This prevents us from calling setColumns twice when both plugins are on.
 		if (!this.options.autoSizePluginOn) {
 			this.grid.setColumns(this.grid.getColumns());
 		}

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -34,7 +34,7 @@ export interface ITableFilterOptions {
 	 * The message to be displayed when the filter is disabled and the user tries to open the filter menu.
 	 */
 	disabledFilterMessage?: string;
-	autoSizePluginOn?: boolean
+	shouldSetColumns?: boolean
 }
 
 export interface ITableFilterStyles extends IButtonStyles, IInputBoxStyles, IListStyles, ICountBadgetyles {
@@ -86,9 +86,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.subscribe(this.grid.onColumnsResized, () => this.columnsResized())
 			.subscribe(this.grid.onKeyDown, async (e: DOMEvent) => { await this.handleGridKeyDown(e as KeyboardEvent); });
 
-		// If the auto size columns plugin is on, then the filter menu buttons will be added when the auto size plugin calls setColumns.
-		// This prevents us from calling setColumns twice when both plugins are on.
-		if (!this.options.autoSizePluginOn) {
+		if (!this.options.shouldSetColumns) {
 			this.grid.setColumns(this.grid.getColumns());
 		}
 

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -34,7 +34,11 @@ export interface ITableFilterOptions {
 	 * The message to be displayed when the filter is disabled and the user tries to open the filter menu.
 	 */
 	disabledFilterMessage?: string;
-	shouldSetColumns?: boolean
+	/**
+	 * The columns are refreshed by default to add the filter menu button to the headers.
+	 * Set to false to prevent the grid from being re-drawn multiple times by different plugins.
+	 */
+	refreshColumns?: boolean;
 }
 
 export interface ITableFilterStyles extends IButtonStyles, IInputBoxStyles, IListStyles, ICountBadgetyles {
@@ -45,6 +49,8 @@ interface NotificationProvider {
 }
 
 const ShowFilterText: string = localize('headerFilter.showFilter', "Show Filter");
+
+export const FilterButtonWidth: number = 34;
 
 export class HeaderFilter<T extends Slick.SlickData> {
 
@@ -86,7 +92,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.subscribe(this.grid.onColumnsResized, () => this.columnsResized())
 			.subscribe(this.grid.onKeyDown, async (e: DOMEvent) => { await this.handleGridKeyDown(e as KeyboardEvent); });
 
-		if (!this.options.shouldSetColumns) {
+		if (this.options.refreshColumns || this.options.refreshColumns === undefined) {
 			this.grid.setColumns(this.grid.getColumns());
 		}
 

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -34,6 +34,7 @@ export interface ITableFilterOptions {
 	 * The message to be displayed when the filter is disabled and the user tries to open the filter menu.
 	 */
 	disabledFilterMessage?: string;
+	autoSizePluginOn?: boolean
 }
 
 export interface ITableFilterStyles extends IButtonStyles, IInputBoxStyles, IListStyles, ICountBadgetyles {
@@ -84,7 +85,11 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.subscribe(this.grid.onClick, (e: DOMEvent) => this.handleBodyMouseDown(e as MouseEvent))
 			.subscribe(this.grid.onColumnsResized, () => this.columnsResized())
 			.subscribe(this.grid.onKeyDown, async (e: DOMEvent) => { await this.handleGridKeyDown(e as KeyboardEvent); });
-		this.grid.setColumns(this.grid.getColumns());
+
+		// If auto size columns plugin is on, then the filter dropdown will be added when the auto size plugin sets the columns
+		if (!this.options.autoSizePluginOn) {
+			this.grid.setColumns(this.grid.getColumns());
+		}
 
 		this.disposableStore.add(addDisposableListener(document.body, 'mousedown', e => this.handleBodyMouseDown(e), true));
 		this.disposableStore.add(addDisposableListener(document.body, 'keydown', e => this.handleKeyDown(e)));

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -92,7 +92,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.subscribe(this.grid.onColumnsResized, () => this.columnsResized())
 			.subscribe(this.grid.onKeyDown, async (e: DOMEvent) => { await this.handleGridKeyDown(e as KeyboardEvent); });
 
-		if (this.options.refreshColumns || this.options.refreshColumns === undefined) {
+		if (this.options.refreshColumns !== false) {
 			this.grid.setColumns(this.grid.getColumns());
 		}
 

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -539,7 +539,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		if (this.enableFilteringFeature) {
 			this.filterPlugin = new HeaderFilter(this.contextViewService, this.notificationService, {
 				disabledFilterMessage: localize('resultsGrid.maxRowCountExceeded', "Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'"),
-				autoSizePluginOn: autoSizeOnRender
+				shouldSetColumns: autoSizeOnRender // If the auto size columns plugin is on, then the filter menu buttons will be added when the auto size plugin calls setColumns. This prevents us from calling setColumns twice when both plugins are on.
 			});
 			this._register(attachTableFilterStyler(this.filterPlugin, this.themeService));
 			this.table.registerPlugin(this.filterPlugin);

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -539,7 +539,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		if (this.enableFilteringFeature) {
 			this.filterPlugin = new HeaderFilter(this.contextViewService, this.notificationService, {
 				disabledFilterMessage: localize('resultsGrid.maxRowCountExceeded', "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'"),
-				refreshColumns: !autoSizeOnRender
+				refreshColumns: !autoSizeOnRender // The auto size columns plugin refreshes the columns so we don't need to refresh twice if both plugins are on.
 			});
 			this._register(attachTableFilterStyler(this.filterPlugin, this.themeService));
 			this.table.registerPlugin(this.filterPlugin);

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -509,7 +509,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		this.table.setTableTitle(localize('resultsGrid', "Results grid"));
 		this.table.setSelectionModel(this.selectionModel);
 		this.table.registerPlugin(new MouseWheelSupport());
-		let autoSizeOnRender: boolean = !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns');
+		const autoSizeOnRender: boolean = !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns');
 		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: autoSizeOnRender, maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth'), extraColumnHeaderWidth: this.enableFilteringFeature ? FilterButtonWidth : 0 }));
 		this.table.registerPlugin(copyHandler);
 		this.table.registerPlugin(this.rowNumberColumn);

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -49,7 +49,7 @@ import { ScrollableView, IView } from 'sql/base/browser/ui/scrollableView/scroll
 import { IQueryEditorConfiguration } from 'sql/platform/query/common/query';
 import { Orientation } from 'vs/base/browser/ui/splitview/splitview';
 import { IQueryModelService } from 'sql/workbench/services/query/common/queryModel';
-import { HeaderFilter } from 'sql/base/browser/ui/table/plugins/headerFilter.plugin';
+import { FilterButtonWidth, HeaderFilter } from 'sql/base/browser/ui/table/plugins/headerFilter.plugin';
 import { HybridDataProvider } from 'sql/base/browser/ui/table/hybridDataProvider';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 
@@ -510,7 +510,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		this.table.setSelectionModel(this.selectionModel);
 		this.table.registerPlugin(new MouseWheelSupport());
 		let autoSizeOnRender: boolean = !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns');
-		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: autoSizeOnRender, maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth') }));
+		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: autoSizeOnRender, maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth'), extraColumnHeaderWidth: this.enableFilteringFeature ? FilterButtonWidth : 0 }));
 		this.table.registerPlugin(copyHandler);
 		this.table.registerPlugin(this.rowNumberColumn);
 		this.table.registerPlugin(new AdditionalKeyBindings());
@@ -538,8 +538,8 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		}));
 		if (this.enableFilteringFeature) {
 			this.filterPlugin = new HeaderFilter(this.contextViewService, this.notificationService, {
-				disabledFilterMessage: localize('resultsGrid.maxRowCountExceeded', "Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'"),
-				shouldSetColumns: autoSizeOnRender // If the auto size columns plugin is on, then the filter menu buttons will be added when the auto size plugin calls setColumns. This prevents us from calling setColumns twice when both plugins are on.
+				disabledFilterMessage: localize('resultsGrid.maxRowCountExceeded', "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'"),
+				refreshColumns: !autoSizeOnRender
 			});
 			this._register(attachTableFilterStyler(this.filterPlugin, this.themeService));
 			this.table.registerPlugin(this.filterPlugin);

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -509,7 +509,8 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		this.table.setTableTitle(localize('resultsGrid', "Results grid"));
 		this.table.setSelectionModel(this.selectionModel);
 		this.table.registerPlugin(new MouseWheelSupport());
-		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns'), maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth') }));
+		let autoSizeOnRender: boolean = !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns');
+		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: autoSizeOnRender, maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth') }));
 		this.table.registerPlugin(copyHandler);
 		this.table.registerPlugin(this.rowNumberColumn);
 		this.table.registerPlugin(new AdditionalKeyBindings());
@@ -537,7 +538,8 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		}));
 		if (this.enableFilteringFeature) {
 			this.filterPlugin = new HeaderFilter(this.contextViewService, this.notificationService, {
-				disabledFilterMessage: localize('resultsGrid.maxRowCountExceeded', "Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'")
+				disabledFilterMessage: localize('resultsGrid.maxRowCountExceeded', "Max row count for filtering/sorting has been exceeded. To update it, you can go to User Settings and change the setting: 'queryEditor.results.inMemoryDataProcessingThreshold'"),
+				autoSizePluginOn: autoSizeOnRender
 			});
 			this._register(attachTableFilterStyler(this.filterPlugin, this.themeService));
 			this.table.registerPlugin(this.filterPlugin);


### PR DESCRIPTION
Improve grid rendering performance by checking if auto size columns plugin is on. If it is, then don't call setColumns in filter plugin. This prevents the grid from getting re-rendered twice if both plugins are on.
This had a 20% loading time improvement for a 2.9m notebook with ~50 grids.