### PR TITLE
Hide suggest widget on cell execution

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -24,6 +24,7 @@ import { URI } from 'vs/base/common/uri';
 import { IModelContentChangedEvent } from 'vs/editor/common/model/textModelEvents';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
+import { ICommandService, NullCommandService } from 'vs/platform/commands/common/commands';
 import { ControlType, IChartOption } from 'sql/workbench/contrib/charts/browser/chartOptions';
 import { CellModel } from 'sql/workbench/services/notebook/browser/models/cell';
 
@@ -31,6 +32,7 @@ let instantiationService: IInstantiationService;
 
 suite('Cell Model', function (): void {
 	let serviceCollection = new ServiceCollection();
+	serviceCollection.set(ICommandService, NullCommandService);
 	instantiationService = new InstantiationService(serviceCollection, true);
 
 	let factory = new ModelFactory(instantiationService);

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -198,7 +198,7 @@ export class RunQueryAction extends QueryTaskbarAction {
 		editor: QueryEditor,
 		@IQueryModelService protected readonly queryModelService: IQueryModelService,
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
-		@ICommandService private readonly commandService: ICommandService
+		@ICommandService private readonly commandService?: ICommandService
 	) {
 		super(connectionManagementService, editor, RunQueryAction.ID, RunQueryAction.EnabledClass);
 		this.label = nls.localize('runQueryLabel', "Run");
@@ -239,7 +239,7 @@ export class RunQueryAction extends QueryTaskbarAction {
 
 		if (this.isConnected(editor)) {
 			// Hide IntelliSense suggestions list when running query to match SSMS behavior
-			this.commandService.executeCommand('hideSuggestWidget');
+			this.commandService?.executeCommand('hideSuggestWidget');
 			// if the selection isn't empty then execute the selection
 			// otherwise, either run the statement or the script depending on parameter
 			let selection = editor.getSelection(false);

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -197,7 +197,8 @@ export class RunQueryAction extends QueryTaskbarAction {
 	constructor(
 		editor: QueryEditor,
 		@IQueryModelService protected readonly queryModelService: IQueryModelService,
-		@IConnectionManagementService connectionManagementService: IConnectionManagementService
+		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
+		@ICommandService private readonly commandService: ICommandService
 	) {
 		super(connectionManagementService, editor, RunQueryAction.ID, RunQueryAction.EnabledClass);
 		this.label = nls.localize('runQueryLabel', "Run");
@@ -237,6 +238,8 @@ export class RunQueryAction extends QueryTaskbarAction {
 		}
 
 		if (this.isConnected(editor)) {
+			// Hide IntelliSense suggestions list when running query to match SSMS behavior
+			this.commandService.executeCommand('hideSuggestWidget');
 			// if the selection isn't empty then execute the selection
 			// otherwise, either run the statement or the script depending on parameter
 			let selection = editor.getSelection(false);

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -559,7 +559,7 @@ export class CellModel extends Disposable implements ICellModel {
 				return false;
 			}
 			this._outputCounter = 0;
-			// Hide IntelliSense suggestions list
+			// Hide IntelliSense suggestions list when running cell to match SSMS behavior
 			this._commandService.executeCommand('hideSuggestWidget');
 			this._telemetryService?.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunCell)
 				.withAdditionalProperties({ cell_language: kernel.name })

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -559,6 +559,8 @@ export class CellModel extends Disposable implements ICellModel {
 				return false;
 			}
 			this._outputCounter = 0;
+			// Hide IntelliSense suggestions list
+			this._commandService.executeCommand('hideSuggestWidget');
 			this._telemetryService?.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunCell)
 				.withAdditionalProperties({ cell_language: kernel.name })
 				.send();


### PR DESCRIPTION
Fixes #3958, which we've recently gotten more feedback around.

Decided to execute the command instead of replicating the implementation of the command to avoid future issues with VS Code merges and avoid code duplication.

@alanrenmsft if this is something that's interesting for query editor, happy to expand this change to query editor and/or edit data as well. I believe this would also match SSMS behavior. Up to you though 😄.