### PR TITLE
Add sql bindings package reference to project

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -456,3 +456,4 @@ export const sqlTableToUpsert = localize('sqlTableToUpsert', "SQL table to upser
 export const connectionStringSetting = localize('connectionStringSetting', "Connection string setting name");
 export const connectionStringSettingPlaceholder = localize('connectionStringSettingPlaceholder', "Connection string setting specified in \"local.settings.json\"");
 export const noAzureFunctionsInFile = localize('noAzureFunctionsInFile', "No Azure functions in the current active file");
+export const noAzureFunctionsProjectsInWorkspace = localize('noAzureFunctionsProjectsInWorkspace', "No Azure functions projects found in the workspace");

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -444,7 +444,6 @@ export function getTargetPlatformFromVersion(version: string): string {
 // Insert SQL binding
 export const hostFileName = 'host.json';
 export const sqlExtensionPackageName = 'Microsoft.Azure.WebJobs.Extensions.Sql';
-export const sqlExtensionPackageVersion = '1.0.0-preview3';
 export const placeHolderObject = '[dbo].[table1]';
 
 export const input = localize('input', "Input");
@@ -457,3 +456,4 @@ export const connectionStringSetting = localize('connectionStringSetting', "Conn
 export const connectionStringSettingPlaceholder = localize('connectionStringSettingPlaceholder', "Connection string setting specified in \"local.settings.json\"");
 export const noAzureFunctionsInFile = localize('noAzureFunctionsInFile', "No Azure functions in the current active file");
 export const noAzureFunctionsProjectsInWorkspace = localize('noAzureFunctionsProjectsInWorkspace', "No Azure functions projects found in the workspace");
+export const addPackage = localize('addPackage', "Add Package");

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -443,7 +443,10 @@ export function getTargetPlatformFromVersion(version: string): string {
 
 // Insert SQL binding
 export const hostFileName = 'host.json';
+export const sqlExtensionPackageName = 'Microsoft.Azure.WebJobs.Extensions.Sql';
+export const sqlExtensionPackageVersion = '1.0.0-preview3';
 export const placeHolderObject = '[dbo].[table1]';
+
 export const input = localize('input', "Input");
 export const output = localize('output', "Output");
 export const selectBindingType = localize('selectBindingType', "Select type of binding");

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -488,3 +488,20 @@ export async function retry<T>(
 
 	return undefined;
 }
+
+/**
+ * Gets all the projects of the specified extension in the folder
+ * @param folder
+ * @param projectExtension project extension to filter on
+ * @returns array of project uris
+ */
+export async function getAllProjectsInFolder(folder: vscode.Uri, projectExtension: string): Promise<vscode.Uri[]> {
+	// path needs to use forward slashes for glob to work
+	const escapedPath = glob.escapePath(folder.fsPath.replace(/\\/g, '/'));
+
+	// filter for projects with the specified project extension
+	const projFilter = path.posix.join(escapedPath, '**', `*${projectExtension}`);
+
+	// glob will return an array of file paths with forward slashes, so they need to be converted back if on windows
+	return (await glob(projFilter)).map(p => vscode.Uri.file(path.resolve(p)));
+}

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -74,7 +74,7 @@ export default class MainController implements vscode.Disposable {
 		vscode.commands.registerCommand('sqlDatabaseProjects.changeTargetPlatform', async (node: WorkspaceTreeItem) => { await this.projectsController.changeTargetPlatform(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.validateExternalStreamingJob', async (node: WorkspaceTreeItem) => { await this.projectsController.validateExternalStreamingJob(node); });
 
-		vscode.commands.registerCommand('sqlDatabaseProjects.addSqlBinding', async (uri: vscode.Uri | undefined) => { await launchAddSqlBindingQuickpick(uri); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.addSqlBinding', async (uri: vscode.Uri | undefined) => { await launchAddSqlBindingQuickpick(uri, this._outputChannel); });
 
 		IconPathHelper.setExtensionContext(this.extensionContext);
 

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -16,6 +16,7 @@ import { WorkspaceTreeItem } from 'dataworkspace';
 import * as constants from '../common/constants';
 import { SqlDatabaseProjectProvider } from '../projectProvider/projectProvider';
 import { launchAddSqlBindingQuickpick } from '../dialogs/addSqlBindingQuickpick';
+import { PackageHelper } from '../tools/packageHelper';
 
 /**
  * The main controller class that initializes the extension
@@ -23,11 +24,13 @@ import { launchAddSqlBindingQuickpick } from '../dialogs/addSqlBindingQuickpick'
 export default class MainController implements vscode.Disposable {
 	protected projectsController: ProjectsController;
 	protected netcoreTool: NetCoreTool;
+	protected packageHelper: PackageHelper;
 	private _outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(constants.projectsOutputChannel);
 
 	public constructor(private context: vscode.ExtensionContext) {
 		this.projectsController = new ProjectsController(this._outputChannel);
 		this.netcoreTool = new NetCoreTool(this._outputChannel);
+		this.packageHelper = new PackageHelper(this._outputChannel);
 	}
 
 	public get extensionContext(): vscode.ExtensionContext {
@@ -74,7 +77,7 @@ export default class MainController implements vscode.Disposable {
 		vscode.commands.registerCommand('sqlDatabaseProjects.changeTargetPlatform', async (node: WorkspaceTreeItem) => { await this.projectsController.changeTargetPlatform(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.validateExternalStreamingJob', async (node: WorkspaceTreeItem) => { await this.projectsController.validateExternalStreamingJob(node); });
 
-		vscode.commands.registerCommand('sqlDatabaseProjects.addSqlBinding', async (uri: vscode.Uri | undefined) => { await launchAddSqlBindingQuickpick(uri, this._outputChannel); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.addSqlBinding', async (uri: vscode.Uri | undefined) => { await launchAddSqlBindingQuickpick(uri, this.packageHelper); });
 
 		IconPathHelper.setExtensionContext(this.extensionContext);
 

--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode';
 import { BindingType } from 'vscode-mssql';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
+import { InstallPackageHelper } from '../tools/installPackageHelper';
+import { DotNetCommandOptions, NetCoreTool } from '../tools/netcoreTool';
 
-export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined): Promise<void> {
+export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, outputChannel: vscode.OutputChannel): Promise<void> {
 	if (!uri) {
 		// this command only shows in the command palette when the active editor is a .cs file, so we can safely assume that's the scenario
 		// when this is called without a uri
@@ -11,89 +13,118 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined):
 	}
 
 	// get all the Azure functions in the file
-	const azureFunctionsService = await utils.getAzureFunctionService();
-	let getAzureFunctionsResult;
-	try {
-		getAzureFunctionsResult = await azureFunctionsService.getAzureFunctions(uri.fsPath);
-	} catch (e) {
-		vscode.window.showErrorMessage(e);
-		return;
-	}
+	// const azureFunctionsService = await utils.getAzureFunctionService();
+	// let getAzureFunctionsResult;
+	// try {
+	// 	getAzureFunctionsResult = await azureFunctionsService.getAzureFunctions(uri.fsPath);
+	// } catch (e) {
+	// 	vscode.window.showErrorMessage(e);
+	// 	return;
+	// }
 
-	const azureFunctions = getAzureFunctionsResult.azureFunctions;
+	// const azureFunctions = getAzureFunctionsResult.azureFunctions;
 
-	if (azureFunctions.length === 0) {
-		vscode.window.showErrorMessage(constants.noAzureFunctionsInFile);
-		return;
-	}
+	// if (azureFunctions.length === 0) {
+	// 	vscode.window.showErrorMessage(constants.noAzureFunctionsInFile);
+	// 	return;
+	// }
 
-	// 1. select Azure function from the current file
-	const azureFunctionName = (await vscode.window.showQuickPick(azureFunctions, {
-		canPickMany: false,
-		title: constants.selectAzureFunction,
-		ignoreFocusOut: true
-	}));
+	// // 1. select Azure function from the current file
+	// const azureFunctionName = (await vscode.window.showQuickPick(azureFunctions, {
+	// 	canPickMany: false,
+	// 	title: constants.selectAzureFunction,
+	// 	ignoreFocusOut: true
+	// }));
 
-	if (!azureFunctionName) {
-		return;
-	}
+	// if (!azureFunctionName) {
+	// 	return;
+	// }
 
-	// 2. select input or output binding
-	const inputOutputItems: (vscode.QuickPickItem & { type: BindingType })[] = [
-		{
-			label: constants.input,
-			type: BindingType.input
-		},
-		{
-			label: constants.output,
-			type: BindingType.output
-		}
-	];
+	// // 2. select input or output binding
+	// const inputOutputItems: (vscode.QuickPickItem & { type: BindingType })[] = [
+	// 	{
+	// 		label: constants.input,
+	// 		type: BindingType.input
+	// 	},
+	// 	{
+	// 		label: constants.output,
+	// 		type: BindingType.output
+	// 	}
+	// ];
 
-	const selectedBinding = (await vscode.window.showQuickPick(inputOutputItems, {
-		canPickMany: false,
-		title: constants.selectBindingType,
-		ignoreFocusOut: true
-	}));
+	// const selectedBinding = (await vscode.window.showQuickPick(inputOutputItems, {
+	// 	canPickMany: false,
+	// 	title: constants.selectBindingType,
+	// 	ignoreFocusOut: true
+	// }));
 
-	if (!selectedBinding) {
-		return;
-	}
+	// if (!selectedBinding) {
+	// 	return;
+	// }
 
-	// 3. ask for object name for the binding
-	const objectName = await vscode.window.showInputBox({
-		prompt: selectedBinding.type === BindingType.input ? constants.sqlObjectToQuery : constants.sqlTableToUpsert,
-		value: constants.placeHolderObject,
-		ignoreFocusOut: true
-	});
+	// // 3. ask for object name for the binding
+	// const objectName = await vscode.window.showInputBox({
+	// 	prompt: selectedBinding.type === BindingType.input ? constants.sqlObjectToQuery : constants.sqlTableToUpsert,
+	// 	value: constants.placeHolderObject,
+	// 	ignoreFocusOut: true
+	// });
 
-	if (!objectName) {
-		return;
-	}
+	// if (!objectName) {
+	// 	return;
+	// }
 
-	// 4. ask for connection string setting name
-	// TODO: load local settings from local.settings.json like in LocalAppSettingListStep in vscode-azurefunctions repo
-	const connectionStringSetting = await vscode.window.showInputBox({
-		prompt: constants.connectionStringSetting,
-		placeHolder: constants.connectionStringSettingPlaceholder,
-		ignoreFocusOut: true
-	});
+	// // 4. ask for connection string setting name
+	// // TODO: load local settings from local.settings.json like in LocalAppSettingListStep in vscode-azurefunctions repo
+	// const connectionStringSetting = await vscode.window.showInputBox({
+	// 	prompt: constants.connectionStringSetting,
+	// 	placeHolder: constants.connectionStringSettingPlaceholder,
+	// 	ignoreFocusOut: true
+	// });
 
-	if (!connectionStringSetting) {
-		return;
-	}
+	// if (!connectionStringSetting) {
+	// 	return;
+	// }
 
-	// 5. insert binding
-	try {
-		const result = await azureFunctionsService.addSqlBinding(selectedBinding.type, uri.fsPath, azureFunctionName, objectName, connectionStringSetting);
+	// // 5. insert binding
+	// try {
+	// 	const result = await azureFunctionsService.addSqlBinding(selectedBinding.type, uri.fsPath, azureFunctionName, objectName, connectionStringSetting);
 
-		if (!result.success) {
-			vscode.window.showErrorMessage(result.errorMessage);
-			return;
-		}
-	} catch (e) {
-		vscode.window.showErrorMessage(e);
-		return;
-	}
+	// 	if (!result.success) {
+	// 		vscode.window.showErrorMessage(result.errorMessage);
+	// 		return;
+	// 	}
+	// } catch (e) {
+	// 	vscode.window.showErrorMessage(e);
+	// 	return;
+	// }
+
+
+	// get project binding was added in
+	let packageHelper = new InstallPackageHelper();
+	const project = await packageHelper.getProjectContainingFile(uri.fsPath);
+
+	// dotnet list package to check
+	const listOptions: DotNetCommandOptions = {
+		commandTitle: 'List Packages',
+		argument: packageHelper.constructListPackageArguments(project)
+	};
+
+	const netCoreTool = new NetCoreTool(outputChannel);
+	// let result = await netCoreTool.runDotnetCommand(listOptions);
+	// console.error(result);
+
+	// if (result.includes(constants.sqlExtensionPackageName)) {
+	// 	console.error('has it!');
+	// } else {
+	// 	console.error('doenst have it')
+	// dotnet add package if it doesn't exist
+	const addOptions: DotNetCommandOptions = {
+		commandTitle: 'Add Package',
+		argument: packageHelper.constructAddPackageArguments(project, constants.sqlExtensionPackageName, constants.sqlExtensionPackageVersion)
+	};
+
+	let result2 = await netCoreTool.runDotnetCommand(addOptions);
+	console.error(result2);
+	// }
 }
 

--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -98,6 +98,6 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 	}
 
 	// 6. Add sql extension package reference to project. If the reference is already there, it doesn't get added again
-	await packageHelper.addPackageToAFProjectContainingFile(uri.fsPath, constants.sqlExtensionPackageName, constants.sqlExtensionPackageVersion);
+	await packageHelper.addPackageToAFProjectContainingFile(uri.fsPath, constants.sqlExtensionPackageName);
 }
 

--- a/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
+++ b/extensions/sql-database-projects/src/dialogs/addSqlBindingQuickpick.ts
@@ -99,32 +99,9 @@ export async function launchAddSqlBindingQuickpick(uri: vscode.Uri | undefined, 
 	// }
 
 
-	// get project binding was added in
-	let packageHelper = new InstallPackageHelper();
-	const project = await packageHelper.getProjectContainingFile(uri.fsPath);
-
-	// dotnet list package to check
-	const listOptions: DotNetCommandOptions = {
-		commandTitle: 'List Packages',
-		argument: packageHelper.constructListPackageArguments(project)
-	};
-
-	const netCoreTool = new NetCoreTool(outputChannel);
-	// let result = await netCoreTool.runDotnetCommand(listOptions);
-	// console.error(result);
-
-	// if (result.includes(constants.sqlExtensionPackageName)) {
-	// 	console.error('has it!');
-	// } else {
-	// 	console.error('doenst have it')
-	// dotnet add package if it doesn't exist
-	const addOptions: DotNetCommandOptions = {
-		commandTitle: 'Add Package',
-		argument: packageHelper.constructAddPackageArguments(project, constants.sqlExtensionPackageName, constants.sqlExtensionPackageVersion)
-	};
-
-	let result2 = await netCoreTool.runDotnetCommand(addOptions);
-	console.error(result2);
-	// }
+	// Add sql extension package reference to project
+	const packageHelper = new InstallPackageHelper(outputChannel);
+	const project = await packageHelper.getAFProjectContainingFile(uri.fsPath);
+	packageHelper.addPackage(project, constants.sqlExtensionPackageName, constants.sqlExtensionPackageVersion);
 }
 

--- a/extensions/sql-database-projects/src/tools/installPackageHelper.ts
+++ b/extensions/sql-database-projects/src/tools/installPackageHelper.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as glob from 'fast-glob';
+import * as utils from '../common/utils';
+import * as constants from '../common/constants';
+
+export class InstallPackageHelper {
+
+	constructor() { }
+
+	public async getProjectContainingFile(filePath: string): Promise<string> {
+		// get csprojs in the workspace
+		const projectPromises = vscode.workspace.workspaceFolders?.map(f => this.getAllProjectsInFolder(f.uri, '.csproj')) ?? [];
+		let projects = (await Promise.all(projectPromises)).reduce((prev, curr) => prev.concat(curr), []);
+
+		// check if it's a functions project
+		let functionsProjects = [];
+		for (const p of projects) {
+			if (this.isFunctionProject(path.dirname(p.fsPath))) {
+				functionsProjects.push(p);
+			}
+		}
+
+		// look for project folder containing file if there's more than one
+		if (functionsProjects.length > 1) {
+			// TODO:
+			console.error('need to look for folder containing ' + filePath);
+			throw new Error('uh oh more than one functions project :o');
+		} else if (functionsProjects.length === 0) {
+			// TODO
+			throw new Error('uh oh no functions projects found in workspace');
+		} else {
+			return functionsProjects[0].fsPath;
+		}
+	}
+
+	/**
+	 * Gets all the projects of the specified extension in the folder
+	 * @param folder
+	 * @param projectExtension
+	 * @returns
+	 */
+	async getAllProjectsInFolder(folder: vscode.Uri, projectExtension: string): Promise<vscode.Uri[]> {
+		// path needs to use forward slashes for glob to work
+		const escapedPath = glob.escapePath(folder.fsPath.replace(/\\/g, '/'));
+
+		// filter for csproj
+		const projFilter = path.posix.join(escapedPath, '**', `*${projectExtension}`);
+
+		// glob will return an array of file paths with forward slashes, so they need to be converted back if on windows
+		return (await glob(projFilter)).map(p => vscode.Uri.file(path.resolve(p)));
+	}
+
+
+	public constructListPackageArguments(projectPath: string): string {
+		projectPath = utils.getQuotedPath(projectPath);
+		return ` list ${projectPath} package`;
+	}
+
+	public constructAddPackageArguments(projectPath: string, packageName: string, packageVersion: string): string {
+		projectPath = utils.getQuotedPath(projectPath);
+		return ` add ${projectPath} package ${packageName} -v ${packageVersion}`;
+	}
+
+	// Use 'host.json' as an indicator that this is a functions project
+	async isFunctionProject(folderPath: string): Promise<boolean> {
+		return await fse.pathExists(path.join(folderPath, constants.hostFileName));
+	}
+}
+

--- a/extensions/sql-database-projects/src/tools/packageHelper.ts
+++ b/extensions/sql-database-projects/src/tools/packageHelper.ts
@@ -5,12 +5,11 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as glob from 'fast-glob';
 import * as utils from '../common/utils';
 import * as constants from '../common/constants';
 import { DotNetCommandOptions, NetCoreTool } from './netcoreTool';
 
-export class InstallPackageHelper {
+export class PackageHelper {
 	private netCoreTool: NetCoreTool;
 
 	constructor(outputChannel: vscode.OutputChannel) {
@@ -30,7 +29,8 @@ export class InstallPackageHelper {
 	}
 
 	/**
-	 * Runs dotnet add package to add a package reference to the specified project
+	 * Runs dotnet add package to add a package reference to the specified project. If the project already has a package reference
+	 * for this package version, the project file won't get updated
 	 * @param projectPath full path to project to add package to
 	 * @param packageName name of package
 	 * @param packageVersion version of package
@@ -45,54 +45,50 @@ export class InstallPackageHelper {
 	}
 
 	/**
+	 * Adds specified package to Azure Functions project the specified file is a part of
+	 * @param filePath full path to file to find the containing AF project of to add package reference to
+	 * @param packageName package to add reference to
+	 * @param packageVersion version of package
+	 */
+	public async addPackageToAFProjectContainingFile(filePath: string, packageName: string, packageVersion: string): Promise<void> {
+		try {
+			const project = await this.getAFProjectContainingFile(filePath);
+
+			if (project) {
+				await this.addPackage(project, packageName, packageVersion);
+			}
+		} catch (e) {
+			vscode.window.showErrorMessage(e.message);
+		}
+	}
+
+	/**
 	 * Gets the Azure Functions project that contains the given file
 	 * @param filePath file that the containing project needs to be found for
-	 * @returns filepath of project
+	 * @returns filepath of project or undefined if project couldn't be found
 	 */
-	public async getAFProjectContainingFile(filePath: string): Promise<string> {
-		// get csprojs in the workspace
-		const projectPromises = vscode.workspace.workspaceFolders?.map(f => this.getAllProjectsInFolder(f.uri, '.csproj')) ?? [];
-		const projects = (await Promise.all(projectPromises)).reduce((prev, curr) => prev.concat(curr), []);
-
-		// check if it's a functions project
-		let functionsProjects = [];
-		for (const p of projects) {
-			if (this.isFunctionProject(path.dirname(p.fsPath))) {
-				functionsProjects.push(p);
-			}
-		}
+	public async getAFProjectContainingFile(filePath: string): Promise<string | undefined> {
+		// get functions csprojs in the workspace
+		const projectPromises = vscode.workspace.workspaceFolders?.map(f => utils.getAllProjectsInFolder(f.uri, '.csproj')) ?? [];
+		const functionsProjects = (await Promise.all(projectPromises)).reduce((prev, curr) => prev.concat(curr), []).filter(p => this.isFunctionProject(path.dirname(p.fsPath)));
 
 		// look for project folder containing file if there's more than one
 		if (functionsProjects.length > 1) {
-			// TODO
-			console.error('need to look for folder containing ' + filePath);
-			throw new Error('uh oh more than one functions project :o');
+			// TODO: figure out which project contains the file
+			// the new style csproj doesn't list all the files in the project anymore, unless the file isn't in the same folder
+			// so we can't rely on using that to check
+			vscode.window.showInformationMessage(`To use SQL bindings, ensure your Azure Functions project has a reference to ${constants.sqlExtensionPackageName}`);
+			console.error('need to find which project contains the file ' + filePath);
+			return undefined;
 		} else if (functionsProjects.length === 0) {
-			// TODO
-			throw new Error('uh oh no functions projects found in workspace');
+			throw new Error(constants.noAzureFunctionsProjectsInWorkspace);
 		} else {
 			return functionsProjects[0].fsPath;
 		}
 	}
 
-	/**
-	 * Gets all the projects of the specified extension in the folder
-	 * @param folder
-	 * @param projectExtension
-	 * @returns
-	 */
-	async getAllProjectsInFolder(folder: vscode.Uri, projectExtension: string): Promise<vscode.Uri[]> {
-		// path needs to use forward slashes for glob to work
-		const escapedPath = glob.escapePath(folder.fsPath.replace(/\\/g, '/'));
-
-		// filter for csproj
-		const projFilter = path.posix.join(escapedPath, '**', `*${projectExtension}`);
-
-		// glob will return an array of file paths with forward slashes, so they need to be converted back if on windows
-		return (await glob(projFilter)).map(p => vscode.Uri.file(path.resolve(p)));
-	}
-
 	// Use 'host.json' as an indicator that this is a functions project
+	// copied from verifyIsproject.ts in vscode-azurefunctions extension
 	async isFunctionProject(folderPath: string): Promise<boolean> {
 		return await fse.pathExists(path.join(folderPath, constants.hostFileName));
 	}


### PR DESCRIPTION
This change makes it so after a sql binding is added using the quickpick added in https://github.com/microsoft/azuredatastudio/pull/16838, the sql bindings package reference gets added to the project using dotnet add package. If the project already has the package reference, it doesn't get added again.

![addPackageReference](https://user-images.githubusercontent.com/31145923/131049016-a831b836-8118-4910-82f7-5f092b7f3399.gif)

Right now, it'll only add the package reference if there's one AF project in the workspace. If there are multiple, a notification will pop up to make sure the package reference is there for build to work. Created an issue to find the right project to add the reference to tackle later https://github.com/microsoft/azuredatastudio/issues/16911


![image](https://user-images.githubusercontent.com/31145923/131049127-d49c0bf2-4c70-4561-ad8e-d5cc15bc26f5.png)

error when no AF projects found in workspace:
![image](https://user-images.githubusercontent.com/31145923/131049151-be202a8a-79d1-47bf-87fe-47635ed0edd5.png)

