### PR TITLE
Escape any open wizards after each test

### DIFF
--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -96,7 +96,11 @@ export function setup() {
 				const name = this.currentTest!.fullTitle().replace(/[^a-z0-9\-]/ig, '_');
 				await app.captureScreenshot(`${name} (screenshot before revertAndCloseActiveEditor action)`);
 			}
+
 			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
+
+			// Close any open wizards
+			await app.code.dispatchKeybinding('escape');
 		});
 
 		describe('Notebook Toolbar Actions', async () => {


### PR DESCRIPTION
This prevents the python wizard from causing other non-python tests to fail.