### PR TITLE
Updated Backup File Table Styling Similar to Migration Status Dailog

### DIFF
--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -75,7 +75,8 @@ export class MigrationCutoverDialog {
 					'border': 'none',
 					'text-align': 'left',
 					'border-bottom': '1px solid',
-					'font-size': '12px'
+					'font-size': '12px',
+					'margin-left': '0px'
 				};
 
 				const headerCssStyles: azdata.CssStyles = {
@@ -160,6 +161,7 @@ export class MigrationCutoverDialog {
 					height: '300px',
 					CSSStyles: {
 						'display': 'none',
+						'margin-left': '0px'
 					}
 				}).component();
 

--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -43,7 +43,7 @@ export class MigrationCutoverDialog {
 	private _lastAppliedBackupTakenOnInfoField!: InfoFieldSchema;
 
 	private _fileCount!: azdata.TextComponent;
-	private _fileTable!: azdata.TableComponent;
+	private _fileTable!: azdata.DeclarativeTableComponent;
 	private _autoRefreshHandle!: any;
 	private _disposables: vscode.Disposable[] = [];
 	private _emptyTableFill!: azdata.FlexContainer;
@@ -71,54 +71,93 @@ export class MigrationCutoverDialog {
 					}
 				}).component();
 
-				this._fileTable = view.modelBuilder.table().withProps({
+				const rowCssStyle: azdata.CssStyles = {
+					'border': 'none',
+					'text-align': 'left',
+					'border-bottom': '1px solid',
+					'font-size': '12px'
+				};
+
+				const headerCssStyles: azdata.CssStyles = {
+					'border': 'none',
+					'text-align': 'left',
+					'border-bottom': '1px solid',
+					'font-weight': 'bold',
+					'padding-left': '0px',
+					'padding-right': '0px'
+				};
+
+				this._fileTable = view.modelBuilder.declarativeTable().withProps({
 					ariaLabel: loc.ACTIVE_BACKUP_FILES,
 					columns: [
 						{
-							value: loc.ACTIVE_BACKUP_FILES,
-							width: 230,
-							type: azdata.ColumnType.text,
+							displayName: loc.ACTIVE_BACKUP_FILES,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '230px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						},
 						{
-							value: loc.TYPE,
-							width: 90,
-							type: azdata.ColumnType.text
+							displayName: loc.TYPE,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '90px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						},
 						{
-							value: loc.STATUS,
-							width: 60,
-							type: azdata.ColumnType.text
+							displayName: loc.STATUS,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '60px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						},
 						{
-							value: loc.DATA_UPLOADED,
-							width: 120,
-							type: azdata.ColumnType.text
+							displayName: loc.DATA_UPLOADED,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '120px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						},
 						{
-							value: loc.COPY_THROUGHPUT,
-							width: 150,
-							type: azdata.ColumnType.text
+							displayName: loc.COPY_THROUGHPUT,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '150px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						},
 						{
-							value: loc.BACKUP_START_TIME,
-							width: 130,
-							type: azdata.ColumnType.text
+							displayName: loc.BACKUP_START_TIME,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '130px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						},
 						{
-							value: loc.FIRST_LSN,
-							width: 120,
-							type: azdata.ColumnType.text
+							displayName: loc.FIRST_LSN,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '120px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						},
 						{
-							value: loc.LAST_LSN,
-							width: 120,
-							type: azdata.ColumnType.text
+							displayName: loc.LAST_LSN,
+							valueType: azdata.DeclarativeDataType.string,
+							width: '120px',
+							isReadOnly: true,
+							rowCssStyles: rowCssStyle,
+							headerCssStyles: headerCssStyles
 						}
 					],
 					data: [],
 					width: '1100px',
 					height: '300px',
-					fontSize: '12px',
 					CSSStyles: {
 						'display': 'none',
 					}

--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -75,8 +75,7 @@ export class MigrationCutoverDialog {
 					'border': 'none',
 					'text-align': 'left',
 					'border-bottom': '1px solid',
-					'font-size': '12px',
-					'margin-left': '0px'
+					'font-size': '12px'
 				};
 
 				const headerCssStyles: azdata.CssStyles = {
@@ -85,7 +84,8 @@ export class MigrationCutoverDialog {
 					'border-bottom': '1px solid',
 					'font-weight': 'bold',
 					'padding-left': '0px',
-					'padding-right': '0px'
+					'padding-right': '0px',
+					'font-size': '12px'
 				};
 
 				this._fileTable = view.modelBuilder.declarativeTable().withProps({
@@ -161,7 +161,7 @@ export class MigrationCutoverDialog {
 					height: '300px',
 					CSSStyles: {
 						'display': 'none',
-						'margin-left': '0px'
+						'padding-left': '0px'
 					}
 				}).component();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
-Task 1339618: ADS UI - Uniform table styling on the migration extension - update the backup file table on the migration cutover page

- before:
![Screenshot (26)](https://user-images.githubusercontent.com/87131830/131319739-7ac3d4b2-6f84-4862-96ee-a9fee1a6940f.png)

now:
![Screenshot (28)](https://user-images.githubusercontent.com/87131830/131319753-1712c78b-4566-4175-9166-1b38396c76d8.png)

