### PR TITLE
Add STS root folder override

### DIFF
--- a/extensions/mssql/src/credentialstore/credentialstore.ts
+++ b/extensions/mssql/src/credentialstore/credentialstore.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SqlOpsDataClient, ClientOptions, SqlOpsFeature } from 'dataprotocol-client';
-import { IConfig, ServerProvider } from '@microsoft/ads-service-downloader';
+import { IConfig } from '@microsoft/ads-service-downloader';
 import { ServerOptions, RPCMessageType, ClientCapabilities, ServerCapabilities, TransportKind } from 'vscode-languageclient';
 import { Disposable } from 'vscode';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
@@ -77,17 +77,15 @@ export class CredentialStore {
 		}
 	}
 
-	public start() {
-		let serverdownloader = new ServerProvider(this._config);
+	public async start(): Promise<void> {
 		let clientOptions: ClientOptions = {
 			providerId: Constants.providerId,
 			features: [CredentialsFeature]
 		};
-		return serverdownloader.getOrDownloadServer().then(e => {
-			let serverOptions = this.generateServerOptions(e);
-			this._client = new SqlOpsDataClient(Constants.serviceName, serverOptions, clientOptions);
-			this._client.start();
-		});
+		const serverPath = await Utils.getOrDownloadServer(this._config);
+		const serverOptions = this.generateServerOptions(serverPath);
+		this._client = new SqlOpsDataClient(Constants.serviceName, serverOptions, clientOptions);
+		this._client.start();
 	}
 
 	dispose() {

--- a/extensions/mssql/src/resourceProvider/resourceProvider.ts
+++ b/extensions/mssql/src/resourceProvider/resourceProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
-import { IConfig, ServerProvider } from '@microsoft/ads-service-downloader';
+import { IConfig } from '@microsoft/ads-service-downloader';
 import { SqlOpsDataClient, SqlOpsFeature, ClientOptions } from 'dataprotocol-client';
 import { ServerCapabilities, ClientCapabilities, RPCMessageType, ServerOptions, TransportKind } from 'vscode-languageclient';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
@@ -81,17 +81,15 @@ export class AzureResourceProvider {
 		}
 	}
 
-	public start() {
-		let serverdownloader = new ServerProvider(this._config);
+	public async start(): Promise<void> {
 		let clientOptions: ClientOptions = {
 			providerId: Constants.providerId,
 			features: [FireWallFeature]
 		};
-		return serverdownloader.getOrDownloadServer().then(e => {
-			let serverOptions = this.generateServerOptions(e);
-			this._client = new SqlOpsDataClient(Constants.serviceName, serverOptions, clientOptions);
-			this._client.start();
-		});
+		const serverPath = await Utils.getOrDownloadServer(this._config);
+		let serverOptions = this.generateServerOptions(serverPath);
+		this._client = new SqlOpsDataClient(Constants.serviceName, serverOptions, clientOptions);
+		this._client.start();
 	}
 
 	public dispose() {

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -82,7 +82,7 @@ export class SqlToolsServer {
 		this.config.installDirectory = path.join(configDir, this.config.installDirectory);
 		this.config.proxy = vscode.workspace.getConfiguration('http').get('proxy');
 		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
-		return getOrDownloadServer(this.config, handleServerProviderEvent, true);
+		return getOrDownloadServer(this.config, handleServerProviderEvent);
 	}
 
 	private activateFeatures(context: AppContext): Promise<void> {

--- a/extensions/mssql/src/sqlToolsServer.ts
+++ b/extensions/mssql/src/sqlToolsServer.ts
@@ -82,7 +82,7 @@ export class SqlToolsServer {
 		this.config.installDirectory = path.join(configDir, this.config.installDirectory);
 		this.config.proxy = vscode.workspace.getConfiguration('http').get('proxy');
 		this.config.strictSSL = vscode.workspace.getConfiguration('http').get('proxyStrictSSL') || true;
-		return getOrDownloadServer(this.config, handleServerProviderEvent);
+		return getOrDownloadServer(this.config, handleServerProviderEvent, true);
 	}
 
 	private activateFeatures(context: AppContext): Promise<void> {

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -308,15 +308,15 @@ export async function exists(path: string): Promise<boolean> {
 }
 
 const STS_OVERRIDE_ENV_VAR = 'ADS_SQLTOOLSSERVICE';
+let overrideMessageDisplayed = false;
 /**
  * Gets the full path to the EXE for the specified tools service, downloading it in the process if necessary. The location
  * for this can be overridden with an environment variable for debugging or other purposes.
  * @param config The configuration values of the server to get/download
  * @param handleServerEvent A callback for handling events from the server downloader
- * @param displayToUser Whether to display a message to the user informing them the service was overridden
  * @returns The path to the server exe
  */
-export async function getOrDownloadServer(config: IConfig, handleServerEvent?: (e: string, ...args: any[]) => void, displayToUser = false): Promise<string> {
+export async function getOrDownloadServer(config: IConfig, handleServerEvent?: (e: string, ...args: any[]) => void): Promise<string> {
 	// This env var is used to override the base install location of STS - primarily to be used for debugging scenarios.
 	try {
 		const stsRootPath = env[STS_OVERRIDE_ENV_VAR];
@@ -324,9 +324,13 @@ export async function getOrDownloadServer(config: IConfig, handleServerEvent?: (
 			for (const exeFile of config.executableFiles) {
 				const serverFullPath = path.join(stsRootPath, exeFile);
 				if (await exists(serverFullPath)) {
-					if (displayToUser) {
-						vscode.window.showInformationMessage(`Using ${exeFile} from ${stsRootPath}`);
+					const overrideMessage = `Using ${exeFile} from ${stsRootPath}`;
+					// Display message to the user so they know the override is active, but only once so we don't show too many
+					if (!overrideMessageDisplayed) {
+						overrideMessageDisplayed = true;
+						vscode.window.showInformationMessage(overrideMessage);
 					}
+					console.log(overrideMessage);
 					return serverFullPath;
 				}
 			}


### PR DESCRIPTION
Useful for debugging scenarios. 

Steps to use (will document this elsewhere as a follow-up):

1. Publish STS project you want to debug (such as service layer). This is needed to get full set of dependent assemblies 
2. Set ADS_SQLTOOLSSERVICE env var to publish path (e.g. `C:\src\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\net5.0\publish`
3. Launch ADS

Note that there are 3 "clients" that all come from the same STS folder. If any of them don't exist (because you didn't publish them) then it'll just fall back to using the normal STS install for those ones. 