### PR TITLE
Take screenshot of failed test before closing the active editor

### DIFF
--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -64,12 +64,7 @@ export function setup() {
 
 			await app.workbench.sqlNotebook.notebookToolbar.changeKernel('Python 3');
 			await app.workbench.configurePythonDialog.waitForConfigurePythonDialog();
-			try {
-				await app.workbench.configurePythonDialog.waitForPageOneLoaded();
-			} catch (e) {
-				await app.captureScreenshot('Configure Python Dialog page one not loaded');
-				throw e;
-			}
+			await app.workbench.configurePythonDialog.waitForPageOneLoaded();
 			await app.workbench.configurePythonDialog.next();
 			await app.workbench.configurePythonDialog.waitForPageTwoLoaded();
 			await app.workbench.configurePythonDialog.install();
@@ -96,6 +91,11 @@ export function setup() {
 
 		afterEach(async function () {
 			const app = this.app as Application;
+			// If the test failed, take a screenshot before closing the active editor.
+			if (this.currentTest!.state === 'failed') {
+				const name = this.currentTest!.fullTitle().replace(/[^a-z0-9\-]/ig, '_');
+				await app.captureScreenshot(`${name} (screenshot before revertAndCloseActiveEditor action)`);
+			}
 			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});
 


### PR DESCRIPTION
Adding a screenshot right after the test fails and before the revertAndCloseActiveEditor command is run. For notebooks, there will be two screenshots for each failed test, one before and one after closing the active editor.