### PR TITLE
Fix debugger type for sp_whoIsActive

### DIFF
--- a/samples/sp_whoIsActive/.vscode/launch.json
+++ b/samples/sp_whoIsActive/.vscode/launch.json
@@ -14,7 +14,7 @@
 
         {
             "name": "Debug in AzureDataStudio install",
-            "type": "azuredatastudioExtensionHost",
+            "type": "sqlopsExtensionHost",
             "request": "launch",
             "runtimeExecutable": "azuredatastudio",
             "args": [
@@ -37,7 +37,7 @@
         },
         {
             "name": "Debug in enlistment",
-            "type": "azuredatastudioExtensionHost",
+            "type": "sqlopsExtensionHost",
             "request": "launch",
             "windows": {
                 "runtimeExecutable": "${workspaceFolder}/../../scripts/sql.bat"


### PR DESCRIPTION
Fixes issues described in https://github.com/microsoft/azuredatastudio/issues/2768 

Two additional notes : 

1. The server-reports extension was moved so no longer has the launch.json. Just fixing it in another place it was wrong
2. Currently the debug extension isn't working. I'm working on a fix for that being tracked by https://github.com/microsoft/azuredatastudio/issues/16760

