### PR TITLE
add attach to renderer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -279,6 +279,7 @@
 				"Attach to Main Process",
 				"Attach to Extension Host",
 				"Attach to Shared Process",
+				"Attach to Renderer"
 			],
 			"preLaunchTask": "Ensure Prelaunch Dependencies",
 			"presentation": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
 				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh"
 			},
 			"port": 9222,
-			"timeout": 20000,
+			"timeout": 30000,
 			"env": {
 				"VSCODE_EXTHOST_WILL_SEND_SOCKET": null,
 				"VSCODE_SKIP_PRELAUNCH": "1"
@@ -104,6 +104,7 @@
 			"name": "Attach to Renderer",
 			"browserAttachLocation": "workspace",
 			"port": 9222,
+			"timeout": 30000,
 			"trace": true,
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"


### PR DESCRIPTION
add the missing 'attach to render' task, without this, breakpoints in core won't be hit.