### PR TITLE
azdata.Account -> AzureAccount

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -69,7 +69,7 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 		}
 	}
 
-	private getAuthMethod(account?: azdata.Account): AzureAuth {
+	private getAuthMethod(account?: AzureAccount): AzureAuth {
 		if (this.authMappings.size === 1) {
 			return this.authMappings.values().next().value;
 		}
@@ -82,12 +82,12 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 		}
 	}
 
-	initialize(storedAccounts: azdata.Account[]): Thenable<azdata.Account[]> {
+	initialize(storedAccounts: AzureAccount[]): Thenable<AzureAccount[]> {
 		return this._initialize(storedAccounts);
 	}
 
-	private async _initialize(storedAccounts: azdata.Account[]): Promise<azdata.Account[]> {
-		const accounts: azdata.Account[] = [];
+	private async _initialize(storedAccounts: AzureAccount[]): Promise<AzureAccount[]> {
+		const accounts: AzureAccount[] = [];
 		console.log(`Initializing stored accounts ${JSON.stringify(accounts)}`);
 		for (let account of storedAccounts) {
 			const azureAuth = this.getAuthMethod(account);
@@ -103,21 +103,21 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 	}
 
 
-	getSecurityToken(account: azdata.Account, resource: azdata.AzureResource): Thenable<MultiTenantTokenResponse | undefined> {
+	getSecurityToken(account: AzureAccount, resource: azdata.AzureResource): Thenable<MultiTenantTokenResponse | undefined> {
 		return this._getSecurityToken(account, resource);
 	}
 
-	getAccountSecurityToken(account: azdata.Account, tenantId: string, resource: azdata.AzureResource): Thenable<Token | undefined> {
+	getAccountSecurityToken(account: AzureAccount, tenantId: string, resource: azdata.AzureResource): Thenable<Token | undefined> {
 		return this._getAccountSecurityToken(account, tenantId, resource);
 	}
 
-	private async _getAccountSecurityToken(account: azdata.Account, tenantId: string, resource: azdata.AzureResource): Promise<Token | undefined> {
+	private async _getAccountSecurityToken(account: AzureAccount, tenantId: string, resource: azdata.AzureResource): Promise<Token | undefined> {
 		await this.initCompletePromise;
 		const azureAuth = this.getAuthMethod(undefined);
 		return azureAuth?.getAccountSecurityToken(account, tenantId, resource);
 	}
 
-	private async _getSecurityToken(account: azdata.Account, resource: azdata.AzureResource): Promise<MultiTenantTokenResponse | undefined> {
+	private async _getSecurityToken(account: AzureAccount, resource: azdata.AzureResource): Promise<MultiTenantTokenResponse | undefined> {
 		vscode.window.showInformationMessage(localize('azure.deprecatedGetSecurityToken', "A call was made to azdata.accounts.getSecurityToken, this method is deprecated and will be removed in future releases. Please use getAccountSecurityToken instead."));
 		const azureAccount = account as AzureAccount;
 		const response: MultiTenantTokenResponse = {};
@@ -128,11 +128,11 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 		return response;
 	}
 
-	prompt(): Thenable<azdata.Account | azdata.PromptFailedResult> {
+	prompt(): Thenable<AzureAccount | azdata.PromptFailedResult> {
 		return this._prompt();
 	}
 
-	private async _prompt(): Promise<azdata.Account | azdata.PromptFailedResult> {
+	private async _prompt(): Promise<AzureAccount | azdata.PromptFailedResult> {
 		const noAuthSelected = localize('azure.NoAuthMethod.Selected', "No Azure auth method selected. You must select what method of authentication you want to use.");
 		const noAuthAvailable = localize('azure.NoAuthMethod.Available', "No Azure auth method available. You must enable the auth methods in ADS configuration.");
 
@@ -170,7 +170,7 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 		return pick.azureAuth.startLogin();
 	}
 
-	refresh(account: azdata.Account): Thenable<azdata.Account | azdata.PromptFailedResult> {
+	refresh(account: AzureAccount): Thenable<AzureAccount | azdata.PromptFailedResult> {
 		return this.prompt();
 	}
 

--- a/extensions/azurecore/src/azureResource/azure-resource.d.ts
+++ b/extensions/azurecore/src/azureResource/azure-resource.d.ts
@@ -5,8 +5,9 @@
 
 declare module 'azureResource' {
 	import { TreeDataProvider } from 'vscode';
-	import { DataProvider, Account, TreeItem } from 'azdata';
+	import { DataProvider, TreeItem } from 'azdata';
 	import { BlobItem } from '@azure/storage-blob';
+	import { AzureAccount } from 'azurecore';
 
 	export namespace azureResource {
 
@@ -38,7 +39,7 @@ declare module 'azureResource' {
 		}
 
 		export interface IAzureResourceNode {
-			readonly account: Account;
+			readonly account: AzureAccount;
 			readonly subscription: AzureResourceSubscription;
 			readonly tenantId: string;
 			readonly treeItem: TreeItem;

--- a/extensions/azurecore/src/azureResource/interfaces.ts
+++ b/extensions/azurecore/src/azureResource/interfaces.ts
@@ -5,8 +5,6 @@
 
 import * as msRest from '@azure/ms-rest-js';
 
-import { Account } from 'azdata';
-
 import { azureResource } from 'azureResource';
 import { AzureAccount, Tenant } from 'azurecore';
 
@@ -22,8 +20,8 @@ export interface IAzureResourceSubscriptionService {
 }
 
 export interface IAzureResourceSubscriptionFilterService {
-	getSelectedSubscriptions(account: Account): Promise<azureResource.AzureResourceSubscription[]>;
-	saveSelectedSubscriptions(account: Account, selectedSubscriptions: azureResource.AzureResourceSubscription[]): Promise<void>;
+	getSelectedSubscriptions(account: AzureAccount): Promise<azureResource.AzureResourceSubscription[]>;
+	saveSelectedSubscriptions(account: AzureAccount, selectedSubscriptions: azureResource.AzureResourceSubscription[]): Promise<void>;
 }
 
 export interface IAzureTerminalService {
@@ -45,5 +43,5 @@ export interface IAzureResourceNodeWithProviderId {
 }
 
 export interface IAzureResourceService<T extends azureResource.AzureResource> {
-	getResources(subscriptions: azureResource.AzureResourceSubscription[], credential: msRest.ServiceClientCredentials, account: Account): Promise<T[]>;
+	getResources(subscriptions: azureResource.AzureResourceSubscription[], credential: msRest.ServiceClientCredentials, account: AzureAccount): Promise<T[]>;
 }

--- a/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/azuremonitor/azuremonitorTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, Account } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azureResource';
+import { AzureAccount } from 'azurecore';
 
 export class AzureMonitorTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.AzureMonitorContainer';
@@ -26,7 +27,7 @@ export class AzureMonitorTreeDataProvider extends ResourceTreeDataProviderBase<a
 	}
 
 
-	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: Account): TreeItem {
+	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
 			id: `LogAnalytics_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${AzureMonitorTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,

--- a/extensions/azurecore/src/azureResource/providers/database/databaseService.ts
+++ b/extensions/azurecore/src/azureResource/providers/database/databaseService.ts
@@ -9,13 +9,13 @@ import { IAzureResourceService } from '../../interfaces';
 import { serversQuery, DbServerGraphData } from '../databaseServer/databaseServerService';
 import { ResourceGraphClient } from '@azure/arm-resourcegraph';
 import { queryGraphResources, GraphData } from '../resourceTreeDataProviderBase';
-import { Account } from 'azdata';
+import { AzureAccount } from 'azurecore';
 
 interface DatabaseGraphData extends GraphData {
 	kind: string;
 }
 export class AzureResourceDatabaseService implements IAzureResourceService<azureResource.AzureResourceDatabase> {
-	public async getResources(subscriptions: azureResource.AzureResourceSubscription[], credential: ServiceClientCredentials, account: Account): Promise<azureResource.AzureResourceDatabase[]> {
+	public async getResources(subscriptions: azureResource.AzureResourceSubscription[], credential: ServiceClientCredentials, account: AzureAccount): Promise<azureResource.AzureResourceDatabase[]> {
 		const databases: azureResource.AzureResourceDatabase[] = [];
 		const resourceClient = new ResourceGraphClient(credential, { baseUri: account.properties.providerSettings.settings.armResource.endpoint });
 

--- a/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TreeItem, ExtensionNodeType, Account } from 'azdata';
+import { TreeItem, ExtensionNodeType } from 'azdata';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { AzureResourceItemType } from '../../../azureResource/constants';
 import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
+import { AzureAccount } from 'azurecore';
 
 export class AzureResourceDatabaseTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabase> {
 
@@ -25,7 +26,7 @@ export class AzureResourceDatabaseTreeDataProvider extends ResourceTreeDataProvi
 	) {
 		super(databaseService);
 	}
-	protected getTreeItemForResource(database: azureResource.AzureResourceDatabase, account: Account): TreeItem {
+	protected getTreeItemForResource(database: azureResource.AzureResourceDatabase, account: AzureAccount): TreeItem {
 		return {
 			id: `databaseServer_${database.serverFullName}.database_${database.name}`,
 			label: this.browseConnectionMode ? `${database.serverName}/${database.name} (${AzureResourceDatabaseTreeDataProvider.containerLabel}, ${database.subscription.name})` : `${database.name} (${database.serverName})`,

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, Account } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azureResource';
+import { AzureAccount } from 'azurecore';
 
 export class AzureResourceDatabaseServerTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.databaseServer.treeDataProvider.databaseServerContainer';
@@ -26,7 +27,7 @@ export class AzureResourceDatabaseServerTreeDataProvider extends ResourceTreeDat
 	}
 
 
-	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: Account): TreeItem {
+	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
 			id: `databaseServer_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${AzureResourceDatabaseServerTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,

--- a/extensions/azurecore/src/azureResource/providers/kusto/kustoTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/kusto/kustoTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, Account } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azureResource';
+import { AzureAccount } from 'azurecore';
 
 export class KustoTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.KustoContainer';
@@ -26,7 +27,7 @@ export class KustoTreeDataProvider extends ResourceTreeDataProviderBase<azureRes
 	}
 
 
-	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: Account): TreeItem {
+	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
 			id: `Kusto_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${KustoTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, Account } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azureResource';
+import { AzureAccount } from 'azurecore';
 
 export class PostgresServerArcTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.postgresArcServer.treeDataProvider.postgresServerContainer';
@@ -26,7 +27,7 @@ export class PostgresServerArcTreeDataProvider extends ResourceTreeDataProviderB
 	}
 
 
-	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: Account): TreeItem {
+	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
 			id: `databaseServer_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${PostgresServerArcTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,

--- a/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, Account } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azureResource';
+import { AzureAccount } from 'azurecore';
 
 export class PostgresServerTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.databaseServer.treeDataProvider.postgresServerContainer';
@@ -26,7 +27,7 @@ export class PostgresServerTreeDataProvider extends ResourceTreeDataProviderBase
 	}
 
 
-	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: Account): TreeItem {
+	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
 			id: `databaseServer_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${PostgresServerTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,

--- a/extensions/azurecore/src/azureResource/providers/resourceTreeDataProviderBase.ts
+++ b/extensions/azurecore/src/azureResource/providers/resourceTreeDataProviderBase.ts
@@ -10,6 +10,7 @@ import { azureResource } from 'azureResource';
 import { IAzureResourceService } from '../interfaces';
 import { AzureResourceErrorMessageUtil } from '../utils';
 import { ResourceGraphClient } from '@azure/arm-resourcegraph';
+import { AzureAccount } from 'azurecore';
 
 export abstract class ResourceTreeDataProviderBase<T extends azureResource.AzureResource> implements azureResource.IAzureResourceTreeDataProvider {
 	public browseConnectionMode: boolean = false;
@@ -49,7 +50,7 @@ export abstract class ResourceTreeDataProviderBase<T extends azureResource.Azure
 		return resources;
 	}
 
-	protected abstract getTreeItemForResource(resource: T, account: azdata.Account): azdata.TreeItem;
+	protected abstract getTreeItemForResource(resource: T, account: AzureAccount): azdata.TreeItem;
 
 	protected abstract createContainerNode(): azureResource.IAzureResourceNode;
 }
@@ -121,7 +122,7 @@ export abstract class ResourceServiceBase<T extends GraphData, U extends azureRe
 	 */
 	protected abstract get query(): string;
 
-	public async getResources(subscriptions: azureResource.AzureResourceSubscription[], credential: msRest.ServiceClientCredentials, account: azdata.Account): Promise<U[]> {
+	public async getResources(subscriptions: azureResource.AzureResourceSubscription[], credential: msRest.ServiceClientCredentials, account: AzureAccount): Promise<U[]> {
 		const convertedResources: U[] = [];
 		const resourceClient = new ResourceGraphClient(credential, { baseUri: account.properties.providerSettings.settings.armResource.endpoint });
 		const graphResources = await queryGraphResources<T>(resourceClient, subscriptions, this.query);

--- a/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, Account } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azureResource';
+import { AzureAccount } from 'azurecore';
 
 export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.sqlInstanceContainer';
@@ -26,7 +27,7 @@ export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<az
 	}
 
 
-	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: Account): TreeItem {
+	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
 			id: `sqlInstance_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${SqlInstanceTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionNodeType, TreeItem, Account } from 'azdata';
+import { ExtensionNodeType, TreeItem } from 'azdata';
 import { TreeItemCollapsibleState, ExtensionContext } from 'vscode';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -13,6 +13,7 @@ import { generateGuid } from '../../utils';
 import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from 'azureResource';
+import { AzureAccount } from 'azurecore';
 
 export class SqlInstanceArcTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.sqlInstanceArcContainer';
@@ -26,7 +27,7 @@ export class SqlInstanceArcTreeDataProvider extends ResourceTreeDataProviderBase
 	}
 
 
-	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: Account): TreeItem {
+	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer, account: AzureAccount): TreeItem {
 		return {
 			id: `sqlInstance_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: this.browseConnectionMode ? `${databaseServer.name} (${SqlInstanceArcTreeDataProvider.containerLabel}, ${databaseServer.subscription.name})` : databaseServer.name,

--- a/extensions/azurecore/src/azureResource/resourceService.ts
+++ b/extensions/azurecore/src/azureResource/resourceService.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { extensions, TreeItem } from 'vscode';
-import { Account } from 'azdata';
 
 import { azureResource } from 'azureResource';
 import { IAzureResourceNodeWithProviderId } from './interfaces';
+import { AzureAccount } from 'azurecore';
 
 export class AzureResourceService {
 	private _areResourceProvidersLoaded: boolean = false;
@@ -33,7 +33,7 @@ export class AzureResourceService {
 		this._areResourceProvidersLoaded = false;
 	}
 
-	public async getRootChildren(resourceProviderId: string, account: Account, subscription: azureResource.AzureResourceSubscription, tenatId: string): Promise<IAzureResourceNodeWithProviderId[]> {
+	public async getRootChildren(resourceProviderId: string, account: AzureAccount, subscription: azureResource.AzureResourceSubscription, tenatId: string): Promise<IAzureResourceNodeWithProviderId[]> {
 		await this.ensureResourceProvidersRegistered();
 
 		if (!(resourceProviderId in this._resourceProviders)) {

--- a/extensions/azurecore/src/azureResource/services/subscriptionFilterService.ts
+++ b/extensions/azurecore/src/azureResource/services/subscriptionFilterService.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Account } from 'azdata';
-
+import { AzureAccount } from 'azurecore';
 import { azureResource } from 'azureResource';
 import { IAzureResourceSubscriptionFilterService, IAzureResourceCacheService } from '../interfaces';
 
@@ -21,7 +20,7 @@ export class AzureResourceSubscriptionFilterService implements IAzureResourceSub
 		this._cacheKey = this._cacheService.generateKey('selectedSubscriptions');
 	}
 
-	public async getSelectedSubscriptions(account: Account): Promise<azureResource.AzureResourceSubscription[]> {
+	public async getSelectedSubscriptions(account: AzureAccount): Promise<azureResource.AzureResourceSubscription[]> {
 		let selectedSubscriptions: azureResource.AzureResourceSubscription[] = [];
 
 		const cache = this._cacheService.get<AzureResourceSelectedSubscriptionsCache>(this._cacheKey);
@@ -32,7 +31,7 @@ export class AzureResourceSubscriptionFilterService implements IAzureResourceSub
 		return selectedSubscriptions;
 	}
 
-	public async saveSelectedSubscriptions(account: Account, selectedSubscriptions: azureResource.AzureResourceSubscription[]): Promise<void> {
+	public async saveSelectedSubscriptions(account: AzureAccount, selectedSubscriptions: azureResource.AzureResourceSubscription[]): Promise<void> {
 		let selectedSubscriptionsCache: { [accountId: string]: azureResource.AzureResourceSubscription[] } = {};
 
 		const cache = this._cacheService.get<AzureResourceSelectedSubscriptionsCache>(this._cacheKey);

--- a/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
+++ b/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
@@ -17,11 +17,12 @@ import { AzureResourceErrorMessageUtil, equals } from '../utils';
 import { IAzureResourceTreeChangeHandler } from './treeChangeHandler';
 import { FlatAccountTreeNode } from './flatAccountTreeNode';
 import { Logger } from '../../utils/Logger';
+import { AzureAccount } from 'azurecore';
 
 export class ConnectionDialogTreeProvider implements vscode.TreeDataProvider<TreeNode>, IAzureResourceTreeChangeHandler {
 	public isSystemInitialized: boolean = false;
 
-	private accounts: azdata.Account[];
+	private accounts: AzureAccount[];
 	private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode>();
 	private loadingAccountsPromise: Promise<void>;
 

--- a/extensions/azurecore/src/azureResource/tree/subscriptionTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/subscriptionTreeNode.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TreeItem, TreeItemCollapsibleState } from 'vscode';
-import { Account, NodeInfo } from 'azdata';
+import { NodeInfo } from 'azdata';
 import { AppContext } from '../../appContext';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -19,10 +19,11 @@ import { AzureResourceMessageTreeNode } from '../messageTreeNode';
 import { AzureResourceErrorMessageUtil } from '../utils';
 import { AzureResourceService } from '../resourceService';
 import { AzureResourceResourceTreeNode } from '../resourceTreeNode';
+import { AzureAccount } from 'azurecore';
 
 export class AzureResourceSubscriptionTreeNode extends AzureResourceContainerTreeNodeBase {
 	public constructor(
-		public readonly account: Account,
+		public readonly account: AzureAccount,
 		public readonly subscription: azureResource.AzureResourceSubscription,
 		public readonly tenatId: string,
 		appContext: AppContext,

--- a/extensions/azurecore/src/azureResource/tree/treeProvider.ts
+++ b/extensions/azurecore/src/azureResource/tree/treeProvider.ts
@@ -16,12 +16,13 @@ import { AzureResourceMessageTreeNode } from '../messageTreeNode';
 import { AzureResourceContainerTreeNodeBase } from './baseTreeNodes';
 import { AzureResourceErrorMessageUtil, equals } from '../utils';
 import { IAzureResourceTreeChangeHandler } from './treeChangeHandler';
+import { AzureAccount } from 'azurecore';
 
 
 export class AzureResourceTreeProvider implements vscode.TreeDataProvider<TreeNode>, IAzureResourceTreeChangeHandler {
 	public isSystemInitialized: boolean = false;
 
-	private accounts: azdata.Account[];
+	private accounts: AzureAccount[];
 	private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode>();
 	private loadingAccountsPromise: Promise<void>;
 

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -107,7 +107,7 @@ export function equals(one: any, other: any): boolean {
 	return true;
 }
 
-export async function getResourceGroups(appContext: AppContext, account?: azdata.Account, subscription?: azureResource.AzureResourceSubscription, ignoreErrors: boolean = false): Promise<GetResourceGroupsResult> {
+export async function getResourceGroups(appContext: AppContext, account?: AzureAccount, subscription?: azureResource.AzureResourceSubscription, ignoreErrors: boolean = false): Promise<GetResourceGroupsResult> {
 	const result: GetResourceGroupsResult = { resourceGroups: [], errors: [] };
 	if (!account?.properties?.tenants || !Array.isArray(account.properties.tenants) || !subscription) {
 		const error = new Error(invalidAzureAccount);
@@ -143,7 +143,7 @@ export async function getResourceGroups(appContext: AppContext, account?: azdata
 	return result;
 }
 
-export async function getLocations(appContext: AppContext, account?: azdata.Account, subscription?: azureResource.AzureResourceSubscription, ignoreErrors: boolean = false): Promise<GetLocationsResult> {
+export async function getLocations(appContext: AppContext, account?: AzureAccount, subscription?: azureResource.AzureResourceSubscription, ignoreErrors: boolean = false): Promise<GetLocationsResult> {
 	const result: GetLocationsResult = { locations: [], errors: [] };
 	if (!account?.properties?.tenants || !Array.isArray(account.properties.tenants) || !subscription) {
 		const error = new Error(invalidAzureAccount);
@@ -178,7 +178,7 @@ export async function getLocations(appContext: AppContext, account?: azdata.Acco
 }
 
 export async function runResourceQuery<T extends azureResource.AzureGraphResource>(
-	account: azdata.Account,
+	account: AzureAccount,
 	subscriptions: azureResource.AzureResourceSubscription[],
 	ignoreErrors: boolean = false,
 	query: string): Promise<ResourceQueryResult<T>> {
@@ -292,7 +292,7 @@ export async function getSubscriptions(appContext: AppContext, account?: AzureAc
 	return result;
 }
 
-export async function getSelectedSubscriptions(appContext: AppContext, account?: azdata.Account, ignoreErrors: boolean = false): Promise<GetSubscriptionsResult> {
+export async function getSelectedSubscriptions(appContext: AppContext, account?: AzureAccount, ignoreErrors: boolean = false): Promise<GetSubscriptionsResult> {
 	const result: GetSubscriptionsResult = { subscriptions: [], errors: [] };
 	if (!account?.properties?.tenants || !Array.isArray(account.properties.tenants)) {
 		const error = new Error(invalidAzureAccount);
@@ -331,7 +331,7 @@ export async function getSelectedSubscriptions(appContext: AppContext, account?:
  * @param host Use this to override the host. The default host is https://management.azure.com
  * @param requestHeaders Provide additional request headers
  */
-export async function makeHttpRequest(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, path: string, requestType: HttpRequestMethod, requestBody?: any, ignoreErrors: boolean = false, host: string = 'https://management.azure.com', requestHeaders: { [key: string]: string } = {}): Promise<AzureRestResponse> {
+export async function makeHttpRequest(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, path: string, requestType: HttpRequestMethod, requestBody?: any, ignoreErrors: boolean = false, host: string = 'https://management.azure.com', requestHeaders: { [key: string]: string } = {}): Promise<AzureRestResponse> {
 	const result: AzureRestResponse = { response: {}, errors: [] };
 
 	if (!account?.properties?.tenants || !Array.isArray(account.properties.tenants)) {
@@ -430,7 +430,7 @@ export async function makeHttpRequest(account: azdata.Account, subscription: azu
 	return result;
 }
 
-export async function getManagedDatabases(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, managedInstance: azureResource.AzureSqlManagedInstance, ignoreErrors: boolean): Promise<GetManagedDatabasesResult> {
+export async function getManagedDatabases(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, managedInstance: azureResource.AzureSqlManagedInstance, ignoreErrors: boolean): Promise<GetManagedDatabasesResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${managedInstance.resourceGroup}/providers/Microsoft.Sql/managedInstances/${managedInstance.name}/databases?api-version=2020-02-02-preview`;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors);
 	return {
@@ -439,7 +439,7 @@ export async function getManagedDatabases(account: azdata.Account, subscription:
 	};
 }
 
-export async function getBlobContainers(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetBlobContainersResult> {
+export async function getBlobContainers(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetBlobContainersResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/blobServices/default/containers?api-version=2019-06-01`;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors);
 	return {
@@ -448,7 +448,7 @@ export async function getBlobContainers(account: azdata.Account, subscription: a
 	};
 }
 
-export async function getFileShares(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetFileSharesResult> {
+export async function getFileShares(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetFileSharesResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/fileServices/default/shares?api-version=2019-06-01`;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.GET, undefined, ignoreErrors);
 	return {
@@ -457,7 +457,7 @@ export async function getFileShares(account: azdata.Account, subscription: azure
 	};
 }
 
-export async function createResourceGroup(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, resourceGroupName: string, location: string, ignoreErrors: boolean): Promise<CreateResourceGroupResult> {
+export async function createResourceGroup(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, resourceGroupName: string, location: string, ignoreErrors: boolean): Promise<CreateResourceGroupResult> {
 	const path = `/subscriptions/${subscription.id}/resourcegroups/${resourceGroupName}?api-version=2021-04-01`;
 	const requestBody = {
 		location: location
@@ -469,7 +469,7 @@ export async function createResourceGroup(account: azdata.Account, subscription:
 	};
 }
 
-export async function getStorageAccountAccessKey(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetStorageAccountAccessKeyResult> {
+export async function getStorageAccountAccessKey(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetStorageAccountAccessKeyResult> {
 	const path = `/subscriptions/${subscription.id}/resourceGroups/${storageAccount.resourceGroup}/providers/Microsoft.Storage/storageAccounts/${storageAccount.name}/listKeys?api-version=2019-06-01`;
 	const response = await makeHttpRequest(account, subscription, path, HttpRequestMethod.POST, undefined, ignoreErrors);
 	return {
@@ -479,7 +479,7 @@ export async function getStorageAccountAccessKey(account: azdata.Account, subscr
 	};
 }
 
-export async function getBlobs(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, containerName: string, ignoreErrors: boolean): Promise<GetBlobsResult> {
+export async function getBlobs(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, containerName: string, ignoreErrors: boolean): Promise<GetBlobsResult> {
 	const result: GetBlobsResult = { blobs: [], errors: [] };
 	const storageKeys = await getStorageAccountAccessKey(account, subscription, storageAccount, ignoreErrors);
 	if (!ignoreErrors) {

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -263,19 +263,19 @@ declare module 'azurecore' {
 	}
 
 	export interface IExtension {
-		getSubscriptions(account?: azdata.Account, ignoreErrors?: boolean, selectedOnly?: boolean): Promise<GetSubscriptionsResult>;
-		getResourceGroups(account?: azdata.Account, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<GetResourceGroupsResult>;
-		getLocations(account?: azdata.Account, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<GetLocationsResult>;
-		getSqlManagedInstances(account: azdata.Account, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetSqlManagedInstancesResult>;
-		getManagedDatabases(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, managedInstance: azureResource.AzureSqlManagedInstance, ignoreErrors?: boolean): Promise<GetManagedDatabasesResult>;
-		getSqlServers(account: azdata.Account, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetSqlServersResult>;
-		getSqlVMServers(account: azdata.Account, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetSqlVMServersResult>;
-		getStorageAccounts(account: azdata.Account, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetStorageAccountResult>;
-		getBlobContainers(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors?: boolean): Promise<GetBlobContainersResult>;
-		getFileShares(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors?: boolean): Promise<GetFileSharesResult>;
-		createResourceGroup(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, resourceGroupName: string, location: string, ignoreErrors?: boolean): Promise<CreateResourceGroupResult>;
-		getStorageAccountAccessKey(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors?: boolean): Promise<GetStorageAccountAccessKeyResult>;
-		getBlobs(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, containerName: string, ignoreErrors?: boolean): Promise<GetBlobsResult>;
+		getSubscriptions(account?: AzureAccount, ignoreErrors?: boolean, selectedOnly?: boolean): Promise<GetSubscriptionsResult>;
+		getResourceGroups(account?: AzureAccount, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<GetResourceGroupsResult>;
+		getLocations(account?: AzureAccount, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<GetLocationsResult>;
+		getSqlManagedInstances(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetSqlManagedInstancesResult>;
+		getManagedDatabases(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, managedInstance: azureResource.AzureSqlManagedInstance, ignoreErrors?: boolean): Promise<GetManagedDatabasesResult>;
+		getSqlServers(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetSqlServersResult>;
+		getSqlVMServers(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetSqlVMServersResult>;
+		getStorageAccounts(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors?: boolean): Promise<GetStorageAccountResult>;
+		getBlobContainers(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors?: boolean): Promise<GetBlobContainersResult>;
+		getFileShares(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors?: boolean): Promise<GetFileSharesResult>;
+		createResourceGroup(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, resourceGroupName: string, location: string, ignoreErrors?: boolean): Promise<CreateResourceGroupResult>;
+		getStorageAccountAccessKey(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, ignoreErrors?: boolean): Promise<GetStorageAccountAccessKeyResult>;
+		getBlobs(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, storageAccount: azureResource.AzureGraphResource, containerName: string, ignoreErrors?: boolean): Promise<GetBlobsResult>;
 		/**
 		 * Makes Azure REST requests to create, retrieve, update or delete access to azure service's resources.
 		 * For reference to different service URLs, See https://docs.microsoft.com/rest/api/?view=Azure
@@ -288,7 +288,7 @@ declare module 'azurecore' {
 		 * @param host Use this to override the host. The default host is https://management.azure.com
 		 * @param requestHeaders Provide additional request headers
 		 */
-		makeAzureRestRequest(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, path: string, requestType: HttpRequestMethod, requestBody?: any, ignoreErrors?: boolean, host?: string, requestHeaders?: { [key: string]: string }): Promise<AzureRestResponse>;
+		makeAzureRestRequest(account: AzureAccount, subscription: azureResource.AzureResourceSubscription, path: string, requestType: HttpRequestMethod, requestBody?: any, ignoreErrors?: boolean, host?: string, requestHeaders?: { [key: string]: string }): Promise<AzureRestResponse>;
 		/**
 		 * Converts a region value (@see AzureRegion) into the localized Display Name
 		 * @param region The region value
@@ -296,7 +296,7 @@ declare module 'azurecore' {
 		getRegionDisplayName(region?: string): string;
 		provideResources(): azureResource.IAzureResourceProvider[];
 
-		runGraphQuery<T extends azureResource.AzureGraphResource>(account: azdata.Account, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors: boolean, query: string): Promise<ResourceQueryResult<T>>;
+		runGraphQuery<T extends azureResource.AzureGraphResource>(account: AzureAccount, subscriptions: azureResource.AzureResourceSubscription[], ignoreErrors: boolean, query: string): Promise<ResourceQueryResult<T>>;
 	}
 
 	export type GetSubscriptionsResult = { subscriptions: azureResource.AzureResourceSubscription[], errors: Error[] };

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -117,7 +117,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 				if (triggerValue === '') {
 					return '';
 				}
-				let accounts: azdata.Account[] = [];
+				let accounts: azurecore.AzureAccount[] = [];
 				try {
 					accounts = await azdata.accounts.getAllAccounts();
 				} catch (err) {
@@ -148,8 +148,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 				? azureResourceUtils.getSelectedSubscriptions(appContext, account, ignoreErrors)
 				: azureResourceUtils.getSubscriptions(appContext, account, ignoreErrors);
 		},
-		getResourceGroups(account?: azdata.Account, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<azurecore.GetResourceGroupsResult> { return azureResourceUtils.getResourceGroups(appContext, account, subscription, ignoreErrors); },
-		getLocations(account?: azdata.Account,
+		getResourceGroups(account?: azurecore.AzureAccount, subscription?: azureResource.AzureResourceSubscription, ignoreErrors?: boolean): Promise<azurecore.GetResourceGroupsResult> { return azureResourceUtils.getResourceGroups(appContext, account, subscription, ignoreErrors); },
+		getLocations(account?: azurecore.AzureAccount,
 			subscription?: azureResource.AzureResourceSubscription,
 			ignoreErrors?: boolean): Promise<azurecore.GetLocationsResult> {
 			return azureResourceUtils.getLocations(appContext, account, subscription, ignoreErrors);
@@ -172,65 +172,65 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 			}
 			return providers;
 		},
-		getSqlManagedInstances(account: azdata.Account,
+		getSqlManagedInstances(account: azurecore.AzureAccount,
 			subscriptions: azureResource.AzureResourceSubscription[],
 			ignoreErrors: boolean): Promise<azurecore.GetSqlManagedInstancesResult> {
 			return azureResourceUtils.runResourceQuery(account, subscriptions, ignoreErrors, `where type == "${azureResource.AzureResourceType.sqlManagedInstance}"`);
 		},
-		getManagedDatabases(account: azdata.Account,
+		getManagedDatabases(account: azurecore.AzureAccount,
 			subscription: azureResource.AzureResourceSubscription,
 			managedInstance: azureResource.AzureSqlManagedInstance,
 			ignoreErrors: boolean): Promise<azurecore.GetManagedDatabasesResult> {
 			return azureResourceUtils.getManagedDatabases(account, subscription, managedInstance, ignoreErrors);
 		},
-		getSqlServers(account: azdata.Account,
+		getSqlServers(account: azurecore.AzureAccount,
 			subscriptions: azureResource.AzureResourceSubscription[],
 			ignoreErrors: boolean): Promise<azurecore.GetSqlServersResult> {
 			return azureResourceUtils.runResourceQuery(account, subscriptions, ignoreErrors, `where type == "${azureResource.AzureResourceType.sqlServer}"`);
 		},
-		getSqlVMServers(account: azdata.Account,
+		getSqlVMServers(account: azurecore.AzureAccount,
 			subscriptions: azureResource.AzureResourceSubscription[],
 			ignoreErrors: boolean): Promise<azurecore.GetSqlVMServersResult> {
 			return azureResourceUtils.runResourceQuery(account, subscriptions, ignoreErrors, `where type == "${azureResource.AzureResourceType.virtualMachines}" and properties.storageProfile.imageReference.publisher == "microsoftsqlserver"`);
 		},
-		getStorageAccounts(account: azdata.Account,
+		getStorageAccounts(account: azurecore.AzureAccount,
 			subscriptions: azureResource.AzureResourceSubscription[],
 			ignoreErrors: boolean): Promise<azurecore.GetStorageAccountResult> {
 			return azureResourceUtils.runResourceQuery(account, subscriptions, ignoreErrors, `where type == "${azureResource.AzureResourceType.storageAccount}"`);
 		},
-		getBlobContainers(account: azdata.Account,
+		getBlobContainers(account: azurecore.AzureAccount,
 			subscription: azureResource.AzureResourceSubscription,
 			storageAccount: azureResource.AzureGraphResource,
 			ignoreErrors: boolean): Promise<azurecore.GetBlobContainersResult> {
 			return azureResourceUtils.getBlobContainers(account, subscription, storageAccount, ignoreErrors);
 		},
-		getFileShares(account: azdata.Account,
+		getFileShares(account: azurecore.AzureAccount,
 			subscription: azureResource.AzureResourceSubscription,
 			storageAccount: azureResource.AzureGraphResource,
 			ignoreErrors: boolean): Promise<azurecore.GetFileSharesResult> {
 			return azureResourceUtils.getFileShares(account, subscription, storageAccount, ignoreErrors);
 		},
-		getStorageAccountAccessKey(account: azdata.Account,
+		getStorageAccountAccessKey(account: azurecore.AzureAccount,
 			subscription: azureResource.AzureResourceSubscription,
 			storageAccount: azureResource.AzureGraphResource,
 			ignoreErrors: boolean): Promise<azurecore.GetStorageAccountAccessKeyResult> {
 			return azureResourceUtils.getStorageAccountAccessKey(account, subscription, storageAccount, ignoreErrors);
 		},
-		getBlobs(account: azdata.Account,
+		getBlobs(account: azurecore.AzureAccount,
 			subscription: azureResource.AzureResourceSubscription,
 			storageAccount: azureResource.AzureGraphResource,
 			containerName: string,
 			ignoreErrors: boolean): Promise<azurecore.GetBlobsResult> {
 			return azureResourceUtils.getBlobs(account, subscription, storageAccount, containerName, ignoreErrors);
 		},
-		createResourceGroup(account: azdata.Account,
+		createResourceGroup(account: azurecore.AzureAccount,
 			subscription: azureResource.AzureResourceSubscription,
 			resourceGroupName: string,
 			location: string,
 			ignoreErrors: boolean): Promise<azurecore.CreateResourceGroupResult> {
 			return azureResourceUtils.createResourceGroup(account, subscription, resourceGroupName, location, ignoreErrors);
 		},
-		makeAzureRestRequest(account: azdata.Account,
+		makeAzureRestRequest(account: azurecore.AzureAccount,
 			subscription: azureResource.AzureResourceSubscription,
 			path: string,
 			requestType: azurecore.HttpRequestMethod,
@@ -241,7 +241,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 			return azureResourceUtils.makeHttpRequest(account, subscription, path, requestType, requestBody, ignoreErrors, host, requestHeaders);
 		},
 		getRegionDisplayName: utils.getRegionDisplayName,
-		runGraphQuery<T extends azureResource.AzureGraphResource>(account: azdata.Account,
+		runGraphQuery<T extends azureResource.AzureGraphResource>(account: azurecore.AzureAccount,
 			subscriptions: azureResource.AzureResourceSubscription[],
 			ignoreErrors: boolean,
 			query: string): Promise<azurecore.ResourceQueryResult<T>> {

--- a/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
@@ -23,6 +23,7 @@ import { AzureResourceSubscriptionTreeNode } from '../../../azureResource/tree/s
 import { AzureResourceItemType, AzureResourceServiceNames } from '../../../azureResource/constants';
 import { AzureResourceMessageTreeNode } from '../../../azureResource/messageTreeNode';
 import { generateGuid } from '../../../azureResource/utils';
+import { AzureAccount } from 'azurecore';
 
 // Mock services
 let mockExtensionContext: TypeMoq.IMock<vscode.ExtensionContext>;
@@ -35,7 +36,7 @@ let mockTreeChangeHandler: TypeMoq.IMock<IAzureResourceTreeChangeHandler>;
 // Mock test data
 const mockTenantId = 'mock_tenant_id';
 
-const mockAccount: azdata.Account = {
+const mockAccount: AzureAccount = {
 	key: {
 		accountId: '97915f6d-84fa-4926-b60c-38db64327ad7',
 		providerId: 'mock_provider'
@@ -50,9 +51,16 @@ const mockAccount: azdata.Account = {
 	properties: {
 		tenants: [
 			{
-				id: mockTenantId
+				id: mockTenantId,
+				displayName: 'Mock Tenant'
 			}
-		]
+		],
+		providerSettings: {
+			settings: { },
+			id: 'azure',
+			displayName: 'Azure'
+		},
+		isMsAccount: true
 	},
 	isStale: false
 };

--- a/extensions/azurecore/src/test/azureResource/tree/subscriptionTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/subscriptionTreeNode.test.ts
@@ -5,7 +5,6 @@
 
 import * as should from 'should';
 import * as TypeMoq from 'typemoq';
-import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import 'mocha';
 import { AppContext } from '../../../appContext';
@@ -18,6 +17,7 @@ import { AzureResourceService } from '../../../azureResource/resourceService';
 import { AzureResourceResourceTreeNode } from '../../../azureResource/resourceTreeNode';
 import { IAzureResourceCacheService } from '../../../azureResource/interfaces';
 import { generateGuid } from '../../../azureResource/utils';
+import { AzureAccount } from 'azurecore';
 
 // Mock services
 let appContext: AppContext;
@@ -28,7 +28,7 @@ let mockCacheService: TypeMoq.IMock<IAzureResourceCacheService>;
 let mockTreeChangeHandler: TypeMoq.IMock<IAzureResourceTreeChangeHandler>;
 
 // Mock test data
-const mockAccount: azdata.Account = {
+const mockAccount: AzureAccount = {
 	key: {
 		accountId: 'mock_account',
 		providerId: 'mock_provider'

--- a/extensions/azurecore/src/test/azureResource/tree/treeProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/treeProvider.test.ts
@@ -17,6 +17,7 @@ import { AzureResourceAccountTreeNode } from '../../../azureResource/tree/accoun
 import { AzureResourceAccountNotSignedInTreeNode } from '../../../azureResource/tree/accountNotSignedInTreeNode';
 import { AzureResourceServiceNames } from '../../../azureResource/constants';
 import { generateGuid } from '../../../azureResource/utils';
+import { AzureAccount } from 'azurecore';
 
 // Mock services
 let mockAppContext: AppContext;
@@ -25,7 +26,7 @@ let mockExtensionContext: TypeMoq.IMock<vscode.ExtensionContext>;
 let mockCacheService: TypeMoq.IMock<IAzureResourceCacheService>;
 
 // Mock test data
-const mockAccount1: azdata.Account = {
+const mockAccount1: AzureAccount = {
 	key: {
 		accountId: 'mock_account_1',
 		providerId: 'mock_provider'
@@ -39,7 +40,7 @@ const mockAccount1: azdata.Account = {
 	properties: undefined,
 	isStale: false
 };
-const mockAccount2: azdata.Account = {
+const mockAccount2: AzureAccount = {
 	key: {
 		accountId: 'mock_account_2',
 		providerId: 'mock_provider'


### PR DESCRIPTION
Update all azdata.Account type references in AzureCore to use AzureAccount instead so that we get the strong typings for the properties.

@aasimkhan30 You may want to consider doing the same for sql-migration