### PR TITLE
added localization for profiler

### DIFF
--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "profiler",
-	"displayName": "SQL Server Profiler",
-	"description": "SQL Server Profiler for Azure Data Studio",
+	"displayName": "%displayName%",
+	"description": "%description%",
 	"version": "0.12.0",
 	"publisher": "Microsoft",
 	"preview": true,
@@ -29,23 +29,23 @@
 		"commands": [
 			{
 				"command": "profiler.newProfiler",
-				"title": "Launch Profiler",
-				"category": "Profiler"
+				"title": "%profiler.contributes.title.newProfler%",
+				"category": "%profiler.category%"
 			},
 			{
 				"command": "profiler.start",
-				"title": "Start",
-				"category": "Profiler"
+				"title": "profiler.contributes.title.start",
+				"category": "%profiler.category%"
 			},
 			{
 				"command": "profiler.stop",
-				"title": "Stop",
-				"category": "Profiler"
+				"title": "profiler.contributes.title.stop",
+				"category": "%profiler.category%"
 			},
 			{
 				"command": "profiler.openCreateSessionDialog",
-				"title": "Create Profiler Session",
-				"category": "Profiler"
+				"title": "profiler.contributes.title.openCreateSessionDialog",
+				"category": "%profiler.category%"
 			}
 		],
 		"menus": {

--- a/extensions/profiler/package.nls.json
+++ b/extensions/profiler/package.nls.json
@@ -1,0 +1,9 @@
+{
+	"displayName": "SQL Server Profiler",
+	"description": "SQL Server Profiler for Azure Data Studio",
+	"profiler.contributes.title.newProfler": "Launch Profiler",
+	"profiler.contributes.title.start": "Start",
+	"profiler.contributes.title.stop": "Stop",
+	"profiler.contributes.title.openCreateSessionDialog": "Create Profiler Season",
+	"profiler.category": "Profiler"
+}


### PR DESCRIPTION
This PR is a start for fixing the issue: #6327 

The main package for Profiler is not localized and that is responsible for the text of the Launch Profiler Menu Item.

This PR localizes the displayName, description, contribute titles and the category for profiler.
