### PR TITLE
reset the icon before use

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
@@ -192,6 +192,7 @@ class TreeNodeTemplate extends Disposable {
 			this._icon.classList.add(iconLowerCaseName);
 		}
 
+		iconRenderer.removeIcon(this._icon);
 		if (element.icon && !instanceOfSqlThemeIcon(element.icon)) {
 			iconRenderer.putIcon(this._icon, element.icon);
 		}

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -160,6 +160,7 @@ export class ServerTreeRenderer implements IRenderer {
 			templateData.icon.classList.add(iconLowerCaseName);
 		}
 
+		iconRenderer.removeIcon(templateData.icon);
 		if (treeNode.icon && !instanceOfSqlThemeIcon(treeNode.icon)) {
 			iconRenderer.putIcon(templateData.icon, treeNode.icon);
 		}


### PR DESCRIPTION
fixes the issue where the icon is not cleared when element is being reused by the tree by remove the icon from previous use.
![image](https://user-images.githubusercontent.com/13777222/130883939-f450f3bc-b6f6-497b-89d5-38cce4403b58.png).

the template reuse is a feature of the vscode tree.

