### PR TITLE
Fix link for Getting Started command

### DIFF
--- a/src/sql/workbench/update/electron-browser/gettingStarted.contribution.ts
+++ b/src/sql/workbench/update/electron-browser/gettingStarted.contribution.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
-import { ShowCurrentReleaseNotesAction } from 'sql/workbench/update/electron-browser/releaseNotes';
+import { ShowGettingStartedAction } from 'sql/workbench/update/electron-browser/gettingStarted';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { Registry } from 'vs/platform/registry/common/platform';
 
 // add product update and release notes contributions
 Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
-	.registerWorkbenchAction(SyncActionDescriptor.create(ShowCurrentReleaseNotesAction, ShowCurrentReleaseNotesAction.ID, ShowCurrentReleaseNotesAction.LABEL), 'Show Getting Started');
+	.registerWorkbenchAction(SyncActionDescriptor.create(ShowGettingStartedAction, ShowGettingStartedAction.ID, ShowGettingStartedAction.LABEL), 'Show Getting Started');

--- a/src/sql/workbench/update/electron-browser/gettingStarted.contribution.ts
+++ b/src/sql/workbench/update/electron-browser/gettingStarted.contribution.ts
@@ -8,6 +8,6 @@ import { ShowGettingStartedAction } from 'sql/workbench/update/electron-browser/
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { Registry } from 'vs/platform/registry/common/platform';
 
-// add product update and release notes contributions
+// add getting started contributions
 Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
 	.registerWorkbenchAction(SyncActionDescriptor.create(ShowGettingStartedAction, ShowGettingStartedAction.ID, ShowGettingStartedAction.LABEL), 'Show Getting Started');

--- a/src/sql/workbench/update/electron-browser/gettingStarted.ts
+++ b/src/sql/workbench/update/electron-browser/gettingStarted.ts
@@ -6,18 +6,20 @@
 import nls = require('vs/nls');
 import { Action } from 'vs/base/common/actions';
 import product from 'vs/platform/product/common/product';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { URI } from 'vs/base/common/uri';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
-import { AbstractShowReleaseNotesAction } from 'vs/workbench/contrib/update/browser/update';
 
-export class OpenGettingStartedInBrowserAction extends Action {
+export class ShowGettingStartedAction extends Action {
+	static ID = 'update.showGettingStarted';
+	static LABEL = nls.localize('showReleaseNotes', "Show Getting Started");
 
 	constructor(
+		id = ShowGettingStartedAction.ID,
+		label = ShowGettingStartedAction.LABEL,
 		@IOpenerService private openerService: IOpenerService
 	) {
-		super('update.openGettingStartedGuide', nls.localize('gettingStarted', "Get Started"), undefined, true);
+		super(id, label, undefined, true);
 	}
 
 	override run(): Promise<any> {
@@ -26,24 +28,10 @@ export class OpenGettingStartedInBrowserAction extends Action {
 	}
 }
 
-export class ShowCurrentReleaseNotesAction extends AbstractShowReleaseNotesAction {
-
-	static ID = 'update.showGettingStarted';
-	static LABEL = nls.localize('showReleaseNotes', "Show Getting Started");
-
-	constructor(
-		id = ShowCurrentReleaseNotesAction.ID,
-		label = ShowCurrentReleaseNotesAction.LABEL,
-		@IInstantiationService instantiationService: IInstantiationService
-	) {
-		super(id, label, product.version, instantiationService);
-	}
-}
-
 MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
 	group: '1_welcome',
 	command: {
-		id: ShowCurrentReleaseNotesAction.ID,
+		id: ShowGettingStartedAction.ID,
 		title: nls.localize({ key: 'miGettingStarted', comment: ['&& denotes a mnemonic'] }, "Getting &&Started")
 	},
 	order: 1

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -165,8 +165,8 @@ import 'vs/workbench/contrib/cli/node/cli.contribution';
 //#endregion
 
 // {{SQL CARBON EDIT}}
-// release notes
-import 'sql/workbench/update/electron-browser/releaseNotes.contribution';
+// getting started
+import 'sql/workbench/update/electron-browser/gettingStarted.contribution';
 
 // query history
 import 'sql/workbench/contrib/queryHistory/electron-browser/queryHistory.contribution';


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/8468.  Current Getting Started is using Release Notes link.  The Release Notes menu item is coming from default vscode source.
